### PR TITLE
Make names conform to Rust API Guidelines

### DIFF
--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -32,7 +32,7 @@ struct Conn {
 
 #[allow(unused)]
 #[derive(Debug, Deserialize)]
-struct DNSConn {
+struct DnsConn {
     orig_addr: IpAddr,
     resp_addr: IpAddr,
     orig_port: u16,
@@ -151,7 +151,7 @@ async fn handle_request((mut _send, mut recv): (SendStream, RecvStream)) -> Resu
         1 => loop {
             match handle_body(&mut recv, record_type).await {
                 Ok(r) => {
-                    println!("{:?}", bincode::deserialize::<DNSConn>(&r)?);
+                    println!("{:?}", bincode::deserialize::<DnsConn>(&r)?);
                 }
                 Err(quinn::ReadExactError::FinishedEarly) => {
                     break;


### PR DESCRIPTION
[Casing conforms to RFC 430 (C-CASE)](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case)

> In UpperCamelCase, acronyms and contractions of compound words count as one word: use Uuid rather than UUID, Usize rather than USize or Stdin rather than StdIn.