### PR TITLE
Read config file from config dir if no path is given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let settings = if let Some(config_filename) = parse() {
         Settings::from_file(&config_filename)?
     } else {
-        Settings::from_file("config.toml")?
+        Settings::new()?
     };
     let s = settings.clone();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,10 +1,12 @@
-use config::{Config, ConfigError, File};
+//! Configurations for the application.
+use config::{builder::DefaultState, Config, ConfigBuilder, ConfigError, File};
 use serde::Deserialize;
 use std::path::PathBuf;
 
 const DEFAULT_INGESTION_ADDRESS: &str = "[::]:38370";
 const DEFAULT_GRAPHQL_ADDRESS: &str = "127.0.0.1:8443";
 
+/// The application settings.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub cert: String,              // Path to the certificate file
@@ -16,29 +18,55 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn from_file(cfg_path: &str) -> Result<Self, ConfigError> {
+    /// Creates a new `Settings` instance, populated from the default
+    /// configuration file if it exists.
+    pub fn new() -> Result<Self, ConfigError> {
         let dirs = directories::ProjectDirs::from("com", "einsis", "giganto").expect("unreachable");
-        let db_dir =
-            directories::ProjectDirs::from_path(PathBuf::from("db")).expect("unreachable db dir");
-        let db_path = db_dir.data_dir().to_str().unwrap();
-        let path = dirs.config_dir();
-        let cert_path = path.join("cert.pem");
-        let key_path = path.join("key.pem");
+        let config_path = dirs.config_dir().join("config.toml");
+        if config_path.exists() {
+            // `config::File` requires a `&str` path, so we can't use `config_path` directly.
+            if let Some(path) = config_path.to_str() {
+                Self::from_file(path)
+            } else {
+                Err(ConfigError::Message(
+                    "config path must be a valid UTF-8 string".to_string(),
+                ))
+            }
+        } else {
+            default_config_builder().build()?.try_deserialize()
+        }
+    }
 
-        let s = Config::builder()
-            .set_default("cert", cert_path.to_str().expect("path to string"))
-            .expect("default cert dir")
-            .set_default("key", key_path.to_str().expect("path to string"))
-            .expect("default key dir")
-            .set_default("ingestion_address", DEFAULT_INGESTION_ADDRESS)
-            .expect("valid address")
-            .set_default("graphql_address", DEFAULT_GRAPHQL_ADDRESS)
-            .expect("local address")
-            .set_default("data_dir", db_path)
-            .expect("data dir")
+    /// Creates a new `Settings` instance, populated from the given
+    /// configuration file.
+    pub fn from_file(cfg_path: &str) -> Result<Self, ConfigError> {
+        let s = default_config_builder()
             .add_source(File::with_name(cfg_path))
             .build()?;
 
         s.try_deserialize()
     }
+}
+
+/// Creates a new `ConfigBuilder` instance with the default configuration.
+fn default_config_builder() -> ConfigBuilder<DefaultState> {
+    let dirs = directories::ProjectDirs::from("com", "einsis", "giganto").expect("unreachable");
+    let db_dir =
+        directories::ProjectDirs::from_path(PathBuf::from("db")).expect("unreachable db dir");
+    let db_path = db_dir.data_dir().to_str().unwrap();
+    let config_dir = dirs.config_dir();
+    let cert_path = config_dir.join("cert.pem");
+    let key_path = config_dir.join("key.pem");
+
+    Config::builder()
+        .set_default("cert", cert_path.to_str().expect("path to string"))
+        .expect("default cert dir")
+        .set_default("key", key_path.to_str().expect("path to string"))
+        .expect("default key dir")
+        .set_default("ingestion_address", DEFAULT_INGESTION_ADDRESS)
+        .expect("valid address")
+        .set_default("graphql_address", DEFAULT_GRAPHQL_ADDRESS)
+        .expect("local address")
+        .set_default("data_dir", db_path)
+        .expect("data dir")
 }


### PR DESCRIPTION
If the command-line argument for the configuration file is missing,
use config.toml in the config directory instead.