### PR TITLE
Decouple web module from graphql

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -3,11 +3,13 @@ use crate::{
     storage::{gen_key, Database, RawEventStore},
 };
 use anyhow::{bail, Result};
-use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, SimpleObject};
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 
 pub struct Query;
+
+pub type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
 
 #[derive(SimpleObject, Debug)]
 pub struct ConnRawEvent {
@@ -214,7 +216,7 @@ where
     Ok(raw_vec)
 }
 
-pub fn schema(database: Database) -> Schema<Query, EmptyMutation, EmptySubscription> {
+pub fn schema(database: Database) -> Schema {
     Schema::build(Query, EmptyMutation, EmptySubscription)
         .data(database)
         .finish()

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,15 +1,11 @@
-use crate::{graphql, settings::Settings};
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use crate::{graphql::Schema, settings::Settings};
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use std::{convert::Infallible, net::SocketAddr};
 use warp::{http::Response as HttpResponse, Filter};
 
-pub async fn serve(schema: Schema<graphql::Query, EmptyMutation, EmptySubscription>, s: &Settings) {
-    type MySchema = Schema<graphql::Query, EmptyMutation, EmptySubscription>;
+pub async fn serve(schema: Schema, s: &Settings) {
     let filter = async_graphql_warp::graphql(schema).and_then(
-        |(schema, request): (MySchema, async_graphql::Request)| async move {
+        |(schema, request): (Schema, async_graphql::Request)| async move {
             let resp = schema.execute(request).await;
 
             Ok::<_, Infallible>(async_graphql_warp::GraphQLResponse::from(resp))


### PR DESCRIPTION
This allows to change the GraphQL schema (e.g., adding mutations) without modifying web.rs.