### PR TITLE
Remove unnecessary memory allocation

### DIFF
--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -129,15 +129,8 @@ mod tests {
     async fn log_with_data() {
         let schema = TestSchema::new();
 
-        let mut source_kind: Vec<u8> = Vec::new();
-        let source = "einsis";
-        let kind = "Hello";
-
-        source_kind.append(&mut source.as_bytes().to_vec());
-        source_kind.push(0);
-        source_kind.append(&mut kind.as_bytes().to_vec());
-        source_kind.push(00);
-        source_kind.append(&mut Utc::now().timestamp_nanos().to_be_bytes().to_vec());
+        let mut source_kind = b"einsis\x00Hello\x00".to_vec();
+        source_kind.extend(Utc::now().timestamp_nanos().to_be_bytes());
 
         let log_body = (
             String::from("Hello"),

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -368,11 +368,8 @@ mod tests {
     async fn conn_with_data() {
         let schema = TestSchema::new();
 
-        let mut key: Vec<u8> = Vec::new();
-        let source = "einsis";
-        key.append(&mut source.as_bytes().to_vec());
-        key.push(00);
-        key.append(&mut Utc::now().timestamp_nanos().to_be_bytes().to_vec());
+        let mut key = b"einsis\x00".to_vec();
+        key.extend(Utc::now().timestamp_nanos().to_be_bytes());
 
         let tmp_dur = Duration::nanoseconds(12345);
         let conn_body = Conn {
@@ -446,11 +443,8 @@ mod tests {
     async fn dns_with_data() {
         let schema = TestSchema::new();
 
-        let mut key: Vec<u8> = Vec::new();
-        let source = "einsis";
-        key.append(&mut source.as_bytes().to_vec());
-        key.push(00);
-        key.append(&mut Utc::now().timestamp_nanos().to_be_bytes().to_vec());
+        let mut key = b"einsis\x00".to_vec();
+        key.extend(Utc::now().timestamp_nanos().to_be_bytes());
 
         let dns_body = DnsConn {
             orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
@@ -512,11 +506,8 @@ mod tests {
     async fn http_with_data() {
         let schema = TestSchema::new();
 
-        let mut key: Vec<u8> = Vec::new();
-        let source = "einsis";
-        key.append(&mut source.as_bytes().to_vec());
-        key.push(00);
-        key.append(&mut Utc::now().timestamp_nanos().to_be_bytes().to_vec());
+        let mut key = b"einsis\x00".to_vec();
+        key.extend(Utc::now().timestamp_nanos().to_be_bytes());
 
         let http_body = HttpConn {
             orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
@@ -589,11 +580,8 @@ mod tests {
     async fn rdp_with_data() {
         let schema = TestSchema::new();
 
-        let mut key: Vec<u8> = Vec::new();
-        let source = "einsis";
-        key.append(&mut source.as_bytes().to_vec());
-        key.push(00);
-        key.append(&mut Utc::now().timestamp_nanos().to_be_bytes().to_vec());
+        let mut key = b"einsis\x00".to_vec();
+        key.extend(Utc::now().timestamp_nanos().to_be_bytes());
 
         let rdp_body = RdpConn {
             orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),


### PR DESCRIPTION
Replace `append` with `extend` so that the argument doesn't have to own data.