### PR TITLE
Document key incompatibility in `web::serve`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = [ "RocksDB" ]
+doc-valid-idents = [ "GraphQL", "RocksDB" ]

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,10 +1,13 @@
 use crate::graphql::Schema;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
-use rustls::Certificate;
 use std::{convert::Infallible, net::SocketAddr};
 use warp::{http::Response as HttpResponse, Filter};
 
-pub async fn serve(schema: Schema, addr: SocketAddr, cert: Certificate, key: Vec<u8>) {
+/// Runs the GraphQL server.
+///
+/// Note that `key` is not compatible with the DER-encoded key extracted by
+/// rustls-pemfile.
+pub async fn serve(schema: Schema, addr: SocketAddr, cert: Vec<u8>, key: Vec<u8>) {
     let filter = async_graphql_warp::graphql(schema).and_then(
         |(schema, request): (Schema, async_graphql::Request)| async move {
             let resp = schema.execute(request).await;


### PR DESCRIPTION
This also removes web's dependency on rustls to avoid any confusion.

Noted by @BLYKIM in #103.