### PR TITLE
Remove unnecessary attribute: `allow(clippy::too_many_arguments)`

### DIFF
--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -31,7 +31,6 @@ impl FromKeyValue<ingestion::Log> for LogRawEvent {
 
 #[Object]
 impl LogQuery {
-    #[allow(clippy::too_many_arguments)]
     async fn log_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -133,7 +133,6 @@ impl FromKeyValue<ingestion::RdpConn> for RdpRawEvent {
 
 #[Object]
 impl NetworkQuery {
-    #[allow(clippy::too_many_arguments)]
     async fn conn_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,
@@ -168,7 +167,6 @@ impl NetworkQuery {
         .await
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn dns_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,
@@ -203,7 +201,6 @@ impl NetworkQuery {
         .await
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn http_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,
@@ -238,7 +235,6 @@ impl NetworkQuery {
         .await
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn rdp_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,


### PR DESCRIPTION
여러 인자를 `filter` 하나로 대체하면서 `allow(clippy::too_many_arguments)`가 필요없게 되었습니다.