### PR TITLE
Make network event names conform to Zeek's naming

### DIFF
--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -109,7 +109,7 @@ impl PubMessage for Conn {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct DnsConn {
+pub struct Dns {
     pub orig_addr: IpAddr,
     pub resp_addr: IpAddr,
     pub orig_port: u16,
@@ -119,7 +119,7 @@ pub struct DnsConn {
     pub answer: Vec<IpAddr>,
 }
 
-impl EventFilter for DnsConn {
+impl EventFilter for Dns {
     fn orig_addr(&self) -> Option<IpAddr> {
         Some(self.orig_addr)
     }
@@ -134,7 +134,7 @@ impl EventFilter for DnsConn {
     }
 }
 
-impl PubMessage for DnsConn {
+impl PubMessage for Dns {
     fn message(&self, timestamp: i64, source: &str) -> Result<Vec<u8>> {
         let answer = if self.answer.is_empty() {
             "-".to_string()
@@ -148,7 +148,7 @@ impl PubMessage for DnsConn {
 
         let dns_csv = format!(
             "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            DnsConn::convert_time_format(timestamp),
+            Dns::convert_time_format(timestamp),
             source,
             self.orig_addr,
             self.orig_port,
@@ -164,7 +164,7 @@ impl PubMessage for DnsConn {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct HttpConn {
+pub struct Http {
     pub orig_addr: IpAddr,
     pub resp_addr: IpAddr,
     pub orig_port: u16,
@@ -177,7 +177,7 @@ pub struct HttpConn {
     pub status_code: u16,
 }
 
-impl EventFilter for HttpConn {
+impl EventFilter for Http {
     fn orig_addr(&self) -> Option<IpAddr> {
         Some(self.orig_addr)
     }
@@ -192,11 +192,11 @@ impl EventFilter for HttpConn {
     }
 }
 
-impl PubMessage for HttpConn {
+impl PubMessage for Http {
     fn message(&self, timestamp: i64, source: &str) -> Result<Vec<u8>> {
         let http_csv = format!(
             "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            HttpConn::convert_time_format(timestamp),
+            Http::convert_time_format(timestamp),
             source,
             self.orig_addr,
             self.orig_port,
@@ -234,7 +234,7 @@ impl PubMessage for HttpConn {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RdpConn {
+pub struct Rdp {
     pub orig_addr: IpAddr,
     pub resp_addr: IpAddr,
     pub orig_port: u16,
@@ -242,7 +242,7 @@ pub struct RdpConn {
     pub cookie: String,
 }
 
-impl EventFilter for RdpConn {
+impl EventFilter for Rdp {
     fn orig_addr(&self) -> Option<IpAddr> {
         Some(self.orig_addr)
     }
@@ -257,11 +257,11 @@ impl EventFilter for RdpConn {
     }
 }
 
-impl PubMessage for RdpConn {
+impl PubMessage for Rdp {
     fn message(&self, timestamp: i64, source: &str) -> Result<Vec<u8>> {
         let rdp_csv = format!(
             "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            RdpConn::convert_time_format(timestamp),
+            Rdp::convert_time_format(timestamp),
             source,
             self.orig_addr,
             self.orig_port,

--- a/src/ingestion/tests.rs
+++ b/src/ingestion/tests.rs
@@ -234,7 +234,7 @@ async fn dns() {
     const RECORD_TYPE_DNS: u32 = 0x01;
 
     #[derive(Serialize)]
-    struct DNSConn {
+    struct Dns {
         orig_addr: IpAddr,
         resp_addr: IpAddr,
         orig_port: u16,
@@ -252,7 +252,7 @@ async fn dns() {
     let (mut send_dns, _) = client.conn.open_bi().await.expect("failed to open stream");
 
     let mut dns_data: Vec<u8> = Vec::new();
-    let dns_body = DNSConn {
+    let dns_body = Dns {
         orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
         orig_port: 46378,
@@ -321,7 +321,7 @@ async fn http() {
     const RECORD_TYPE_HTTP: u32 = 0x03;
 
     #[derive(Serialize)]
-    struct HttpConn {
+    struct Http {
         orig_addr: IpAddr,
         resp_addr: IpAddr,
         orig_port: u16,
@@ -343,7 +343,7 @@ async fn http() {
     let (mut send_http, _) = client.conn.open_bi().await.expect("failed to open stream");
 
     let mut http_data: Vec<u8> = Vec::new();
-    let http_body = HttpConn {
+    let http_body = Http {
         orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         orig_port: 46378,
@@ -378,7 +378,7 @@ async fn rdp() {
     const RECORD_TYPE_RDP: u32 = 0x04;
 
     #[derive(Serialize)]
-    struct RdpConn {
+    struct Rdp {
         orig_addr: IpAddr,
         resp_addr: IpAddr,
         orig_port: u16,
@@ -395,7 +395,7 @@ async fn rdp() {
     let (mut send_rdp, _) = client.conn.open_bi().await.expect("failed to open stream");
 
     let mut rdp_data: Vec<u8> = Vec::new();
-    let rdp_body = RdpConn {
+    let rdp_body = Rdp {
         orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         orig_port: 46378,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -71,7 +71,7 @@ impl Database {
     }
 
     /// Returns the raw event store for dns.
-    pub fn dns_store(&self) -> Result<RawEventStore<ingestion::DnsConn>> {
+    pub fn dns_store(&self) -> Result<RawEventStore<ingestion::Dns>> {
         let cf = self
             .db
             .cf_handle("dns")
@@ -89,7 +89,7 @@ impl Database {
     }
 
     /// Returns the raw event store for http.
-    pub fn http_store(&self) -> Result<RawEventStore<ingestion::HttpConn>> {
+    pub fn http_store(&self) -> Result<RawEventStore<ingestion::Http>> {
         let cf = self
             .db
             .cf_handle("http")
@@ -98,7 +98,7 @@ impl Database {
     }
 
     /// Returns the raw event store for rdp.
-    pub fn rdp_store(&self) -> Result<RawEventStore<ingestion::RdpConn>> {
+    pub fn rdp_store(&self) -> Result<RawEventStore<ingestion::Rdp>> {
         let cf = self
             .db
             .cf_handle("rdp")


### PR DESCRIPTION
네트워크 이벤트의 자료구조 이름을 Zeek에서 사용하는 것과 동일하게 맞춥니다.