### PR TITLE
Bump the publish protocol version

### DIFF
--- a/src/publish.rs
+++ b/src/publish.rs
@@ -29,7 +29,7 @@ use tokio::{
 };
 use tracing::{error, info};
 
-const PUBLISH_VERSION_REQ: &str = "0.6";
+const PUBLISH_VERSION_REQ: &str = "=0.7.0-alpha.1";
 
 lazy_static! {
     pub static ref HOG_DIRECT_CHANNEL: RwLock<HashMap<String, UnboundedSender<Vec<u8>>>> =

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -28,7 +28,7 @@ const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/root.pem";
 const HOST: &str = "localhost";
 const TEST_PORT: u16 = 60191;
-const PROTOCOL_VERSION: &str = "0.6.0";
+const PROTOCOL_VERSION: &str = "0.7.0-alpha.1";
 
 struct TestClient {
     send: SendStream,
@@ -498,6 +498,22 @@ fn insert_periodic_time_series_raw_event(
     let ser_periodic_time_series_body = gen_periodic_time_series_raw_event();
     store.append(&key, &ser_periodic_time_series_body).unwrap();
     ser_periodic_time_series_body
+}
+
+#[test]
+fn protocol_version() {
+    use semver::{Version, VersionReq};
+
+    let compat_versions = ["0.7.0-alpha.1"];
+    let incompat_versions = ["0.6.0", "0.8.0"];
+
+    let req = VersionReq::parse(super::PUBLISH_VERSION_REQ).unwrap();
+    for version in &compat_versions {
+        assert!(req.matches(&Version::parse(version).unwrap()));
+    }
+    for version in &incompat_versions {
+        assert!(!req.matches(&Version::parse(version).unwrap()));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
publish 프로토콜이 0.6.0과 달라졌으므로, 0.6.0 프로토콜을 쓰는 클라이언트의 접속을 막기 위해 버전 조건을 변경합니다.