### PR TITLE
receive and save traffic statistics from piglet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add `Statistics` column family. Receive and save traffic statistics from Piglet.
+
+### Changed
+
 - Send different stream start message depending on the daemon.
 
 ## [0.6.0] - 2022-12-06

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -210,7 +210,7 @@ where
     let mut records = Vec::with_capacity(size);
     let mut has_more = false;
     while let Some(item) = iter.next() {
-        let item = item.map_err(|e| format!("failed to read database: {}", e))?;
+        let item = item.map_err(|e| format!("failed to read database: {e}"))?;
         match filter.check(
             item.1.orig_addr(),
             item.1.resp_addr(),

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -122,7 +122,22 @@ impl PubMessage for PeriodicTimeSeries {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, TryFromPrimitive, PartialEq)]
+#[derive(Debug, Deserialize)]
+pub struct Statistics {
+    period: u16,
+    stats: Vec<(RecordType, u64, u64)>, // protocol, packet count, paket size
+}
+
+impl Display for Statistics {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        for stat in &self.stats {
+            writeln!(f, "{:?}\t{}\t{}\t{}", stat.0, stat.1, stat.2, self.period)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, TryFromPrimitive, PartialEq, Deserialize)]
 #[repr(u32)]
 enum RecordType {
     Conn = 0,
@@ -136,6 +151,7 @@ enum RecordType {
     Kerberos = 8,
     Ssh = 9,
     DceRpc = 10,
+    Statistics = 11,
 }
 
 pub struct Server {
@@ -198,7 +214,7 @@ async fn handle_connection(
     let stream = connection.accept_bi().await;
     let (mut send, mut recv) = stream?;
     if let Err(e) = server_handshake(&mut send, &mut recv, INGESTION_VERSION_REQ).await {
-        let err = format!("Handshake fail: {}", e);
+        let err = format!("Handshake fail: {e}");
         send.finish().await?;
         connection.close(quinn::VarInt::from_u32(0), err.as_bytes());
         bail!(err);
@@ -378,6 +394,17 @@ async fn handle_request(
                 Some(gen_network_key(&source, "dce rpc")),
                 source,
                 db.dce_rpc_store()?,
+            )
+            .await?;
+        }
+        RecordType::Statistics => {
+            handle_data(
+                send,
+                recv,
+                RecordType::Statistics,
+                Some(gen_network_key(&source, "statistics")),
+                source,
+                db.statistics_store()?,
             )
             .await?;
         }
@@ -591,8 +618,8 @@ pub struct NetworkKey {
 }
 
 pub fn gen_network_key(source: &str, protocol: &str) -> NetworkKey {
-    let source_key = format!("{}\0{}", source, protocol);
-    let all_key = format!("all\0{}", protocol);
+    let source_key = format!("{source}\0{protocol}");
+    let all_key = format!("all\0{protocol}");
 
     NetworkKey {
         source_key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn parse() -> Option<String> {
     if arg == "--help" || arg == "-h" {
         println!("{}", version());
         println!();
-        print!("{}", USAGE);
+        print!("{USAGE}");
         exit(0);
     }
     if arg == "--version" || arg == "-V" {
@@ -114,8 +114,8 @@ fn parse() -> Option<String> {
         exit(0);
     }
     if arg.starts_with('-') {
-        eprintln!("Error: unknown option: {}", arg);
-        eprintln!("\n{}", USAGE);
+        eprintln!("Error: unknown option: {arg}");
+        eprintln!("\n{USAGE}");
         exit(1);
     }
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -348,7 +348,7 @@ async fn handle_connection(conn: quinn::Connecting, db: Database) -> Result<()> 
 
     let (mut send, mut recv) = stream?;
     if let Err(e) = server_handshake(&mut send, &mut recv, PUBLISH_VERSION_REQ).await {
-        let err = format!("Handshake fail: {}", e);
+        let err = format!("Handshake fail: {e}");
         send.finish().await?;
         connection.close(quinn::VarInt::from_u32(0), err.as_bytes());
         bail!(err);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -93,5 +93,5 @@ where
 {
     let addr = String::deserialize(deserializer)?;
     addr.parse()
-        .map_err(|e| D::Error::custom(format!("invalid address \"{}\": {}", addr, e)))
+        .map_err(|e| D::Error::custom(format!("invalid address \"{addr}\": {e}")))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,7 +12,7 @@ use std::{cmp, marker::PhantomData, mem, path::Path, sync::Arc, time::Duration};
 use tokio::time;
 use tracing::error;
 
-const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 11] = [
+const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 12] = [
     "conn",
     "dns",
     "log",
@@ -24,6 +24,7 @@ const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 11] = [
     "kerberos",
     "ssh",
     "dce rpc",
+    "statistics",
 ];
 const META_DATA_COLUMN_FAMILY_NAMES: [&str; 1] = ["sources"];
 const TIMESTAMP_SIZE: usize = 8;
@@ -163,6 +164,15 @@ impl Database {
             .db
             .cf_handle("dce rpc")
             .context("cannot access dce rpc column family")?;
+        Ok(RawEventStore::new(&self.db, cf))
+    }
+
+    /// Returns the store for statistics
+    pub fn statistics_store(&self) -> Result<RawEventStore<ingestion::Statistics>> {
+        let cf = self
+            .db
+            .cf_handle("statistics")
+            .context("cannot access sources column family")?;
         Ok(RawEventStore::new(&self.db, cf))
     }
 


### PR DESCRIPTION
#219 Piglet으로부터 트래픽 수집 및 저장 기능

* Receive traffic statistics from Piglet and save it to `statistics` db.
* Fix clippy error from rust 1.66