### PR TITLE
Add GraphQL API for Packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add more fields to `dns`, `conn`, `http`
 - Add common fields to network events.
-- Add Packet store
+- Add Packet store.
+- Add GraphQL API for Packet.
 
 ### Changed
 

--- a/giganto-client/src/ingest.rs
+++ b/giganto-client/src/ingest.rs
@@ -30,7 +30,7 @@ pub enum RecordType {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Packet {
     pub packet_timestamp: i64,
-    pub packet: String,
+    pub packet: Vec<u8>,
 }
 
 /// Sends the record type. (`RecordType`)

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -1,28 +1,104 @@
-use super::network::NetworkFilter;
-use crate::ingest::{request_packets, PacketSources};
-use async_graphql::{Context, Object, Result};
+use super::{
+    get_timestamp, load_connection, FromKeyValue, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
+};
+use crate::storage::Database;
+use async_graphql::{
+    connection::{query, Connection},
+    Context, InputObject, Object, Result, SimpleObject,
+};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::Packet as pk;
+use std::net::IpAddr;
 
 #[derive(Default)]
 pub(super) struct PacketQuery;
 
+#[allow(clippy::module_name_repetitions)]
+#[derive(InputObject)]
+pub struct PacketFilter {
+    source: String,
+    request_time: DateTime<Utc>,
+    packet_time: Option<TimeRange>,
+}
+
+impl RawEventFilter for PacketFilter {
+    fn time(&self) -> (Option<DateTime<Utc>>, Option<DateTime<Utc>>) {
+        if let Some(time) = &self.packet_time {
+            (time.start, time.end)
+        } else {
+            (None, None)
+        }
+    }
+
+    fn check(
+        &self,
+        _orig_addr: Option<IpAddr>,
+        _resp_addr: Option<IpAddr>,
+        _orig_port: Option<u16>,
+        _resp_port: Option<u16>,
+        _log_level: Option<String>,
+        _log_contents: Option<String>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[derive(SimpleObject, Debug)]
+struct Packet {
+    request_time: DateTime<Utc>,
+    packet_time: DateTime<Utc>,
+    packet: String,
+}
+
+impl FromKeyValue<pk> for Packet {
+    fn from_key_value(key: &[u8], pk: pk) -> Result<Self> {
+        Ok(Packet {
+            request_time: get_timestamp(&key[..key.len() - (TIMESTAMP_SIZE + 1)])?,
+            packet_time: get_timestamp(key)?,
+            packet: base64::encode(pk.packet),
+        })
+    }
+}
+
 #[Object]
 impl PacketQuery {
-    async fn packets(&self, ctx: &Context<'_>, filter: NetworkFilter) -> Result<Vec<String>> {
-        let packet_sources = ctx.data::<PacketSources>()?;
-        let source = &filter.source;
-        let mut resp_data = Vec::new();
-        if let Some(connection) = packet_sources.read().await.get(source) {
-            for packet in request_packets(connection, filter).await? {
-                resp_data.push(base64::encode(packet));
-            }
-        }
-        Ok(resp_data)
+    async fn packets<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        filter: PacketFilter,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Connection<String, Packet>> {
+        let db = ctx.data::<Database>()?;
+        let store = db.packet_store()?;
+
+        let mut key_prefix = Vec::with_capacity(filter.source.len() + TIMESTAMP_SIZE + 2);
+        key_prefix.extend_from_slice(filter.source.as_bytes());
+        key_prefix.push(0);
+        key_prefix.extend_from_slice(&filter.request_time.timestamp_nanos().to_be_bytes());
+        key_prefix.push(0);
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                load_connection(&store, &key_prefix, &filter, after, before, first, last)
+            },
+        )
+        .await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::graphql::TestSchema;
+    use crate::{graphql::TestSchema, storage::RawEventStore};
+    use chrono::{TimeZone, Utc};
+    use giganto_client::ingest::Packet as pk;
+    use std::mem;
 
     #[tokio::test]
     async fn packets_empty() {
@@ -31,16 +107,124 @@ mod tests {
         {
             packets(
                 filter: {
-                    time: { start: "1992-06-05T00:00:00Z", end: "2011-09-22T00:00:00Z" }
                     source: "a"
-                    origAddr: { start: "192.168.4.75", end: "192.168.4.79" }
-                    respAddr: { start: "192.168.4.75", end: "192.168.4.79" }
-                    origPort: { start: 46377, end: 46380 }
-                    respPort: { start: 100, end: 200 }
+                    requestTime: "2023-01-20T00:00:00Z"
+                    packetTime: { start: "1992-06-05T00:00:00Z", end: "2023-09-22T00:00:00Z" }
                 }
-            )
+                first: 1
+            ) {
+                edges {
+                    node {
+                        packet
+                    }
+                }
+            }
         }"#;
         let res = schema.execute(query).await;
-        assert_eq!(res.data.to_string(), "{packets: []}");
+        assert_eq!(res.data.to_string(), "{packets: {edges: []}}");
+    }
+
+    #[tokio::test]
+    async fn packets_with_data() {
+        let schema = TestSchema::new();
+        let store = schema.db.packet_store().unwrap();
+
+        let dt1 = Utc.with_ymd_and_hms(2023, 1, 20, 0, 0, 0).unwrap();
+        let dt2 = Utc.with_ymd_and_hms(2023, 1, 20, 0, 0, 1).unwrap();
+        let dt3 = Utc.with_ymd_and_hms(2023, 1, 20, 0, 0, 2).unwrap();
+
+        let ts1 = dt1.timestamp_nanos();
+        let ts2 = dt2.timestamp_nanos();
+        let ts3 = dt3.timestamp_nanos();
+
+        insert_packet(&store, "src 1", ts1, ts1);
+        insert_packet(&store, "src 1", ts1, ts2);
+
+        insert_packet(&store, "src 2", ts1, ts1);
+        insert_packet(&store, "src 2", ts1, ts3);
+
+        insert_packet(&store, "src 1", ts2, ts1);
+        insert_packet(&store, "src 1", ts2, ts3);
+
+        let query = r#"
+        {
+            packets(
+                filter: {
+                    source: "src 1"
+                    requestTime: "2023-01-20T00:00:00Z"
+                }
+                first: 10
+            ) {
+                edges {
+                    node {
+                        packetTime
+                    }
+                }
+            }
+        }"#;
+        let res = schema.execute(query).await;
+        assert_eq!(res.data.to_string(), "{packets: {edges: [{node: {packetTime: \"2023-01-20T00:00:00+00:00\"}},{node: {packetTime: \"2023-01-20T00:00:01+00:00\"}}]}}");
+
+        let query = r#"
+        {
+            packets(
+                filter: {
+                    source: "src 2"
+                    requestTime: "2023-01-20T00:00:00Z"
+                }
+                first: 10
+            ) {
+                edges {
+                    node {
+                        packetTime
+                    }
+                }
+            }
+        }"#;
+        let res = schema.execute(query).await;
+        assert_eq!(res.data.to_string(), "{packets: {edges: [{node: {packetTime: \"2023-01-20T00:00:00+00:00\"}},{node: {packetTime: \"2023-01-20T00:00:02+00:00\"}}]}}");
+
+        let query = r#"
+        {
+            packets(
+                filter: {
+                    source: "src 1"
+                    requestTime: "2023-01-20T00:00:01Z"
+                }
+                first: 10
+            ) {
+                edges {
+                    node {
+                        packetTime
+                    }
+                }
+            }
+        }"#;
+        let res = schema.execute(query).await;
+        assert_eq!(res.data.to_string(), "{packets: {edges: [{node: {packetTime: \"2023-01-20T00:00:00+00:00\"}},{node: {packetTime: \"2023-01-20T00:00:02+00:00\"}}]}}");
+    }
+
+    fn insert_packet(
+        store: &RawEventStore<pk>,
+        source: &str,
+        req_timestamp: i64,
+        pk_timestamp: i64,
+    ) {
+        let mut key = Vec::with_capacity(
+            source.len() + 1 + mem::size_of::<i64>() + 1 + mem::size_of::<i64>(),
+        );
+        key.extend_from_slice(source.as_bytes());
+        key.push(0);
+        key.extend(req_timestamp.to_be_bytes());
+        key.push(0);
+        key.extend(pk_timestamp.to_be_bytes());
+
+        let packet_body = pk {
+            packet_timestamp: pk_timestamp,
+            packet: vec![0, 1, 2, 3],
+        };
+        let ser_packet_body = bincode::serialize(&packet_body).unwrap();
+
+        store.append(&key, &ser_packet_body).unwrap();
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2,14 +2,12 @@ pub mod implement;
 #[cfg(test)]
 mod tests;
 
-use crate::graphql::network::NetworkFilter;
 use crate::publish::send_direct_stream;
 use crate::server::{certificate_info, config_server};
 use crate::storage::{Database, RawEventStore};
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use giganto_client::connection::server_handshake;
-use giganto_client::frame;
 use giganto_client::ingest::log::{Log, Oplog};
 use giganto_client::ingest::timeseries::PeriodicTimeSeries;
 use giganto_client::ingest::{
@@ -441,18 +439,6 @@ async fn handle_data<T>(
     }
 
     Ok(())
-}
-
-pub async fn request_packets(
-    connection: &quinn::Connection,
-    filter: NetworkFilter,
-) -> Result<Vec<String>> {
-    let (mut send, mut recv) = connection.open_bi().await?;
-
-    let mut buf = Vec::new();
-    frame::send(&mut send, &mut buf, &filter).await?;
-    let packets = frame::recv::<Vec<String>>(&mut recv, &mut buf).await?;
-    Ok(packets)
 }
 
 async fn check_sources_conn(

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -2,6 +2,7 @@ use giganto_client::ingest::{
     log::{Log, OpLogLevel, Oplog},
     network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
     timeseries::PeriodicTimeSeries,
+    Packet,
 };
 use std::net::IpAddr;
 
@@ -250,6 +251,27 @@ impl EventFilter for Oplog {
 }
 
 impl EventFilter for PeriodicTimeSeries {
+    fn orig_addr(&self) -> Option<IpAddr> {
+        None
+    }
+    fn resp_addr(&self) -> Option<IpAddr> {
+        None
+    }
+    fn orig_port(&self) -> Option<u16> {
+        None
+    }
+    fn resp_port(&self) -> Option<u16> {
+        None
+    }
+    fn log_level(&self) -> Option<String> {
+        None
+    }
+    fn log_contents(&self) -> Option<String> {
+        None
+    }
+}
+
+impl EventFilter for Packet {
     fn orig_addr(&self) -> Option<IpAddr> {
         None
     }


### PR DESCRIPTION
- Modify ingest packet to `Vec<u8>` from `String`
- In graphql `Packets` takes `source` and `requestTime` and
  optional `packetTime` range,
  returns `packet`, `packetTime`, `requestTime`

Issue: #247