### PR TITLE
Bump base64 from 0.20 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -740,7 +740,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-warp",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bincode",
  "chrono",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 async-graphql = { version = "5.0", features = ["chrono"] }
 async-graphql-warp = "5.0"
-base64 = "0.20"
+base64 = "0.21"
 bincode = "1.3"
 config = { version = "0.13", features = ["toml"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -16,6 +16,7 @@ use async_graphql::{
     connection::{Connection, Edge},
     EmptyMutation, EmptySubscription, InputObject, MergedObject, OutputType, Result,
 };
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use chrono::{DateTime, TimeZone, Utc};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{net::IpAddr, path::PathBuf};
@@ -95,7 +96,7 @@ where
         let (start, end) = filter.time();
 
         let last = last.unwrap_or(MAXIMUM_PAGE_SIZE).min(MAXIMUM_PAGE_SIZE);
-        let cursor = base64::decode(before)?;
+        let cursor = base64_engine.decode(before)?;
         let time = upper_closed_bound_key(key_prefix, end);
         if cursor.cmp(&time) == std::cmp::Ordering::Greater {
             return Err("invalid cursor".into());
@@ -125,7 +126,7 @@ where
         let (start, end) = filter.time();
 
         let first = first.unwrap_or(MAXIMUM_PAGE_SIZE).min(MAXIMUM_PAGE_SIZE);
-        let cursor = base64::decode(after)?;
+        let cursor = base64_engine.decode(after)?;
         let time = lower_closed_bound_key(key_prefix, start);
         if cursor.cmp(&time) == std::cmp::Ordering::Less {
             return Err("invalid cursor".into());
@@ -195,7 +196,7 @@ where
         .into_iter()
         .map(|(key, node)| {
             Edge::new(
-                base64::encode(&key),
+                base64_engine.encode(&key),
                 N::from_key_value(&key, node).expect("failed to convert value"),
             )
         })
@@ -265,7 +266,7 @@ where
         let (start, end) = filter.time();
 
         let last = last.unwrap_or(MAXIMUM_PAGE_SIZE).min(MAXIMUM_PAGE_SIZE);
-        let cursor = base64::decode(before)?;
+        let cursor = base64_engine.decode(before)?;
         let time = upper_closed_bound_key(key_prefix, end);
         if cursor.cmp(&time) == std::cmp::Ordering::Greater {
             return Err("invalid cursor".into());
@@ -287,7 +288,7 @@ where
         let (start, end) = filter.time();
 
         let first = first.unwrap_or(MAXIMUM_PAGE_SIZE).min(MAXIMUM_PAGE_SIZE);
-        let cursor = base64::decode(after)?;
+        let cursor = base64_engine.decode(after)?;
         let time = lower_closed_bound_key(key_prefix, start);
         if cursor.cmp(&time) == std::cmp::Ordering::Less {
             return Err("invalid cursor".into());

--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -1,4 +1,6 @@
-use super::{get_timestamp, load_connection, network::key_prefix, FromKeyValue};
+use super::{
+    base64_engine, get_timestamp, load_connection, network::key_prefix, Engine, FromKeyValue,
+};
 use crate::{
     graphql::{RawEventFilter, TimeRange},
     storage::Database,
@@ -104,7 +106,7 @@ impl FromKeyValue<Log> for LogRawEvent {
     fn from_key_value(key: &[u8], l: Log) -> Result<Self> {
         Ok(LogRawEvent {
             timestamp: get_timestamp(key)?,
-            log: base64::encode(l.log),
+            log: base64_engine.encode(l.log),
         })
     }
 }
@@ -191,7 +193,7 @@ impl LogQuery {
 
 #[cfg(test)]
 mod tests {
-    use super::{LogFilter, LogRawEvent, OpLogFilter, OpLogRawEvent};
+    use super::{base64_engine, Engine, LogFilter, LogRawEvent, OpLogFilter, OpLogRawEvent};
     use crate::{
         graphql::{TestSchema, TimeRange},
         storage::RawEventStore,
@@ -236,11 +238,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
 
@@ -267,15 +269,15 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log3"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log4"
         );
         assert_eq!(
-            base64::decode(&connection.edges[2].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[2].node.log).unwrap(),
             b"log5"
         );
 
@@ -302,15 +304,15 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
         assert_eq!(
-            base64::decode(&connection.edges[2].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[2].node.log).unwrap(),
             b"log3"
         );
 
@@ -340,11 +342,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
 
@@ -371,15 +373,15 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log3"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log4"
         );
         assert_eq!(
-            base64::decode(&connection.edges[2].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[2].node.log).unwrap(),
             b"log5"
         );
 
@@ -406,11 +408,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
 
@@ -433,20 +435,18 @@ mod tests {
                 kind: Some("kind1".to_string()),
             },
             None,
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x03",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x03")),
             None,
             Some(3),
         )
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
 
@@ -466,20 +466,18 @@ mod tests {
                 kind: Some("kind1".to_string()),
             },
             None,
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x04",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x04")),
             None,
             Some(3),
         )
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log2"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log3"
         );
 
@@ -499,24 +497,22 @@ mod tests {
                 kind: Some("kind1".to_string()),
             },
             None,
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x04",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x04")),
             None,
             Some(3),
         )
         .unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log2"
         );
         assert_eq!(
-            base64::decode(&connection.edges[2].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[2].node.log).unwrap(),
             b"log3"
         );
 
@@ -538,9 +534,7 @@ mod tests {
                 source: "src1".to_string(),
                 kind: Some("kind1".to_string()),
             },
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x01",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x01")),
             None,
             Some(3),
             None,
@@ -548,11 +542,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log2"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log3"
         );
 
@@ -571,9 +565,7 @@ mod tests {
                 source: "src1".to_string(),
                 kind: Some("kind1".to_string()),
             },
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x03",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x03")),
             None,
             None,
             None,
@@ -581,11 +573,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log4"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log5"
         );
 
@@ -604,9 +596,7 @@ mod tests {
                 source: "src1".to_string(),
                 kind: Some("kind1".to_string()),
             },
-            Some(base64::encode(
-                b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x01",
-            )),
+            Some(base64_engine.encode(b"src1\x00kind1\x00\x00\x00\x00\x00\x00\x00\x00\x01")),
             None,
             None,
             None,
@@ -614,11 +604,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log2"
         );
         assert_eq!(
-            base64::decode(&connection.edges[1].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[1].node.log).unwrap(),
             b"log3"
         );
 
@@ -642,11 +632,11 @@ mod tests {
         .unwrap();
         assert_eq!(connection.edges.len(), 5);
         assert_eq!(
-            base64::decode(&connection.edges[0].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[0].node.log).unwrap(),
             b"log1"
         );
         assert_eq!(
-            base64::decode(&connection.edges[4].node.log).unwrap(),
+            base64_engine.decode(&connection.edges[4].node.log).unwrap(),
             b"log5"
         );
     }
@@ -692,7 +682,7 @@ mod tests {
         let res = schema.execute(query).await;
         assert_eq!(
             res.data.to_string(),
-            format!("{{logRawEvents: {{edges: [{{node: {{log: \"{}\"}}}}],pageInfo: {{hasPreviousPage: false}}}}}}", base64::encode("log 1"))
+            format!("{{logRawEvents: {{edges: [{{node: {{log: \"{}\"}}}}],pageInfo: {{hasPreviousPage: false}}}}}}", base64_engine.encode("log 1"))
         );
     }
 

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -1,4 +1,6 @@
-use super::{get_filtered_iter, get_timestamp, load_connection, FromKeyValue};
+use super::{
+    base64_engine, get_filtered_iter, get_timestamp, load_connection, Engine, FromKeyValue,
+};
 use crate::{
     graphql::{RawEventFilter, TimeRange},
     storage::{Database, FilteredIter},
@@ -820,7 +822,7 @@ fn network_connection(
         if selected == conn_ts {
             if let Some((key, value)) = conn_data {
                 result_vec.push(Edge::new(
-                    base64::encode(&key),
+                    base64_engine.encode(&key),
                     NetworkRawEvents::ConnRawEvent(ConnRawEvent::from_key_value(&key, value)?),
                 ));
                 conn_data = conn_iter.next();
@@ -829,7 +831,7 @@ fn network_connection(
         } else if selected == dns_ts {
             if let Some((key, value)) = dns_data {
                 result_vec.push(Edge::new(
-                    base64::encode(&key),
+                    base64_engine.encode(&key),
                     NetworkRawEvents::DnsRawEvent(DnsRawEvent::from_key_value(&key, value)?),
                 ));
                 dns_data = dns_iter.next();
@@ -838,7 +840,7 @@ fn network_connection(
         } else if selected == http_ts {
             if let Some((key, value)) = http_data {
                 result_vec.push(Edge::new(
-                    base64::encode(&key),
+                    base64_engine.encode(&key),
                     NetworkRawEvents::HttpRawEvent(HttpRawEvent::from_key_value(&key, value)?),
                 ));
                 http_data = http_iter.next();
@@ -847,7 +849,7 @@ fn network_connection(
         } else if selected == rdp_ts {
             if let Some((key, value)) = rdp_data {
                 result_vec.push(Edge::new(
-                    base64::encode(&key),
+                    base64_engine.encode(&key),
                     NetworkRawEvents::RdpRawEvent(RdpRawEvent::from_key_value(&key, value)?),
                 ));
                 rdp_data = rdp_iter.next();

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -1,5 +1,6 @@
 use super::{
-    get_timestamp, load_connection, FromKeyValue, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
+    base64_engine, get_timestamp, load_connection, Engine, FromKeyValue, RawEventFilter, TimeRange,
+    TIMESTAMP_SIZE,
 };
 use crate::storage::Database;
 use async_graphql::{
@@ -55,7 +56,7 @@ impl FromKeyValue<pk> for Packet {
         Ok(Packet {
             request_time: get_timestamp(&key[..key.len() - (TIMESTAMP_SIZE + 1)])?,
             packet_time: get_timestamp(key)?,
-            packet: base64::encode(pk.packet),
+            packet: base64_engine.encode(pk.packet),
         })
     }
 }

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -1,5 +1,6 @@
 use super::Server;
 use crate::{storage::Database, to_cert_chain, to_private_key};
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use chrono::{Duration, Utc};
 use giganto_client::{
     connection::client_handshake,
@@ -249,7 +250,7 @@ async fn log() {
 
     let log_body = Log {
         kind: String::from("Hello"),
-        log: base64::decode("aGVsbG8gd29ybGQ=").unwrap(),
+        log: base64_engine.decode("aGVsbG8gd29ybGQ=").unwrap(),
     };
 
     send_record_header(&mut send_log, RECORD_TYPE_LOG)

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -3,6 +3,7 @@ use crate::{
     storage::{Database, RawEventStore},
     to_cert_chain, to_private_key,
 };
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use giganto_client::{
     connection::client_handshake,
@@ -370,7 +371,7 @@ fn gen_dce_rpc_raw_event() -> Vec<u8> {
 fn gen_log_raw_event() -> Vec<u8> {
     let log_body = Log {
         kind: String::from("Hello"),
-        log: base64::decode("aGVsbG8gd29ybGQ=").unwrap(),
+        log: base64_engine.decode("aGVsbG8gd29ybGQ=").unwrap(),
     };
 
     bincode::serialize(&log_body).unwrap()


### PR DESCRIPTION
- Modify base64::{encode, decode} to base64::engine::general_purpose::STANDARD.encode decode