### PR TITLE
Fix ingest::handle_data packet logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modify module name `ingestion` to `ingest`.
 - Create giganto's communication part as a separate crate. (giganto-client)
 - Move init tracing to giganto-client crate for oplog logging.
+- Fix packet logic in ingest.
 
 ## [0.7.0] - 2023-01-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "bincode",
  "chrono",
  "config",
+ "data-encoding",
  "directories",
  "futures-util",
  "giganto-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.21"
 bincode = "1.3"
 config = { version = "0.13", features = ["toml"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
+data-encoding = "2.3"
 directories = "4.0"
 futures-util = "0.3"
 giganto-client = { path ="giganto-client" }

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -1,6 +1,5 @@
 use super::{
-    base64_engine, get_timestamp, load_connection, Engine, FromKeyValue, RawEventFilter, TimeRange,
-    TIMESTAMP_SIZE,
+    get_timestamp, load_connection, FromKeyValue, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
 };
 use crate::storage::Database;
 use async_graphql::{
@@ -8,6 +7,7 @@ use async_graphql::{
     Context, InputObject, Object, Result, SimpleObject,
 };
 use chrono::{DateTime, Utc};
+use data_encoding::BASE64;
 use giganto_client::ingest::Packet as pk;
 use std::net::IpAddr;
 
@@ -56,7 +56,7 @@ impl FromKeyValue<pk> for Packet {
         Ok(Packet {
             request_time: get_timestamp(&key[..key.len() - (TIMESTAMP_SIZE + 1)])?,
             packet_time: get_timestamp(key)?,
-            packet: base64_engine.encode(pk.packet),
+            packet: BASE64.encode(&pk.packet),
         })
     }
 }


### PR DESCRIPTION
- Modify to deserialize packet

`giganto-client`가 적용되며 packet 데이터를 `bincode::serialize`하고 보내게 변경되어서
기존 packet data의 앞에 길이값이 추가되는 버그를 수정합니다.