### PR TITLE
Capitalize struct name in CamelCase

### DIFF
--- a/giganto-client/src/publish.rs
+++ b/giganto-client/src/publish.rs
@@ -59,8 +59,8 @@ impl From<frame::SendError> for PublishError {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Pcapfilter {
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct PcapFilter {
     pub timestamp: i64,
     pub source: String,
     pub src_addr: IpAddr,
@@ -349,7 +349,7 @@ where
 /// * `PublishError::RequestFail`: if the extract request ack data is Err
 pub async fn pcap_extract_request(
     conn: &Connection,
-    pcap_filter: &Pcapfilter,
+    pcap_filter: &PcapFilter,
 ) -> Result<(), PublishError> {
     //open target(piglet) source's channel
     let (mut send, mut recv) = conn.open_bi().await?;
@@ -378,10 +378,10 @@ pub async fn pcap_extract_request(
 pub async fn pcap_extract_response(
     mut send: SendStream,
     mut recv: RecvStream,
-) -> Result<Pcapfilter, PublishError> {
+) -> Result<PcapFilter, PublishError> {
     // Recieve pcap extract request filter
     let mut buf = Vec::new();
-    match frame::recv::<Pcapfilter>(&mut recv, &mut buf).await {
+    match frame::recv::<PcapFilter>(&mut recv, &mut buf).await {
         Ok(filter) => {
             // Send ack response (Ok())
             send_ok(&mut send, &mut buf, ()).await?;
@@ -457,7 +457,7 @@ mod tests {
         use crate::publish::{
             range::ResponseRangeData,
             stream::{RequestCrusherStream, RequestHogStream},
-            Pcapfilter,
+            PcapFilter,
         };
         use crate::test::{channel, TOKEN};
         use std::net::IpAddr;
@@ -617,7 +617,7 @@ mod tests {
         );
 
         // send/recv pcap extract request
-        let p_filter = Pcapfilter {
+        let p_filter = PcapFilter {
             timestamp: 12345,
             source: "hello".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -24,7 +24,7 @@ use giganto_client::{
         send_crusher_stream_start_message, send_err, send_hog_stream_start_message, send_ok,
         send_range_data,
         stream::{NodeType, RequestCrusherStream, RequestHogStream, RequestStreamRecord},
-        Pcapfilter,
+        PcapFilter,
     },
 };
 use quinn::{Connection, Endpoint, RecvStream, SendStream, ServerConfig};
@@ -224,7 +224,7 @@ async fn process_pcap_extract(
     resp_send: &mut SendStream,
 ) -> Result<()> {
     let mut buf = Vec::new();
-    let filters = match bincode::deserialize::<Vec<Pcapfilter>>(filter_data) {
+    let filters = match bincode::deserialize::<Vec<PcapFilter>>(filter_data) {
         Ok(filters) => {
             send_ok(resp_send, &mut buf, ())
                 .await


### PR DESCRIPTION
struct 이름을 [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/naming.html#naming)를 따르도록 고쳤습니다.
giganto와 `PcapFilter`를 공유하는 `piglet`/`reconverge`도 수정이 필요하며,개별적으로 pcapfilter구조체를 정의하여 사용하는 hog 또한 이 구조체를 사용하도록 수정이 필요합니다. 