### PR TITLE
Modify db options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create giganto's communication part as a separate crate. (giganto-client)
 - Move init tracing to giganto-client crate for oplog logging.
 - Fix packet logic in ingest.
+- Rocksdb compression type has changed to Lz4, zstd from snappy
 
 ## [0.7.0] - 2023-01-04
 


### PR DESCRIPTION
- Delete WAL with `set_max_total_wal_size`.
- Modify `target_file_size_multiplier` 1 to 10. By default, L1's sst has maximum about 51.2MB, L2's sst has maximum 512MB and so on.
- Set compression type to `Lz4`, bottommost compression type `Zstd` from default `Snappy` As recommendation from [Compression](https://github.com/facebook/rocksdb/wiki/Compression)

Issue: #280,
Issue: #283


이 PR은 compaction을 통해 sst 파일의 갯수와 용량 관리에 도움을 줄 수 있습니다.
하지만 이전의 db와 호환되지 않아 데이터를 새로 넣을 필요가 있습니다.