### PR TITLE
Add sources graphql api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add GraphQL API to return source list.
+
 ## [0.8.0] - 2023-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.8.0"
+version = "0.8.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.8.0"
+version = "0.8.1-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -2,6 +2,7 @@ mod export;
 mod log;
 pub mod network;
 mod packet;
+mod source;
 pub mod status;
 mod timeseries;
 
@@ -48,6 +49,7 @@ pub struct Query(
     packet::PacketQuery,
     timeseries::TimeSeriesQuery,
     status::GigantoStatusQuery,
+    source::SourceQuery,
 );
 
 #[derive(Default, MergedObject)]

--- a/src/graphql/source.rs
+++ b/src/graphql/source.rs
@@ -1,0 +1,47 @@
+use crate::storage::Database;
+use async_graphql::{Context, Object, Result};
+
+#[derive(Default)]
+pub(super) struct SourceQuery;
+
+#[Object]
+impl SourceQuery {
+    #[allow(clippy::unused_async)]
+    async fn sources<'ctx>(&self, ctx: &Context<'ctx>) -> Result<Vec<String>> {
+        let db = ctx.data::<Database>()?;
+        let source_store = db.sources_store()?;
+        let names = source_store.names();
+        let res: Vec<String> = names
+            .iter()
+            .map(|key| String::from_utf8(key.clone()).expect("from utf8"))
+            .collect();
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graphql::TestSchema;
+    use chrono::Utc;
+
+    #[tokio::test]
+    async fn sources_test() {
+        let schema = TestSchema::new();
+        let store = schema.db.sources_store().unwrap();
+        store.insert("src 1", Utc::now()).unwrap();
+        store.insert("src 2", Utc::now()).unwrap();
+        store.insert("src 1", Utc::now()).unwrap();
+        store.insert("src 3", Utc::now()).unwrap();
+        store.insert("src 1", Utc::now()).unwrap();
+
+        let query = r#"
+        {
+            sources
+        }"#;
+        let res = schema.execute(query).await;
+        assert_eq!(
+            res.data.to_string(),
+            "{sources: [\"src 1\",\"src 2\",\"src 3\"]}"
+        );
+    }
+}

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -570,18 +570,20 @@ async fn check_sources_conn(
             }
 
             Some((source_key,timestamp_val,conn_state, rep)) = rx.recv() => {
-                if !rep {
-                    match conn_state{
-                        ConnState::Connected =>{
-                            if source_store.insert(&source_key, timestamp_val).is_err(){
-                                error!("Failed to append Source store");
-                            }
+                match conn_state {
+                    ConnState::Connected => {
+                        if source_store.insert(&source_key, timestamp_val).is_err() {
+                            error!("Failed to append Source store");
+                        }
+                        if !rep {
                             sources.write().await.insert(source_key, timestamp_val);
                         }
-                        ConnState::Disconnected =>{
-                            if source_store.insert(&source_key, timestamp_val).is_err(){
-                                error!("Failed to append Source store");
-                            }
+                    }
+                    ConnState::Disconnected => {
+                        if source_store.insert(&source_key, timestamp_val).is_err() {
+                            error!("Failed to append Source store");
+                        }
+                        if !rep {
                             sources.write().await.remove(&source_key);
                             packet_sources.write().await.remove(&source_key);
                         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -360,7 +360,7 @@ impl<'db> SourceStore<'db> {
     }
 
     /// Returns the names of all sources.
-    fn names(&self) -> Vec<Vec<u8>> {
+    pub fn names(&self) -> Vec<Vec<u8>> {
         self.db
             .iterator_cf(self.cf, rocksdb::IteratorMode::Start)
             .flatten()


### PR DESCRIPTION
- Add `sources` query api returns source names.

```graphql
query sources {
  sources
}
```

Issue: #294