### PR TITLE
[WIP] Add `delete_sampling_policy` api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a GraphQL API that can delete timeseries from the database using an ID.
+
 ### Changed
 
 - Replaced `lazy_static` with the new `std::sync::OnceLock`.

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -55,7 +55,10 @@ pub struct Query(
 );
 
 #[derive(Default, MergedObject)]
-pub struct Mutation(status::GigantoConfigMutation);
+pub struct Mutation(
+    status::GigantoConfigMutation,
+    timeseries::TimeSeriesMutation,
+);
 
 #[derive(InputObject, Serialize)]
 pub struct TimeRange {
@@ -555,6 +558,7 @@ impl TestSchema {
             schema,
         }
     }
+
     async fn execute(&self, query: &str) -> async_graphql::Response {
         let request: async_graphql::Request = query.into();
         self.schema.execute(request).await


### PR DESCRIPTION
- Add a GraphQL API that can delete timeseries from the database using an ID.

Issue: #351