### PR TITLE
Use rocksdb in storage module only

### DIFF
--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     ingest::implement::EventFilter,
-    storage::{lower_closed_bound_key, upper_open_bound_key, Database, RawEventStore},
+    storage::{lower_closed_bound_key, upper_open_bound_key, Database, Direction, RawEventStore},
 };
 use anyhow::anyhow;
 use async_graphql::{Context, InputObject, Object, Result};
@@ -17,7 +17,6 @@ use giganto_client::{
         timeseries::PeriodicTimeSeries,
     },
 };
-use rocksdb::Direction;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     borrow::Cow,


### PR DESCRIPTION
rocksdb는 캡슐화 원칙에 따라 storage 모듈 내부에서만 사용하도록 하고 이외의 모듈에서는 사용하지 않도록 합니다.