### PR TITLE
Support the Ftp Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add GIGANTO DB version compatibility check.
 - Add a publish API to return the source, raw_events
   from the source, timestamps for REconverge.
+- Supports the FTP protocol.
 
 ## [0.9.0] - 2023-04-03
 
 ### Added
 
 - Add GraphQL API to return source list.
-- Add GIGANTO DB version compatibility check.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -387,9 +387,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -837,8 +837,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.3.1"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.3.1#f704868520dba791b0054ae158bcd6c56a7e37b5"
+version = "0.4.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.4.0#03bbfe616677e3aeecafa9062aa8808ad953301f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -863,9 +863,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1173,9 +1173,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "log"
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -1930,13 +1930,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.0",
 ]
 
 [[package]]
@@ -1945,7 +1945,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1953,6 +1953,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
 
 [[package]]
 name = "ring"
@@ -2024,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags",
  "errno 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ chrono = { version = "0.4", features = ["serde"] }
 data-encoding = "2.3"
 directories = "5.0"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.3.1" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.4.0" }
 humantime = "2.1"
 humantime-serde = "1"
 libc = "0.2"

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -13,7 +13,7 @@ use giganto_client::{
     convert_time_format,
     ingest::{
         log::{Log, Oplog},
-        network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Qclass, Qtype, Rdp, Smtp, Ssh},
+        network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ntlm, Qclass, Qtype, Rdp, Smtp, Ssh},
         timeseries::PeriodicTimeSeries,
     },
 };
@@ -213,6 +213,26 @@ struct DceRpcJsonOutput {
     named_pipe: String,
     endpoint: String,
     operation: String,
+}
+
+#[derive(Serialize, Debug)]
+struct FtpJsonOutput {
+    timestamp: String,
+    source: String,
+    orig_addr: String,
+    orig_port: u16,
+    resp_addr: String,
+    resp_port: u16,
+    proto: u16,
+    last_time: i64,
+    user: String,
+    password: String,
+    data_passive: bool,
+    data_orig_addr: String,
+    data_resp_addr: String,
+    data_resp_port: u16,
+    file: String,
+    file_id: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -438,6 +458,29 @@ impl JsonOutput<OpLogJsonOutput> for Oplog {
             agent_id: source,
             level: self.log_level().unwrap_or_else(|| "-".to_string()),
             contents: self.contents.clone(),
+        })
+    }
+}
+
+impl JsonOutput<FtpJsonOutput> for Ftp {
+    fn convert_json_output(&self, timestamp: String, source: String) -> Result<FtpJsonOutput> {
+        Ok(FtpJsonOutput {
+            timestamp,
+            source,
+            orig_addr: self.orig_addr.to_string(),
+            orig_port: self.orig_port,
+            resp_addr: self.resp_addr.to_string(),
+            resp_port: self.resp_port,
+            proto: self.proto,
+            last_time: self.last_time,
+            user: self.user.clone(),
+            password: self.password.clone(),
+            data_passive: self.data_passive,
+            data_orig_addr: self.data_orig_addr.to_string(),
+            data_resp_addr: self.data_resp_addr.to_string(),
+            data_resp_port: self.data_resp_port,
+            file: self.file.clone(),
+            file_id: self.file_id.clone(),
         })
     }
 }
@@ -779,6 +822,20 @@ fn export_by_protocol(
                 error!("Failed to open db store");
             }
         }),
+        "ftp" => tokio::spawn(async move {
+            if let Ok(store) = db.ftp_store() {
+                match process_export(&store, &key_prefix, &filter, &export_type, &export_path) {
+                    Ok(result) => {
+                        info!("{}", result);
+                    }
+                    Err(e) => {
+                        error!("Failed to export file: {:?}", e);
+                    }
+                }
+            } else {
+                error!("Failed to open db store");
+            }
+        }),
         none => {
             return Err(anyhow!("{}: Unknown protocol", none).into());
         }
@@ -894,7 +951,7 @@ mod tests {
     use chrono::{Duration, Utc};
     use giganto_client::ingest::{
         log::{Log, OpLogLevel, Oplog},
-        network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
+        network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
         timeseries::PeriodicTimeSeries,
     };
     use std::mem;
@@ -1788,5 +1845,81 @@ mod tests {
         let value = bincode::serialize(&oplog_body).unwrap();
 
         store.append(&key, &value).unwrap();
+    }
+
+    #[tokio::test]
+    async fn export_ftp() {
+        let schema = TestSchema::new();
+        let store = schema.db.ftp_store().unwrap();
+
+        insert_ftp_raw_event(&store, "src1", Utc::now().timestamp_nanos());
+        insert_ftp_raw_event(&store, "src2", Utc::now().timestamp_nanos());
+
+        // export csv file
+        let query = r#"
+        {
+            export(
+                filter:{
+                    protocol: "ftp",
+                    sourceId: "src1",
+                    time: { start: "1992-06-05T00:00:00Z", end: "2023-09-22T00:00:00Z" }
+                    origAddr: { start: "192.168.4.70", end: "192.168.4.78" }
+                    respAddr: { start: "192.168.4.75", end: "192.168.4.79" }
+                    origPort: { start: 46377, end: 46380 }
+                    respPort: { start: 0, end: 200 }
+                }
+                ,exportType:"csv")
+        }"#;
+        let res = schema.execute(query).await;
+        assert!(res.data.to_string().contains("ftp"));
+
+        // export json file
+        let query = r#"
+        {
+            export(
+                filter:{
+                    protocol: "ftp",
+                    sourceId: "src2",
+                    time: { start: "1992-06-05T00:00:00Z", end: "2023-09-22T00:00:00Z" }
+                    origAddr: { start: "192.168.4.70", end: "192.168.4.78" }
+                    respAddr: { start: "192.168.4.75", end: "192.168.4.79" }
+                    origPort: { start: 46377, end: 46380 }
+                    respPort: { start: 0, end: 200 }
+                }
+                ,exportType:"json")
+        }"#;
+        let res = schema.execute(query).await;
+        assert!(res.data.to_string().contains("ftp"));
+    }
+
+    fn insert_ftp_raw_event(store: &RawEventStore<Ftp>, source: &str, timestamp: i64) {
+        let mut key = Vec::with_capacity(source.len() + 1 + mem::size_of::<i64>());
+        key.extend_from_slice(source.as_bytes());
+        key.push(0);
+        key.extend(timestamp.to_be_bytes());
+
+        let ftp_body = Ftp {
+            orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            orig_port: 46378,
+            resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+            resp_port: 80,
+            proto: 17,
+            last_time: 1,
+            user: "einsis".to_string(),
+            password: "aice".to_string(),
+            command: "command".to_string(),
+            reply_code: "500".to_string(),
+            reply_msg: "reply_message".to_string(),
+            data_passive: false,
+            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+            data_resp_port: 80,
+            file: "fpt_file".to_string(),
+            file_size: 100,
+            file_id: "1".to_string(),
+        };
+        let ser_ftp_body = bincode::serialize(&ftp_body).unwrap();
+
+        store.append(&key, &ser_ftp_body).unwrap();
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -410,6 +410,19 @@ async fn handle_request(
             )
             .await?;
         }
+        RecordType::Ftp => {
+            handle_data(
+                send,
+                recv,
+                RecordType::Ftp,
+                Some(NetworkKey::new(&source, "ftp")),
+                source,
+                db.ftp_store()?,
+                stream_direct_channel,
+                shutdown_signal,
+            )
+            .await?;
+        }
     };
     Ok(())
 }

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -1,6 +1,6 @@
 use giganto_client::ingest::{
     log::{Log, OpLogLevel, Oplog},
-    network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
+    network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
     timeseries::PeriodicTimeSeries,
     Packet,
 };
@@ -283,6 +283,27 @@ impl EventFilter for Packet {
     }
     fn resp_port(&self) -> Option<u16> {
         None
+    }
+    fn log_level(&self) -> Option<String> {
+        None
+    }
+    fn log_contents(&self) -> Option<String> {
+        None
+    }
+}
+
+impl EventFilter for Ftp {
+    fn orig_addr(&self) -> Option<IpAddr> {
+        Some(self.orig_addr)
+    }
+    fn resp_addr(&self) -> Option<IpAddr> {
+        Some(self.resp_addr)
+    }
+    fn orig_port(&self) -> Option<u16> {
+        Some(self.orig_port)
+    }
+    fn resp_port(&self) -> Option<u16> {
+        Some(self.resp_port)
     }
     fn log_level(&self) -> Option<String> {
         None

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -10,7 +10,7 @@ use giganto_client::{
     frame::recv_bytes,
     ingest::{
         log::{Log, OpLogLevel, Oplog},
-        network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
+        network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
         receive_ack_timestamp, send_event, send_record_header,
         timeseries::PeriodicTimeSeries,
         Packet, RecordType,
@@ -667,6 +667,50 @@ async fn packet() {
         .expect("failed to shutdown stream");
 
     client.conn.close(0u32.into(), b"packet_done");
+    client.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+async fn ftp() {
+    const RECORD_TYPE_FTP: RecordType = RecordType::Ftp;
+    let _lock = TOKEN.lock().await;
+    let db_dir = tempfile::tempdir().unwrap();
+    run_server(db_dir);
+
+    let client = TestClient::new().await;
+    let (mut send_ftp, _) = client.conn.open_bi().await.expect("failed to open stream");
+
+    let ftp_body = Ftp {
+        orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+        orig_port: 46378,
+        resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+        resp_port: 80,
+        proto: 17,
+        last_time: 1,
+        user: "einsis".to_string(),
+        password: "aice".to_string(),
+        command: "command".to_string(),
+        reply_code: "500".to_string(),
+        reply_msg: "reply_message".to_string(),
+        data_passive: false,
+        data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+        data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+        data_resp_port: 80,
+        file: "fpt_file".to_string(),
+        file_size: 100,
+        file_id: "1".to_string(),
+    };
+
+    send_record_header(&mut send_ftp, RECORD_TYPE_FTP)
+        .await
+        .unwrap();
+    send_event(&mut send_ftp, Utc::now().timestamp_nanos(), ftp_body)
+        .await
+        .unwrap();
+
+    send_ftp.finish().await.expect("failed to shutdown stream");
+
+    client.conn.close(0u32.into(), b"ftp_done");
     client.endpoint.wait_idle().await;
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use giganto_client::ingest::{
     log::{Log, Oplog},
-    network::{Conn, DceRpc, Dns, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
+    network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ntlm, Rdp, Smtp, Ssh},
     statistics::Statistics,
     timeseries::PeriodicTimeSeries,
     Packet,
@@ -33,7 +33,7 @@ use std::{
 use tokio::{select, sync::Notify, time};
 use tracing::error;
 
-const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 14] = [
+const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 15] = [
     "conn",
     "dns",
     "log",
@@ -48,6 +48,7 @@ const RAW_DATA_COLUMN_FAMILY_NAMES: [&str; 14] = [
     "statistics",
     "oplog",
     "packet",
+    "ftp",
 ];
 const META_DATA_COLUMN_FAMILY_NAMES: [&str; 1] = ["sources"];
 const TIMESTAMP_SIZE: usize = 8;
@@ -296,6 +297,15 @@ impl Database {
             .cf_handle("sources")
             .context("cannot access sources column family")?;
         Ok(SourceStore { db: &self.db, cf })
+    }
+
+    /// Returns the store for Ftp
+    pub fn ftp_store(&self) -> Result<RawEventStore<Ftp>> {
+        let cf = self
+            .db
+            .cf_handle("ftp")
+            .context("cannot access ftp column family")?;
+        Ok(RawEventStore::new(&self.db, cf))
     }
 }
 


### PR DESCRIPTION
- Update giganto-client to 0.4.0.
- Add functionality to the graphql qeury to support the ftp protocol.
- Add functionality to the ingest and publish to support the ftp protocol.

Closes: #339