### PR TITLE
Add event search GraphQL API for protocols supported by giganto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add event search GraphQL API for protocols supported by `giganto`.
+  (`dns`, `conn`, `rdp`, `smtp`, `ntlm`, `kerberos`, `ssh`, `DceRpc`,`ftp`)
+
 ## [0.10.0] - 2023-04-28
 
 ### Added
@@ -151,6 +158,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.10.0...main
 [0.10.0]: https://github.com/aicers/giganto/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/aicers/giganto/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/aicers/giganto/compare/0.7.0...0.8.0


### PR DESCRIPTION
https://github.com/aicers/giganto/pull/362 에서 추가한 api처럼 giganto가 지원하는 나머지 프로토콜을 대상으로 사용할 수 있는 api들을 추가합니다.