### PR TITLE
Add `cfg path` fields to Settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Supports the MQTT protocol.
+- Add `cfg path` fields to Settings. This path is used to fetch/modify
+  giganto's config.
 
 ### Fixed
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -90,12 +90,14 @@ pub fn schema(
     packet_sources: PacketSources,
     export_path: PathBuf,
     config_reload: Arc<Notify>,
+    config_file_path: String,
 ) -> Schema {
     Schema::build(Query::default(), Mutation::default(), EmptySubscription)
         .data(database)
         .data(packet_sources)
         .data(export_path)
         .data(config_reload)
+        .data(config_file_path)
         .finish()
 }
 
@@ -533,6 +535,7 @@ impl TestSchema {
             packet_sources,
             export_dir.path().to_path_buf(),
             config_reload,
+            "file_path".to_string(),
         );
         Self {
             _dir: db_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,7 @@ mod settings;
 mod storage;
 mod web;
 
-use crate::{
-    graphql::status::DEFAULT_TOML, server::SERVER_REBOOT_DELAY, storage::migrate_data_dir,
-};
+use crate::{server::SERVER_REBOOT_DELAY, storage::migrate_data_dir};
 use anyhow::{anyhow, Context, Result};
 use giganto_client::init_tracing;
 use rustls::{Certificate, PrivateKey};
@@ -89,6 +87,7 @@ async fn main() -> Result<()> {
             packet_sources.clone(),
             settings.export_dir.clone(),
             config_reload.clone(),
+            settings.cfg_path.clone(),
         );
         task::spawn(web::serve(
             schema,
@@ -133,7 +132,7 @@ async fn main() -> Result<()> {
         ));
         loop {
             config_reload.notified().await;
-            match Settings::from_file(DEFAULT_TOML) {
+            match Settings::from_file(&settings.cfg_path) {
                 Ok(new_settings) => {
                     settings = new_settings;
                     notify_shutdown.notify_waiters();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,6 +28,9 @@ pub struct Settings {
     // db options
     pub max_open_files: i32,
     pub max_mb_of_level_base: u64,
+
+    //config file path
+    pub cfg_path: String,
 }
 
 impl Settings {
@@ -56,8 +59,9 @@ impl Settings {
         let s = default_config_builder()
             .add_source(File::with_name(cfg_path))
             .build()?;
-
-        s.try_deserialize()
+        let mut setting: Settings = s.try_deserialize()?;
+        setting.cfg_path = cfg_path.to_string();
+        Ok(setting)
     }
 }
 
@@ -79,6 +83,7 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
     let config_dir = dirs.config_dir();
     let cert_path = config_dir.join("cert.pem");
     let key_path = config_dir.join("key.pem");
+    let config_path = config_dir.join("config.toml");
 
     Config::builder()
         .set_default("cert", cert_path.to_str().expect("path to string"))
@@ -103,6 +108,8 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .expect("default max open files")
         .set_default("max_mb_of_level_base", 512)
         .expect("default max mb of level base")
+        .set_default("cfg_path", config_path.to_str().expect("path to string"))
+        .expect("deafult config dir")
 }
 
 /// Deserializes a socket address.


### PR DESCRIPTION
기존의 setting은 argument의 설정이나 default 설정을 이용하도록 되어 있습니다. 그러나 실제 현재 현장에서 사용 되는 default 설정은 아래와 같습니다.

- giganto 설정 파일 : `usr/local/aice/conf/giganto.toml` 
- giganto 데이터 폴더 : `/data`

또한 graphql 의 `setGigantoConfig` 및 `reboot`을 할때 읽는 설정 파일의 위치는 고정값을 항상 사용하기 때문에, 만일 argument를 통해 giganto를 실행한 경우에는 실제 config 파일을 재 설정하지 않을 것입니다.
 
그렇기 때문에  1. 정확한 defautl 설정 값으로 수정  2. 실행시 참조한 설정 파일을 사용 하도록 수정하였습니다.