### PR TITLE
Add giganto clustering functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- added Giganto clustering funtionality. This feature connects giganto peer-to-peer,
+  and connected gigantos share each other's `peer` list and connected `source` list.
+
 ## [0.11.0] - 2023-05-16
 
 ### Changed
@@ -178,8 +185,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.11.0...main
 [0.11.0]: https://github.com/aicers/giganto/compare/0.10.2...0.11.0
-[0.10.2]: https://github.com/aicers/giganto/compare/0.10.0...0.10.2
+[0.10.2]: https://github.com/aicers/giganto/compare/0.10.1...0.10.2
 [0.10.1]: https://github.com/aicers/giganto/compare/0.10.0...0.10.1
 [0.10.0]: https://github.com/aicers/giganto/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/aicers/giganto/compare/0.8.0...0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 1.0.109",
  "synstructure",
@@ -82,7 +82,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 1.0.109",
 ]
@@ -131,7 +131,7 @@ dependencies = [
  "async-graphql-parser",
  "darling 0.14.4",
  "proc-macro-crate",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 1.0.109",
  "thiserror",
@@ -190,7 +190,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -201,7 +201,7 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -246,7 +246,7 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "regex",
  "rustc-hash",
@@ -445,6 +445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +482,7 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "strsim",
  "syn 1.0.109",
@@ -486,7 +496,7 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "strsim",
  "syn 2.0.16",
@@ -582,7 +592,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -721,7 +731,7 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -798,6 +808,7 @@ dependencies = [
  "bincode",
  "chrono",
  "config",
+ "ctrlc",
  "data-encoding",
  "directories",
  "futures-util",
@@ -1141,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1434,7 +1445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -1550,7 +1561,7 @@ checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -1581,7 +1592,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -1646,7 +1657,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "regex",
  "syn 1.0.109",
@@ -1707,7 +1718,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617feabb81566b593beb4886fb8c1f38064169dae4dccad0e3220160c3b37203"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "syn 2.0.16",
 ]
 
@@ -1732,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1802,7 +1813,7 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
 ]
 
 [[package]]
@@ -2142,7 +2153,7 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -2193,7 +2204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling 0.20.1",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -2320,7 +2331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "rustversion",
  "syn 1.0.109",
@@ -2343,7 +2354,7 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "unicode-ident",
 ]
@@ -2354,7 +2365,7 @@ version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "unicode-ident",
 ]
@@ -2365,7 +2376,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -2427,7 +2438,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -2518,7 +2529,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -2633,7 +2644,7 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
 ]
@@ -2869,9 +2880,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2879,14 +2890,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
  "wasm-bindgen-shared",
@@ -2894,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote 1.0.27",
  "wasm-bindgen-macro-support",
@@ -2904,11 +2915,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "quote 1.0.27",
  "syn 2.0.16",
  "wasm-bindgen-backend",
@@ -2917,15 +2928,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.21"
 bincode = "1.3"
 config = { version = "0.13", features = ["toml"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
+ctrlc = { version = "3", features = ["termination"] }
 data-encoding = "2.4"
 directories = "5.0"
 futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ log_dir = "/data/logs/apps"                # path to giganto's syslog file
 export_dir = "tests/export"                # path to giganto's export file
 max_open_files = 8000                      # db options max open files,
 max_mb_of_level_base = 512                 # db options max MB of rocksDB Level 1
+peer_address = "10.10.11.1:38383"          # address to listen for peers QUIC
+peers=[{address = "10.10.12.1:38383", host_name = "ai"}]     # list of peer info.
 ```
 
 By default, giganto reads the config file from the following directories:
@@ -58,6 +60,9 @@ be appropriate.
 These values assume you've used all the way up to level 6, so the actual values may
 change if you want to grow your data further at the level base.
 So if it's less than `512`MB, it's recommended to set default value of `512`MB.
+
+If there is no `peer_address` option in the configuration file, it runs in
+`standalone` mode, and if there is, it runs in `cluster` mode for P2P.
 
 ## Test
 

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -1,6 +1,6 @@
 #[cfg(debug_assertions)]
 use crate::storage::Database;
-use anyhow::Context as ct;
+use anyhow::{anyhow, Context as ct};
 use async_graphql::Context;
 use async_graphql::{InputObject, Object, Result, SimpleObject};
 use std::{
@@ -10,9 +10,21 @@ use std::{
     time::Duration,
 };
 use tokio::sync::Notify;
-use toml_edit::{value, Document};
+use toml_edit::{value, Document, InlineTable};
 
 const GRAPHQL_REBOOT_DELAY: u64 = 100;
+const CONFIG_INGEST_ADDRESS: &str = "ingest_address";
+const CONFIG_PUBLISH_ADDRESS: &str = "publish_address";
+const CONFIG_GRAPHQL_ADDRESS: &str = "graphql_address";
+const CONFIG_RETENTION: &str = "retention";
+const CONFIG_MAX_OPEN_FILES: &str = "max_open_files";
+const CONFIG_MAX_MB_OF_LEVEL_BASE: &str = "max_mb_of_level_base";
+const CONFIG_PEER_ADDRESS: &str = "peer_address";
+
+pub trait TomlPeers {
+    fn get_host_name(&self) -> String;
+    fn get_address(&self) -> String;
+}
 
 #[derive(SimpleObject, Debug)]
 struct GigantoStatus {
@@ -36,6 +48,22 @@ struct Properties {
     stats: String,
 }
 
+#[derive(InputObject, SimpleObject, Debug)]
+#[graphql(input_name = "InputPeerList")]
+pub struct PeerList {
+    pub address: String,
+    pub host_name: String,
+}
+
+impl TomlPeers for PeerList {
+    fn get_host_name(&self) -> String {
+        self.host_name.clone()
+    }
+    fn get_address(&self) -> String {
+        self.address.clone()
+    }
+}
+
 #[derive(SimpleObject, Debug)]
 struct GigantoConfig {
     ingest_address: String,
@@ -44,6 +72,8 @@ struct GigantoConfig {
     retention: String,
     max_open_files: String,
     max_mb_of_level_base: String,
+    peer_address: String,
+    peer_list: Vec<PeerList>,
 }
 
 #[derive(InputObject)]
@@ -54,6 +84,8 @@ struct UserConfig {
     retention: Option<String>,
     max_open_files: Option<String>,
     max_mb_of_level_base: Option<String>,
+    peer_address: Option<String>,
+    peer_list: Option<Vec<PeerList>>,
 }
 
 #[derive(Default)]
@@ -98,36 +130,39 @@ impl GigantoStatusQuery {
     }
 
     #[allow(clippy::unused_async)]
-    async fn giganto_config<'ctx>(&self, ctx: &Context<'ctx>) -> Result<GigantoConfig> {
+    async fn giganto_config<'ctx>(
+        &self,
+        ctx: &async_graphql::Context<'ctx>,
+    ) -> Result<GigantoConfig> {
         let cfg_path = ctx.data::<String>()?;
-        let toml = fs::read_to_string(cfg_path).context("toml not found")?;
-        let doc = toml.parse::<Document>()?;
-
-        let ingest_address = doc
-            .get("ingest_address")
-            .context("\"ingest_address\" not found")?
-            .to_string();
-        let publish_address = doc
-            .get("publish_address")
-            .context("\"publish_address\" not found")?
-            .to_string();
-        let graphql_address = doc
-            .get("graphql_address")
-            .context("\"graphql_address\" not found")?
-            .to_string();
-        let retention = doc
-            .get("retention")
-            .context("\"retention\" not found")?
-            .to_string();
-        let max_open_files = doc
-            .get("max_open_files")
-            .context("\"max_open_files\" not found")?
-            .to_string();
-        let max_mb_of_level_base = doc
-            .get("max_mb_of_level_base")
-            .context("\"max_mb_of_level_base\" not found")?
-            .to_string();
-
+        let doc = read_toml_file(cfg_path)?;
+        let ingest_address = parse_toml_element(CONFIG_INGEST_ADDRESS, &doc)?;
+        let publish_address = parse_toml_element(CONFIG_PUBLISH_ADDRESS, &doc)?;
+        let graphql_address = parse_toml_element(CONFIG_GRAPHQL_ADDRESS, &doc)?;
+        let retention = parse_toml_element(CONFIG_RETENTION, &doc)?;
+        let max_open_files = parse_toml_element(CONFIG_MAX_OPEN_FILES, &doc)?;
+        let max_mb_of_level_base = parse_toml_element(CONFIG_MAX_MB_OF_LEVEL_BASE, &doc)?;
+        let peer_address = parse_toml_element(CONFIG_PEER_ADDRESS, &doc)?;
+        let peers_value = doc
+            .get("peers")
+            .context("peers not found")?
+            .as_array()
+            .context("invaild peers format")?;
+        let mut peer_list = Vec::new();
+        for peer in peers_value.iter() {
+            if let Some(peer_data) = peer.as_inline_table() {
+                let (Some(address_val),Some(host_name_val)) = (peer_data.get("address"),peer_data.get("host_name")) else{
+                    return Err(anyhow!("Invalid address/hostname Value format").into());
+                };
+                let (Some(address),Some(host_name)) = (address_val.as_str(),host_name_val.as_str()) else{
+                    return Err(anyhow!("Invalid address/hostname String format").into());
+                };
+                peer_list.push(PeerList {
+                    address: address.to_string(),
+                    host_name: host_name.to_string(),
+                });
+            }
+        }
         Ok(GigantoConfig {
             ingest_address,
             publish_address,
@@ -135,6 +170,8 @@ impl GigantoStatusQuery {
             retention,
             max_open_files,
             max_mb_of_level_base,
+            peer_address,
+            peer_list,
         })
     }
 }
@@ -148,34 +185,20 @@ impl GigantoConfigMutation {
         field: UserConfig,
     ) -> Result<String> {
         let cfg_path = ctx.data::<String>()?;
-        let toml = fs::read_to_string(cfg_path).context("toml not found")?;
-        let mut doc = toml.parse::<Document>()?;
-
-        if let Some(ingest_address) = field.ingest_address {
-            doc["ingest_address"] = value(ingest_address);
-        }
-        if let Some(publish_address) = field.publish_address {
-            doc["publish_address"] = value(publish_address);
-        }
-        if let Some(graphql_address) = field.graphql_address {
-            doc["graphql_address"] = value(graphql_address);
-        }
-        if let Some(retention) = field.retention {
-            doc["retention"] = value(retention);
-        }
-        if let Some(max_open_files) = field.max_open_files {
-            doc["max_open_files"] = value(max_open_files);
-        }
-        if let Some(max_mb_of_level_base) = field.max_mb_of_level_base {
-            doc["max_mb_of_level_base"] = value(max_mb_of_level_base);
-        }
-
-        let output = doc.to_string();
-        let mut toml_file = OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(cfg_path)?;
-        writeln!(toml_file, "{output}")?;
+        let mut doc = read_toml_file(cfg_path)?;
+        insert_toml_element(CONFIG_INGEST_ADDRESS, &mut doc, field.ingest_address);
+        insert_toml_element(CONFIG_PUBLISH_ADDRESS, &mut doc, field.publish_address);
+        insert_toml_element(CONFIG_GRAPHQL_ADDRESS, &mut doc, field.graphql_address);
+        insert_toml_element(CONFIG_RETENTION, &mut doc, field.retention);
+        insert_toml_element(CONFIG_MAX_OPEN_FILES, &mut doc, field.max_open_files);
+        insert_toml_element(
+            CONFIG_MAX_MB_OF_LEVEL_BASE,
+            &mut doc,
+            field.max_mb_of_level_base,
+        );
+        insert_toml_element(CONFIG_PEER_ADDRESS, &mut doc, field.peer_address);
+        insert_toml_peers(&mut doc, field.peer_list)?;
+        write_toml_file(&doc, cfg_path)?;
 
         let config_reload = ctx.data::<Arc<Notify>>()?.clone();
         tokio::spawn(async move {
@@ -186,4 +209,61 @@ impl GigantoConfigMutation {
 
         Ok("Done".to_string())
     }
+}
+
+pub fn read_toml_file(path: &str) -> Result<Document> {
+    let toml = fs::read_to_string(path).context("toml not found")?;
+    let doc = toml.parse::<Document>()?;
+    Ok(doc)
+}
+
+pub fn write_toml_file(doc: &Document, path: &str) -> Result<()> {
+    let output = doc.to_string();
+    let mut config_file = OpenOptions::new().write(true).truncate(true).open(path)?;
+    writeln!(config_file, "{output}")?;
+    Ok(())
+}
+
+fn parse_toml_element(key: &str, doc: &Document) -> Result<String> {
+    let Some(item) = doc.get(key) else {
+        return Err(anyhow!("{} not found.",key).into());
+    };
+    let Some(value) = item.as_str() else {
+        return Err(anyhow!("parse failed: {}'s format is not available.",key).into());
+    };
+    Ok(value.to_string())
+}
+
+fn insert_toml_element(key: &str, doc: &mut Document, input: Option<String>) {
+    if let Some(element) = input {
+        doc[key] = value(element);
+    };
+}
+
+pub fn insert_toml_peers<T>(doc: &mut Document, input: Option<Vec<T>>) -> Result<()>
+where
+    T: TomlPeers,
+{
+    if let Some(peer_list) = input {
+        let Some(array) = doc["peers"].as_array_mut() else {
+            return Err(anyhow!("insert failed: peers option not found").into());
+        };
+        array.clear();
+        for peer in peer_list {
+            let mut table = InlineTable::new();
+            if let (Some(address), Some(host_name)) = (
+                value(peer.get_address()).as_value(),
+                value(peer.get_host_name()).as_value(),
+            ) {
+                table.insert("address", address.clone());
+                table.insert("host_name", host_name.clone());
+            } else {
+                return Err(
+                    anyhow!("insert failed: peer's address/hostname option not found.").into(),
+                );
+            }
+            array.push(table);
+        }
+    }
+    Ok(())
 }

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -841,5 +841,6 @@ fn run_server(db_dir: TempDir) -> JoinHandle<()> {
         sources,
         stream_direct_channel,
         Arc::new(Notify::new()),
+        Some(Arc::new(Notify::new())),
     ))
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,0 +1,906 @@
+#![allow(clippy::module_name_repetitions)]
+
+use crate::{
+    graphql::status::{insert_toml_peers, read_toml_file, write_toml_file, TomlPeers},
+    ingest::Sources,
+    server::{
+        certificate_info, config_client, config_server, extract_cert_from_conn,
+        SERVER_CONNNECTION_DELAY, SERVER_ENDPOINT_DELAY,
+    },
+};
+use anyhow::{anyhow, bail, Context, Result};
+use giganto_client::{
+    connection::{client_handshake, server_handshake},
+    frame::{self, recv_bytes, recv_raw, send_bytes},
+};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use quinn::{
+    ClientConfig, Connection, ConnectionError, Endpoint, RecvStream, SendStream, ServerConfig,
+};
+use rustls::{Certificate, PrivateKey};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{
+    select,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Notify, RwLock,
+    },
+    time::sleep,
+};
+use toml_edit::Document;
+use tracing::{error, info, warn};
+
+const PEER_VERSION_REQ: &str = "0.11.0";
+const PEER_RETRY_INTERVAL: u64 = 5;
+
+pub type PeerSources = Arc<RwLock<HashMap<String, HashSet<String>>>>;
+
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, IntoPrimitive, PartialEq, Serialize, TryFromPrimitive,
+)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum PeerCode {
+    UpdatePeerList = 0,
+    UpdateSourceList = 1,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PeerInfo {
+    pub address: SocketAddr,
+    pub host_name: String,
+}
+
+impl TomlPeers for PeerInfo {
+    fn get_host_name(&self) -> String {
+        self.host_name.clone()
+    }
+    fn get_address(&self) -> String {
+        self.address.to_string()
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Debug)]
+pub struct PeerConnInfo {
+    peer_conn: Arc<RwLock<HashMap<String, Connection>>>, //key: hostname, value: connection
+    peer_list: Arc<RwLock<HashSet<PeerInfo>>>,
+    sources: Sources,
+    peer_sources: PeerSources, //key: address(for request graphql/publish), value: peer's collect sources(hashset)
+    peer_sender: Sender<PeerInfo>,
+    local_address: SocketAddr,
+    notify_source: Arc<Notify>,
+    config_doc: Document,
+    config_path: String,
+}
+
+pub struct Peer {
+    client_config: ClientConfig,
+    server_config: ServerConfig,
+    local_address: SocketAddr,
+    local_host_name: String,
+}
+
+impl Peer {
+    pub fn new(
+        local_address: SocketAddr,
+        certs: Vec<Certificate>,
+        key: PrivateKey,
+        files: Vec<Vec<u8>>,
+    ) -> Result<Self> {
+        let (_, local_host_name) = certificate_info(&certs)?;
+
+        let server_config = config_server(certs.clone(), key.clone(), files.clone())
+            .expect("server configuration error with cert, key or root");
+
+        let client_config = config_client(certs, key, files)
+            .expect("client configuration error with cert, key or root");
+
+        Ok(Peer {
+            client_config,
+            server_config,
+            local_address,
+            local_host_name,
+        })
+    }
+
+    pub async fn run(
+        self,
+        peers: HashSet<PeerInfo>,
+        sources: Sources,
+        peer_sources: PeerSources,
+        notify_source: Arc<Notify>,
+        wait_shutdown: Arc<Notify>,
+        config_path: String,
+    ) -> Result<()> {
+        let server_endpoint =
+            Endpoint::server(self.server_config, self.local_address).expect("endpoint");
+        info!(
+            "listening on {}",
+            server_endpoint
+                .local_addr()
+                .expect("for local addr display")
+        );
+
+        let client_socket = SocketAddr::new(self.local_address.ip(), 0);
+        let client_endpoint = {
+            let mut e = Endpoint::client(client_socket).expect("endpoint");
+            e.set_default_client_config(self.client_config);
+            e
+        };
+
+        let (sender, mut receiver): (Sender<PeerInfo>, Receiver<PeerInfo>) = channel(100);
+
+        let Ok(config_doc) = read_toml_file(&config_path) else {
+            bail!("Failed to open/read config's toml file");
+        };
+
+        // A structure of values common to peer connections.
+        let peer_conn_info = PeerConnInfo {
+            peer_conn: Arc::new(RwLock::new(HashMap::new())),
+            peer_list: Arc::new(RwLock::new(peers)),
+            peer_sources,
+            sources,
+            peer_sender: sender,
+            local_address: self.local_address,
+            notify_source,
+            config_doc,
+            config_path,
+        };
+
+        tokio::spawn(client_run(
+            client_endpoint.clone(),
+            peer_conn_info.clone(),
+            self.local_host_name.clone(),
+            wait_shutdown.clone(),
+        ));
+
+        loop {
+            select! {
+                Some(conn) = server_endpoint.accept()  => {
+                    let peer_conn_info = peer_conn_info.clone();
+                    let wait_shutdown = wait_shutdown.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = server_connection(
+                            conn,
+                            peer_conn_info,
+                            wait_shutdown,
+                        )
+                        .await
+                        {
+                            error!("connection failed: {}", e);
+                        }
+                    });
+                },
+                Some(peer) = receiver.recv()  => {
+                    tokio::spawn(client_connection(
+                        client_endpoint.clone(),
+                        peer,
+                        peer_conn_info.clone(),
+                        self.local_host_name.clone(),
+                        wait_shutdown.clone(),
+                    ));
+                },
+                _ = wait_shutdown.notified() => {
+                    sleep(Duration::from_millis(SERVER_ENDPOINT_DELAY)).await;      // Wait time for connection to be ready for shutdown.
+                    server_endpoint.close(0_u32.into(), &[]);
+                    info!("Shutting down peer");
+                    return Ok(())
+                }
+
+            }
+        }
+    }
+}
+
+async fn client_run(
+    client_endpoint: Endpoint,
+    peer_conn_info: PeerConnInfo,
+    local_host_name: String,
+    wait_shutdown: Arc<Notify>,
+) {
+    for peer in peer_conn_info.peer_list.read().await.iter() {
+        tokio::spawn(client_connection(
+            client_endpoint.clone(),
+            peer.clone(),
+            peer_conn_info.clone(),
+            local_host_name.clone(),
+            wait_shutdown.clone(),
+        ));
+    }
+}
+
+async fn connect(
+    client_endpoint: &Endpoint,
+    peer_info: &PeerInfo,
+) -> Result<(Connection, SendStream, RecvStream)> {
+    let connection = client_endpoint
+        .connect(peer_info.address, &peer_info.host_name)?
+        .await?;
+    let (send, recv) = client_handshake(&connection, PEER_VERSION_REQ).await?;
+    Ok((connection, send, recv))
+}
+
+#[allow(clippy::too_many_lines)]
+async fn client_connection(
+    client_endpoint: Endpoint,
+    peer_info: PeerInfo,
+    peer_conn_info: PeerConnInfo,
+    local_host_name: String,
+    wait_shutdown: Arc<Notify>,
+) -> Result<()> {
+    'connection: loop {
+        match connect(&client_endpoint, &peer_info).await {
+            Ok((connection, mut send, mut recv)) => {
+                // Remove duplicate connections.
+                let (remote_addr, remote_host_name) = match check_for_duplicate_connections(
+                    &connection,
+                    peer_conn_info.peer_conn.clone(),
+                )
+                .await
+                {
+                    Ok((addr, name)) => {
+                        info!("Connection established to {}/{} (client role)", addr, name);
+                        (addr, name)
+                    }
+                    Err(_) => {
+                        return Ok(());
+                    }
+                };
+
+                let send_source_list: HashSet<String> = peer_conn_info
+                    .sources
+                    .read()
+                    .await
+                    .keys()
+                    .cloned()
+                    .collect();
+
+                // Add my peer info to the peer list.
+                let mut send_peer_list = peer_conn_info.peer_list.read().await.clone();
+                send_peer_list.insert(PeerInfo {
+                    address: peer_conn_info.local_address,
+                    host_name: local_host_name.clone(),
+                });
+
+                // Exchange peer list/source list.
+                let (recv_peer_list, recv_source_list) =
+                    request_init_info::<(HashSet<PeerInfo>, HashSet<String>)>(
+                        &mut send,
+                        &mut recv,
+                        PeerCode::UpdatePeerList,
+                        (send_peer_list, send_source_list),
+                    )
+                    .await?;
+
+                // Update to the list of received sources.
+                update_to_new_source_list(
+                    recv_source_list,
+                    remote_addr.clone(),
+                    peer_conn_info.peer_sources.clone(),
+                )
+                .await;
+
+                // Update to the list of received peers.
+                update_to_new_peer_list(
+                    recv_peer_list,
+                    peer_conn_info.local_address,
+                    peer_conn_info.peer_list.clone(),
+                    peer_conn_info.peer_sender.clone(),
+                    peer_conn_info.config_doc.clone(),
+                    &peer_conn_info.config_path,
+                )
+                .await?;
+
+                // Share the received peer list with connected peers.
+                for (_, conn) in peer_conn_info.peer_conn.read().await.iter() {
+                    tokio::spawn(update_peer_info::<HashSet<PeerInfo>>(
+                        conn.clone(),
+                        PeerCode::UpdatePeerList,
+                        peer_conn_info.peer_list.read().await.clone(),
+                    ));
+                }
+
+                // Update my peer list
+                peer_conn_info
+                    .peer_conn
+                    .write()
+                    .await
+                    .insert(remote_host_name.clone(), connection.clone());
+
+                loop {
+                    select! {
+                        stream = connection.accept_bi()  => {
+                            let stream = match stream {
+                                Err(e) => {
+                                    peer_conn_info.peer_conn.write().await.remove(&remote_host_name);
+                                    peer_conn_info.peer_sources.write().await.remove(&remote_addr);
+                                    if let quinn::ConnectionError::ApplicationClosed(_) = e {
+                                        info!("giganto peer({}/{}) closed",remote_host_name, remote_addr);
+                                        return Ok(());
+                                    }
+                                    continue 'connection;
+                                }
+                                Ok(s) => s,
+                            };
+
+                            let peer_list = peer_conn_info.peer_list.clone();
+                            let sender = peer_conn_info.peer_sender.clone();
+                            let remote_addr =remote_addr.clone();
+                            let peer_sources = peer_conn_info.peer_sources.clone();
+                            let doc = peer_conn_info.config_doc.clone();
+                            let path= peer_conn_info.config_path.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = handle_request(stream,peer_conn_info.local_address,remote_addr,peer_list,peer_sources,sender,doc,path).await {
+                                    error!("failed: {}", e);
+                                }
+                            });
+                        },
+                        _ = peer_conn_info.notify_source.notified() => {
+                            let source_list: HashSet<String> = peer_conn_info.sources.read().await.keys().cloned().collect();
+                            for (_, conn) in peer_conn_info.peer_conn.write().await.iter() {
+                                tokio::spawn(update_peer_info::<HashSet<String>>(
+                                    conn.clone(),
+                                    PeerCode::UpdateSourceList,
+                                    source_list.clone(),
+                                ));
+                            }
+                        },
+                        _ = wait_shutdown.notified() => {
+                            // Wait time for channels to be ready for shutdown.
+                            sleep(Duration::from_millis(SERVER_CONNNECTION_DELAY)).await;
+                            connection.close(0_u32.into(), &[]);
+                            return Ok(())
+                        },
+                    }
+                }
+            }
+            Err(e) => {
+                if let Some(e) = e.downcast_ref::<ConnectionError>() {
+                    match e {
+                        ConnectionError::ConnectionClosed(_)
+                        | ConnectionError::ApplicationClosed(_)
+                        | ConnectionError::Reset
+                        | ConnectionError::TimedOut => {
+                            warn!(
+                                "Retry connection to {} after {} seconds.",
+                                peer_info.address, PEER_RETRY_INTERVAL,
+                            );
+                            sleep(Duration::from_secs(PEER_RETRY_INTERVAL)).await;
+                            continue 'connection;
+                        }
+                        _ => {}
+                    }
+                } else {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn server_connection(
+    conn: quinn::Connecting,
+    peer_conn_info: PeerConnInfo,
+    wait_shutdown: Arc<Notify>,
+) -> Result<()> {
+    let connection = conn.await?;
+
+    let (mut send, mut recv) = match server_handshake(&connection, PEER_VERSION_REQ).await {
+        Ok((send, recv)) => (send, recv),
+        Err(e) => {
+            connection.close(quinn::VarInt::from_u32(0), e.to_string().as_bytes());
+            bail!("{e}")
+        }
+    };
+
+    // Remove duplicate connections.
+    let (remote_addr, remote_host_name) = match check_for_duplicate_connections(
+        &connection,
+        peer_conn_info.peer_conn.clone(),
+    )
+    .await
+    {
+        Ok((addr, name)) => {
+            info!("Connection established to {}/{} (server role)", addr, name);
+            (addr, name)
+        }
+        Err(_) => {
+            return Ok(());
+        }
+    };
+
+    let source_list: HashSet<String> = peer_conn_info
+        .sources
+        .read()
+        .await
+        .keys()
+        .cloned()
+        .collect();
+
+    // Exchange peer list/source list.
+    let (recv_peer_list, recv_source_list) =
+        response_init_info::<(HashSet<PeerInfo>, HashSet<String>)>(
+            &mut send,
+            &mut recv,
+            PeerCode::UpdatePeerList,
+            (peer_conn_info.peer_list.read().await.clone(), source_list),
+        )
+        .await?;
+
+    // Update to the list of received sources.
+    update_to_new_source_list(
+        recv_source_list.clone(),
+        remote_addr.clone(),
+        peer_conn_info.peer_sources.clone(),
+    )
+    .await;
+
+    // Update to the list of received peers.
+    update_to_new_peer_list(
+        recv_peer_list.clone(),
+        peer_conn_info.local_address,
+        peer_conn_info.peer_list.clone(),
+        peer_conn_info.peer_sender.clone(),
+        peer_conn_info.config_doc.clone(),
+        &peer_conn_info.config_path,
+    )
+    .await?;
+
+    // Share the received peer list with your connected peers.
+    for (_, conn) in peer_conn_info.peer_conn.read().await.iter() {
+        tokio::spawn(update_peer_info::<HashSet<PeerInfo>>(
+            conn.clone(),
+            PeerCode::UpdatePeerList,
+            peer_conn_info.peer_list.read().await.clone(),
+        ));
+    }
+
+    // Update my peer list
+    peer_conn_info
+        .peer_conn
+        .write()
+        .await
+        .insert(remote_host_name.clone(), connection.clone());
+
+    loop {
+        select! {
+            stream = connection.accept_bi()  => {
+                let stream = match stream {
+                    Err(e) => {
+                        peer_conn_info.peer_conn.write().await.remove(&remote_host_name);
+                        peer_conn_info.peer_sources.write().await.remove(&remote_addr);
+                        if let quinn::ConnectionError::ApplicationClosed(_) = e {
+                            info!("giganto peer({}/{}) closed",remote_host_name, remote_addr);
+                            return Ok(());
+                        }
+                        return Err(e.into());
+                    }
+                    Ok(s) => s,
+                };
+
+                let peer_list = peer_conn_info.peer_list.clone();
+                let sender = peer_conn_info.peer_sender.clone();
+                let remote_addr =remote_addr.clone();
+                let peer_sources = peer_conn_info.peer_sources.clone();
+                let doc = peer_conn_info.config_doc.clone();
+                let path= peer_conn_info.config_path.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_request(stream,peer_conn_info.local_address,remote_addr,peer_list,peer_sources,sender,doc,path).await {
+                        error!("failed: {}", e);
+                    }
+                });
+            },
+            _ = peer_conn_info.notify_source.notified() => {
+                let source_list: HashSet<String> = peer_conn_info.sources.read().await.keys().cloned().collect();
+                for (_, conn) in peer_conn_info.peer_conn.read().await.iter() {
+                    tokio::spawn(update_peer_info::<HashSet<String>>(
+                        conn.clone(),
+                        PeerCode::UpdateSourceList,
+                        source_list.clone(),
+                    ));
+                }
+            },
+            _ = wait_shutdown.notified() => {
+                // Wait time for channels to be ready for shutdown.
+                sleep(Duration::from_millis(SERVER_CONNNECTION_DELAY)).await;
+                connection.close(0_u32.into(), &[]);
+                return Ok(())
+            },
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_request(
+    (_, mut recv): (SendStream, RecvStream),
+    local_addr: SocketAddr,
+    remote_addr: String,
+    peer_list: Arc<RwLock<HashSet<PeerInfo>>>,
+    peer_sources: PeerSources,
+    sender: Sender<PeerInfo>,
+    doc: Document,
+    path: String,
+) -> Result<()> {
+    let (msg_type, msg_buf) = receive_peer_data(&mut recv).await?;
+    match msg_type {
+        PeerCode::UpdatePeerList => {
+            let update_peer_list = bincode::deserialize::<HashSet<PeerInfo>>(&msg_buf)
+                .map_err(|e| anyhow!("Failed to deseralize peer list: {}", e))?;
+            update_to_new_peer_list(update_peer_list, local_addr, peer_list, sender, doc, &path)
+                .await?;
+        }
+        PeerCode::UpdateSourceList => {
+            let update_source_list = bincode::deserialize::<HashSet<String>>(&msg_buf)
+                .map_err(|e| anyhow!("Failed to deseralize source list: {}", e))?;
+            update_to_new_source_list(update_source_list, remote_addr, peer_sources).await;
+        }
+    }
+    Ok(())
+}
+
+pub async fn send_peer_data<T>(send: &mut SendStream, msg: PeerCode, update_data: T) -> Result<()>
+where
+    T: Serialize,
+{
+    // send PeerCode
+    let msg_type: u32 = msg.into();
+    send_bytes(send, &msg_type.to_le_bytes()).await?;
+
+    // send the peer data to be updated
+    let mut buf = Vec::new();
+    frame::send(send, &mut buf, update_data).await?;
+    Ok(())
+}
+
+pub async fn receive_peer_data(recv: &mut RecvStream) -> Result<(PeerCode, Vec<u8>)> {
+    // receive PeerCode
+    let mut buf = [0; mem::size_of::<u32>()];
+    recv_bytes(recv, &mut buf).await?;
+    let msg_type = PeerCode::try_from(u32::from_le_bytes(buf)).context("unknown peer code")?;
+
+    // receive the peer data to be updated
+    let mut buf = Vec::new();
+    recv_raw(recv, &mut buf).await?;
+    Ok((msg_type, buf))
+}
+
+async fn request_init_info<T>(
+    send: &mut SendStream,
+    recv: &mut RecvStream,
+    init_type: PeerCode,
+    init_data: T,
+) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    send_peer_data::<T>(send, init_type, init_data).await?;
+    let (_, recv_data) = receive_peer_data(recv).await?;
+    let recv_init_data = bincode::deserialize::<T>(&recv_data)?;
+    Ok(recv_init_data)
+}
+
+async fn response_init_info<T>(
+    send: &mut SendStream,
+    recv: &mut RecvStream,
+    init_type: PeerCode,
+    init_data: T,
+) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    let (_, recv_data) = receive_peer_data(recv).await?;
+    let recv_init_data = bincode::deserialize::<T>(&recv_data)?;
+    send_peer_data::<T>(send, init_type, init_data).await?;
+    Ok(recv_init_data)
+}
+
+async fn update_peer_info<T>(connection: Connection, msg_type: PeerCode, peer_data: T) -> Result<()>
+where
+    T: Serialize + DeserializeOwned,
+{
+    match connection.open_bi().await {
+        Ok((mut send, _)) => {
+            send_peer_data::<T>(&mut send, msg_type, peer_data).await?;
+            Ok(())
+        }
+        Err(_) => {
+            bail!("Failed to send peer data");
+        }
+    }
+}
+
+async fn check_for_duplicate_connections(
+    connection: &Connection,
+    peer_conn: Arc<RwLock<HashMap<String, Connection>>>,
+) -> Result<(String, String)> {
+    let remote_addr = connection.remote_address().ip().to_string();
+    let (_, remote_host_name) = certificate_info(&extract_cert_from_conn(connection)?)?;
+    if peer_conn.read().await.contains_key(&remote_host_name) {
+        connection.close(
+            quinn::VarInt::from_u32(0),
+            "exist connection close".as_bytes(),
+        );
+        bail!("Duplicated connection close:{:?}", remote_host_name);
+    }
+    Ok((remote_addr, remote_host_name))
+}
+
+async fn update_to_new_peer_list(
+    recv_peer_list: HashSet<PeerInfo>,
+    local_address: SocketAddr,
+    peer_list: Arc<RwLock<HashSet<PeerInfo>>>,
+    sender: Sender<PeerInfo>,
+    mut doc: Document,
+    path: &str,
+) -> Result<()> {
+    let mut is_change = false;
+    for recv_peer_info in recv_peer_list {
+        if local_address.ip() != recv_peer_info.address.ip()
+            && !peer_list.read().await.contains(&recv_peer_info)
+        {
+            is_change = true;
+            peer_list.write().await.insert(recv_peer_info.clone());
+            sender.send(recv_peer_info).await?;
+        }
+    }
+
+    if is_change {
+        let data: Vec<PeerInfo> = peer_list.read().await.iter().cloned().collect();
+        if let Err(e) = insert_toml_peers(&mut doc, Some(data)) {
+            error!("{e:?}");
+        }
+        if let Err(e) = write_toml_file(&doc, path) {
+            error!("{e:?}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn update_to_new_source_list(
+    recv_source_list: HashSet<String>,
+    remote_addr: String,
+    peer_sources: Arc<RwLock<HashMap<String, HashSet<String>>>>,
+) {
+    peer_sources
+        .write()
+        .await
+        .insert(remote_addr, recv_source_list);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Peer;
+    use crate::{
+        peer::{receive_peer_data, request_init_info, PeerCode, PeerInfo},
+        to_cert_chain, to_private_key,
+    };
+    use chrono::Utc;
+    use giganto_client::connection::client_handshake;
+    use lazy_static::lazy_static;
+    use quinn::{Connection, Endpoint, RecvStream, SendStream};
+    use std::{
+        collections::{HashMap, HashSet},
+        fs::{self, File},
+        net::{IpAddr, Ipv6Addr, SocketAddr},
+        path::Path,
+        sync::Arc,
+    };
+    use tempfile::TempDir;
+    use tokio::sync::{Mutex, Notify, RwLock};
+
+    lazy_static! {
+        pub(crate) static ref TOKEN: Mutex<u32> = Mutex::new(0);
+    }
+
+    const CERT_PATH: &str = "tests/cert.pem";
+    const KEY_PATH: &str = "tests/key.pem";
+    const CA_CERT_PATH: &str = "tests/root.pem";
+    const HOST: &str = "localhost";
+    const TEST_PORT: u16 = 60191;
+    const PROTOCOL_VERSION: &str = "0.11.0";
+
+    struct TestClient {
+        send: SendStream,
+        recv: RecvStream,
+        conn: Connection,
+    }
+
+    impl TestClient {
+        async fn new() -> Self {
+            let endpoint = init_client();
+            let conn = endpoint
+            .connect(
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PORT),
+                HOST,
+            )
+            .expect(
+                "Failed to connect server's endpoint, Please check if the setting value is correct",
+            )
+            .await
+            .expect("Failed to connect server's endpoint, Please make sure the Server is alive");
+            let (send, recv) = client_handshake(&conn, PROTOCOL_VERSION).await.unwrap();
+            Self { send, recv, conn }
+        }
+    }
+
+    fn init_client() -> Endpoint {
+        let (cert, key) = match fs::read(CERT_PATH)
+            .map(|x| (x, fs::read(KEY_PATH).expect("Failed to Read key file")))
+        {
+            Ok(x) => x,
+            Err(_) => {
+                panic!(
+                "failed to read (cert, key) file, {}, {} read file error. Cert or key doesn't exist in default test folder",
+                CERT_PATH,
+                KEY_PATH,
+            );
+            }
+        };
+
+        let pv_key = if Path::new(KEY_PATH)
+            .extension()
+            .map_or(false, |x| x == "der")
+        {
+            rustls::PrivateKey(key)
+        } else {
+            let pkcs8 = rustls_pemfile::pkcs8_private_keys(&mut &*key)
+                .expect("malformed PKCS #8 private key");
+            match pkcs8.into_iter().next() {
+                Some(x) => rustls::PrivateKey(x),
+                None => {
+                    let rsa = rustls_pemfile::rsa_private_keys(&mut &*key)
+                        .expect("malformed PKCS #1 private key");
+                    match rsa.into_iter().next() {
+                        Some(x) => rustls::PrivateKey(x),
+                        None => {
+                            panic!(
+                            "no private keys found. Private key doesn't exist in default test folder"
+                        );
+                        }
+                    }
+                }
+            }
+        };
+        let cert_chain = if Path::new(CERT_PATH)
+            .extension()
+            .map_or(false, |x| x == "der")
+        {
+            vec![rustls::Certificate(cert)]
+        } else {
+            rustls_pemfile::certs(&mut &*cert)
+                .expect("invalid PEM-encoded certificate")
+                .into_iter()
+                .map(rustls::Certificate)
+                .collect()
+        };
+
+        let mut server_root = rustls::RootCertStore::empty();
+        let file = fs::read(CA_CERT_PATH).expect("Failed to read file");
+        let root_cert: Vec<rustls::Certificate> = rustls_pemfile::certs(&mut &*file)
+            .expect("invalid PEM-encoded certificate")
+            .into_iter()
+            .map(rustls::Certificate)
+            .collect();
+
+        if let Some(cert) = root_cert.get(0) {
+            server_root.add(cert).expect("Failed to add cert");
+        }
+
+        let client_crypto = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(server_root)
+            .with_single_cert(cert_chain, pv_key)
+            .expect("the server root, cert chain or private key are not valid");
+
+        let mut endpoint =
+            quinn::Endpoint::client("[::]:0".parse().expect("Failed to parse Endpoint addr"))
+                .expect("Failed to create endpoint");
+        endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(client_crypto)));
+        endpoint
+    }
+
+    fn peer_init() -> Peer {
+        let cert_pem = fs::read(CERT_PATH).unwrap();
+        let cert = to_cert_chain(&cert_pem).unwrap();
+        let key_pem = fs::read(KEY_PATH).unwrap();
+        let key = to_private_key(&key_pem).unwrap();
+        let ca_cert = fs::read("tests/root.pem").unwrap();
+
+        Peer::new(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PORT),
+            cert,
+            key,
+            vec![ca_cert],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn recv_peer_data() {
+        let _lock = TOKEN.lock().await;
+
+        // peer server's peer list
+        let peer_addr = SocketAddr::new("123.123.123.123".parse::<IpAddr>().unwrap(), TEST_PORT);
+        let peer_name = String::from("einsis_peer");
+        let mut peers = HashSet::new();
+        peers.insert(PeerInfo {
+            address: peer_addr,
+            host_name: peer_name.clone(),
+        });
+
+        // peer server's source list
+        let source_name = String::from("einsis_source");
+        let mut source_info = HashMap::new();
+        source_info.insert(source_name.clone(), Utc::now());
+
+        let sources = Arc::new(RwLock::new(source_info));
+        let peer_sources = Arc::new(RwLock::new(HashMap::new()));
+        let notify_source = Arc::new(Notify::new());
+
+        // create temp config file
+        let tmp_dir = TempDir::new().unwrap();
+        let file_path = tmp_dir.path().join("config.toml");
+        File::create(&file_path).unwrap();
+
+        // run peer
+        tokio::spawn(peer_init().run(
+            peers,
+            sources.clone(),
+            peer_sources,
+            notify_source.clone(),
+            Arc::new(Notify::new()),
+            file_path.to_str().unwrap().to_string(),
+        ));
+
+        // run peer client
+        let mut peer_client_one = TestClient::new().await;
+        let (recv_peer_list, recv_source_list) =
+            request_init_info::<(HashSet<PeerInfo>, HashSet<String>)>(
+                &mut peer_client_one.send,
+                &mut peer_client_one.recv,
+                PeerCode::UpdatePeerList,
+                (HashSet::new(), HashSet::new()),
+            )
+            .await
+            .unwrap();
+
+        // compare server's peer list/source list
+        assert!(recv_peer_list.contains(&PeerInfo {
+            address: peer_addr,
+            host_name: peer_name,
+        }));
+        assert!(recv_source_list.contains(&source_name));
+
+        // insert peer server's source value & notify to server
+        let source_name2 = String::from("einsis_source2");
+        sources
+            .write()
+            .await
+            .insert(source_name2.clone(), Utc::now());
+        notify_source.notify_one();
+
+        // receive source list
+        let (_, mut recv_pub_resp) = peer_client_one
+            .conn
+            .accept_bi()
+            .await
+            .expect("failed to open stream");
+        let (msg_type, msg_buf) = receive_peer_data(&mut recv_pub_resp).await.unwrap();
+        let update_source_list = bincode::deserialize::<HashSet<String>>(&msg_buf).unwrap();
+
+        // compare server's source list
+        assert_eq!(msg_type, PeerCode::UpdateSourceList);
+        assert!(update_source_list.contains(&source_name));
+        assert!(update_source_list.contains(&source_name2));
+    }
+}

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -6,7 +6,8 @@ use self::implement::{RequestRangeMessage, RequestStreamMessage};
 use crate::graphql::TIMESTAMP_SIZE;
 use crate::ingest::{implement::EventFilter, NetworkKey, PacketSources, StreamDirectChannel};
 use crate::server::{
-    certificate_info, config_server, SERVER_CONNNECTION_DELAY, SERVER_ENDPOINT_DELAY,
+    certificate_info, config_server, extract_cert_from_conn, SERVER_CONNNECTION_DELAY,
+    SERVER_ENDPOINT_DELAY,
 };
 use crate::storage::{
     lower_closed_bound_key, upper_open_bound_key, Database, Direction, RawEventStore,
@@ -126,7 +127,7 @@ async fn handle_connection(
             bail!("{e}")
         }
     };
-    let (_, source) = certificate_info(&connection)?;
+    let (_, source) = certificate_info(&extract_cert_from_conn(&connection)?)?;
     tokio::spawn(request_stream(
         connection.clone(),
         db.clone(),

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,12 +1,17 @@
-key = "tests/key.pem"
-cert = "tests/cert.pem"
-roots = ["tests/root.pem"]
+key = "key.pem"
+cert = "cert.pem"
+roots = ["ca1.pem", "ca2.pem", "ca3.pem"]
 ingest_address = "0.0.0.0:38370"
 publish_address = "0.0.0.0:38371"
 graphql_address = "127.0.0.1:8443"
 data_dir = "tests/data"
-retention = "10000d"
-log_dir = "tests/logs/apps"
+retention = "100d"
+log_dir = "/data/logs/apps"
 export_dir = "tests/export"
 max_open_files = 8000
 max_mb_of_level_base = 512
+peer_address= "100.101.102.1:38383"
+peers=[
+	{ address = "100.101.102.2:38383", host_name = "einsis1"},
+	{ address = "100.101.102.3:38383", host_name = "einsis2"},
+]


### PR DESCRIPTION
- Add giganto's peers options to config file.
- Accepts QUIC connections from giganto's peers.
- Add the capability to exchange source and peer address lists between peers of the giganto.
- Change giganto's execution command.

Closes: #324 , #325