### PR TITLE
Modify the processing part of REconverge's data request and release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2023-06-20
 
 ### Added
 
@@ -17,6 +17,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Supports the expanded HTTP protocol.
 - Modify `proto` field of `Ftp`, `Mqtt`, `Ldap` to u8 from u16.
+- Supports the LDAP protocol.
+- Modify the processing part of REconverge's data request.
+  - Modify to handle network, log, and time series data requests with `ReqRange`
+    and `RequestRange`.
+  - Add to handle `Timeseries` requests in `MessageCode::RawData`.
+  - Modify `multi_get_with_source` to return in the form of
+    `Vec<(i64, String, Vec<u8>)>`.
 
 ## [0.11.0] - 2023-05-16
 
@@ -191,7 +198,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
-[Unreleased]: https://github.com/aicers/giganto/compare/0.11.0...main
+[0.12.0]: https://github.com/aicers/giganto/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/aicers/giganto/compare/0.10.2...0.11.0
 [0.10.2]: https://github.com/aicers/giganto/compare/0.10.1...0.10.2
 [0.10.1]: https://github.com/aicers/giganto/compare/0.10.0...0.10.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -811,8 +811,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.8.0"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.8.0#8af8e8a1493a925d224799532145198404745b0c"
+version = "0.9.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.9.0#2f0ac47373d4864ebb3ef2804263b7d023eb0dec"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1483,9 +1483,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
 dependencies = [
  "once_cell",
  "pest",
@@ -1662,9 +1662,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
+checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
 dependencies = [
  "proc-macro2 1.0.60",
  "syn 2.0.18",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
  "proc-macro2 1.0.60",
  "quote 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]
@@ -15,7 +15,7 @@ ctrlc = { version = "3", features = ["termination"] }
 data-encoding = "2.4"
 directories = "5.0"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.8.0" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.9.0" }
 humantime = "2.1"
 humantime-serde = "1"
 libc = "0.2"

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -49,7 +49,7 @@ const CHANNEL_CLOSE_MESSAGE: &[u8; 12] = b"channel done";
 const CHANNEL_CLOSE_TIMESTAMP: i64 = -1;
 const NO_TIMESTAMP: i64 = 0;
 const SOURCE_INTERVAL: u64 = 60 * 60 * 24;
-const INGEST_VERSION_REQ: &str = ">=0.11.0,<0.12.0-alpha";
+const INGEST_VERSION_REQ: &str = ">=0.12.0,<0.13.0";
 
 type SourceInfo = (String, DateTime<Utc>, ConnState, bool);
 pub type PacketSources = Arc<RwLock<HashMap<String, Connection>>>;

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -40,7 +40,7 @@ const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/root.pem";
 const HOST: &str = "localhost";
 const TEST_PORT: u16 = 60190;
-const PROTOCOL_VERSION: &str = "0.11.0";
+const PROTOCOL_VERSION: &str = "0.12.0";
 
 struct TestClient {
     conn: Connection,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -37,7 +37,7 @@ use tokio::{
 use toml_edit::Document;
 use tracing::{error, info, warn};
 
-const PEER_VERSION_REQ: &str = "0.11.0";
+const PEER_VERSION_REQ: &str = ">=0.12.0,<0.13.0";
 const PEER_RETRY_INTERVAL: u64 = 5;
 
 pub type PeerSources = Arc<RwLock<HashMap<String, HashSet<String>>>>;
@@ -707,7 +707,7 @@ mod tests {
     const CA_CERT_PATH: &str = "tests/root.pem";
     const HOST: &str = "localhost";
     const TEST_PORT: u16 = 60191;
-    const PROTOCOL_VERSION: &str = "0.11.0";
+    const PROTOCOL_VERSION: &str = "0.12.0";
 
     struct TestClient {
         send: SendStream,

--- a/src/publish/implement.rs
+++ b/src/publish/implement.rs
@@ -1,8 +1,5 @@
 use anyhow::{bail, Result};
-use giganto_client::publish::{
-    range::{RequestRange, RequestTimeSeriesRange},
-    stream::{NodeType, RequestCrusherStream, RequestHogStream},
-};
+use giganto_client::publish::stream::{NodeType, RequestCrusherStream, RequestHogStream};
 use std::{net::IpAddr, vec};
 
 pub trait RequestStreamMessage {
@@ -109,49 +106,5 @@ impl RequestStreamMessage for RequestCrusherStream {
 
     fn source_id(&self) -> Option<String> {
         Some(self.id.clone())
-    }
-}
-
-pub trait RequestRangeMessage {
-    fn source(&self) -> &str;
-    fn kind(&self) -> &str;
-    fn start(&self) -> i64;
-    fn end(&self) -> i64;
-    fn count(&self) -> usize;
-}
-
-impl RequestRangeMessage for RequestRange {
-    fn source(&self) -> &str {
-        &self.source
-    }
-    fn kind(&self) -> &str {
-        &self.kind
-    }
-    fn start(&self) -> i64 {
-        self.start
-    }
-    fn end(&self) -> i64 {
-        self.end
-    }
-    fn count(&self) -> usize {
-        self.count
-    }
-}
-
-impl RequestRangeMessage for RequestTimeSeriesRange {
-    fn source(&self) -> &str {
-        &self.source
-    }
-    fn kind(&self) -> &str {
-        ""
-    }
-    fn start(&self) -> i64 {
-        self.start
-    }
-    fn end(&self) -> i64 {
-        self.end
-    }
-    fn count(&self) -> usize {
-        self.count
     }
 }

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -13,9 +13,7 @@ use giganto_client::{
         timeseries::PeriodicTimeSeries,
     },
     publish::{
-        range::{
-            MessageCode, RequestRange, RequestRawData, RequestTimeSeriesRange, ResponseRangeData,
-        },
+        range::{MessageCode, RequestRange, RequestRawData, ResponseRangeData},
         receive_crusher_data, receive_crusher_stream_start_message, receive_hog_data,
         receive_hog_stream_start_message, receive_range_data, receive_raw_events,
         send_range_data_request, send_stream_request,
@@ -44,7 +42,7 @@ const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/root.pem";
 const HOST: &str = "localhost";
 const TEST_PORT: u16 = 60191;
-const PROTOCOL_VERSION: &str = "0.11.0";
+const PROTOCOL_VERSION: &str = "0.12.0";
 
 struct TestClient {
     send: SendStream,
@@ -573,7 +571,7 @@ fn insert_ldap_raw_event(store: &RawEventStore<Ldap>, source: &str, timestamp: i
 
 #[tokio::test]
 async fn request_range_data_with_protocol() {
-    const PUBLISH_LOG_MESSAGE_CODE: MessageCode = MessageCode::Log;
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SOURCE: &str = "einsis";
     const CONN_KIND: &str = "conn";
     const DNS_KIND: &str = "dns";
@@ -636,7 +634,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -697,7 +695,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -761,7 +759,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -822,7 +820,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -886,7 +884,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -950,7 +948,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1013,7 +1011,7 @@ async fn request_range_data_with_protocol() {
             end: end.timestamp_nanos(),
             count: 5,
         };
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1076,7 +1074,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1140,7 +1138,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1203,7 +1201,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1267,7 +1265,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1331,7 +1329,7 @@ async fn request_range_data_with_protocol() {
             count: 5,
         };
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
             .await
             .unwrap();
 
@@ -1366,7 +1364,7 @@ async fn request_range_data_with_protocol() {
 
 #[tokio::test]
 async fn request_range_data_with_log() {
-    const PUBLISH_LOG_MESSAGE_CODE: MessageCode = MessageCode::Log;
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SOURCE: &str = "einsis";
     const KIND: &str = "Hello";
 
@@ -1426,7 +1424,7 @@ async fn request_range_data_with_log() {
         count: 5,
     };
 
-    send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
         .await
         .unwrap();
 
@@ -1457,8 +1455,9 @@ async fn request_range_data_with_log() {
 
 #[tokio::test]
 async fn request_range_data_with_period_time_series() {
-    const PUBLISH_LOG_MESSAGE_CODE: MessageCode = MessageCode::PeriodicTimeSeries;
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SAMPLING_POLICY_ID: &str = "policy_one";
+    const KIND: &str = "timeseries";
 
     let _lock = TOKEN.lock().await;
     let db_dir = tempfile::tempdir().unwrap();
@@ -1499,14 +1498,15 @@ async fn request_range_data_with_period_time_series() {
             .expect("valid time"),
         Utc,
     );
-    let message = RequestTimeSeriesRange {
+    let message = RequestRange {
         source: String::from(SAMPLING_POLICY_ID),
+        kind: String::from(KIND),
         start: start.timestamp_nanos(),
         end: end.timestamp_nanos(),
         count: 5,
     };
 
-    send_range_data_request(&mut send_pub_req, PUBLISH_LOG_MESSAGE_CODE, message)
+    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
         .await
         .unwrap();
 
@@ -2893,6 +2893,7 @@ async fn request_raw_events() {
     const PUBLISH_RAW_DATA_MESSAGE_CODE: MessageCode = MessageCode::RawData;
     const SOURCE: &str = "src 1";
     const KIND: &str = "conn";
+    const TIMESTAMP: i64 = 100;
 
     let _lock = TOKEN.lock().await;
     let db_dir = tempfile::tempdir().unwrap();
@@ -2911,12 +2912,12 @@ async fn request_raw_events() {
         publish.conn.open_bi().await.expect("failed to open stream");
 
     let conn_store = db.conn_store().unwrap();
-    let send_conn_time = 1;
+    let send_conn_time = TIMESTAMP;
     let conn_raw_data = insert_conn_raw_event(&conn_store, SOURCE, send_conn_time);
 
     let message = RequestRawData {
         kind: String::from(KIND),
-        input: vec![(String::from(SOURCE), vec![1])],
+        input: vec![(String::from(SOURCE), vec![TIMESTAMP])],
     };
 
     send_range_data_request(&mut send_pub_req, PUBLISH_RAW_DATA_MESSAGE_CODE, message)
@@ -2925,6 +2926,7 @@ async fn request_raw_events() {
 
     let resp_data = receive_raw_events(&mut recv_pub_resp).await.unwrap();
 
-    assert_eq!(&resp_data[0].0, "src 1");
-    assert_eq!(resp_data[0].1, conn_raw_data);
+    assert_eq!(resp_data[0].0, TIMESTAMP);
+    assert_eq!(&resp_data[0].1, "src 1");
+    assert_eq!(resp_data[0].2, conn_raw_data);
 }

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -7,7 +7,7 @@ use std::{
     path::Path,
 };
 
-const COMPATIBLE_VERSION_REQ: &str = ">=0.10.0,<0.12.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.10.0,<0.13.0-alpha";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -81,7 +81,7 @@ mod tests {
         let breaking = {
             let mut breaking = current.clone();
             if breaking.major == 0 {
-                breaking.minor -= 2;
+                breaking.minor -= 3;
             } else {
                 breaking.major -= 1;
             }


### PR DESCRIPTION
- Modify to handle network, log, and time series data requests with `ReqRange` and `RequestRange`.
- Add to handle `Timeseries` requests in `MessageCode::RawData`.
- Modify `multi_get_with_source` to return in the form of `Vec<(i64, String, Vec<u8>)>`.
- Bump version to 0.12.0

Closes: #435
Related issue: https://github.com/aicers/giganto-client/issues/32