### PR TITLE
Add `tls` protocol and migration features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Supports the TLS protocol.
+- Added migration functionality in `0.12.0`. This feature adds values for new fields
+  (`orig_filenames`, `orig_mime_types`, `resp_filenames`, `resp_mime_types`) to
+  `http raw event` in versions 0.12.0 and earlier.
+
 ## [0.12.0] - 2023-06-20
 
 ### Added
@@ -17,7 +26,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Supports the expanded HTTP protocol.
 - Modify `proto` field of `Ftp`, `Mqtt`, `Ldap` to u8 from u16.
-- Supports the LDAP protocol.
 - Modify the processing part of REconverge's data request.
   - Modify to handle network, log, and time series data requests with `ReqRange`
     and `RequestRange`.
@@ -198,6 +206,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.12.0...main
 [0.12.0]: https://github.com/aicers/giganto/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/aicers/giganto/compare/0.10.2...0.11.0
 [0.10.2]: https://github.com/aicers/giganto/compare/0.10.1...0.10.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,8 +811,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.9.0"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.9.0#2f0ac47373d4864ebb3ef2804263b7d023eb0dec"
+version = "0.10.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.10.0#4eb962872a9d7b0e8832d78f51d57ee0bc410dbf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1483,9 +1483,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -1662,9 +1662,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2 1.0.60",
  "syn 2.0.18",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.60",
  "quote 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ctrlc = { version = "3", features = ["termination"] }
 data-encoding = "2.4"
 directories = "5.0"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.9.0" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.10.0" }
 humantime = "2.1"
 humantime-serde = "1"
 libc = "0.2"

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -451,6 +451,19 @@ async fn handle_request(
             )
             .await?;
         }
+        RecordType::Tls => {
+            handle_data(
+                send,
+                recv,
+                RecordType::Tls,
+                Some(NetworkKey::new(&source, "tls")),
+                source,
+                db.tls_store()?,
+                stream_direct_channel,
+                shutdown_signal,
+            )
+            .await?;
+        }
         _ => {
             error!("The record type message could not be processed.");
         }

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use giganto_client::ingest::{
     log::{Log, OpLogLevel, Oplog},
-    network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Ntlm, Rdp, Smtp, Ssh},
+    network::{Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Ntlm, Rdp, Smtp, Ssh, Tls},
     timeseries::PeriodicTimeSeries,
     Packet,
 };
@@ -348,6 +348,27 @@ impl EventFilter for Mqtt {
 }
 
 impl EventFilter for Ldap {
+    fn orig_addr(&self) -> Option<IpAddr> {
+        Some(self.orig_addr)
+    }
+    fn resp_addr(&self) -> Option<IpAddr> {
+        Some(self.resp_addr)
+    }
+    fn orig_port(&self) -> Option<u16> {
+        Some(self.orig_port)
+    }
+    fn resp_port(&self) -> Option<u16> {
+        Some(self.resp_port)
+    }
+    fn log_level(&self) -> Option<String> {
+        None
+    }
+    fn log_contents(&self) -> Option<String> {
+        None
+    }
+}
+
+impl EventFilter for Tls {
     fn orig_addr(&self) -> Option<IpAddr> {
         Some(self.orig_addr)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
         files.push(file);
     }
 
-    if let Err(e) = migrate_data_dir(&settings.data_dir) {
+    if let Err(e) = migrate_data_dir(&settings.data_dir, &database) {
         error!("migration failed: {e}");
         return Ok(());
     }

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1,13 +1,18 @@
 //! Routines to check the database format version and migrate it if necessary.
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
 use std::{
     fs::{create_dir_all, File},
     io::{Read, Write},
+    net::IpAddr,
     path::Path,
 };
+use tracing::info;
 
-const COMPATIBLE_VERSION_REQ: &str = ">=0.10.0,<0.13.0-alpha";
+use super::Database;
+
+const COMPATIBLE_VERSION_REQ: &str = ">=0.12.0,<0.13.0-alpha";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -15,15 +20,32 @@ const COMPATIBLE_VERSION_REQ: &str = ">=0.10.0,<0.13.0-alpha";
 ///
 /// Returns an error if the data directory doesn't exist and cannot be created,
 /// or if the data directory exists but is in the format too old to be upgraded.
-pub fn migrate_data_dir(data_dir: &Path) -> Result<()> {
+pub fn migrate_data_dir(data_dir: &Path, db: &Database) -> Result<()> {
     let compatible = VersionReq::parse(COMPATIBLE_VERSION_REQ).expect("valid version requirement");
-    let data_ver = retrieve_or_create_version(data_dir)?;
-    if compatible.matches(&data_ver) {
+    let mut version = retrieve_or_create_version(data_dir)?;
+    if compatible.matches(&version) {
         return Ok(());
     }
 
-    // TODO: Handling migration based on version.
-    bail!("Incompatible DB version");
+    let migration: Vec<(_, _, fn(_) -> Result<_, _>)> = vec![(
+        VersionReq::parse(">=0.10.0,<0.12.0").expect("valid version requirement"),
+        Version::parse("0.12.0").expect("valid version"),
+        migrate_0_10_to_0_12,
+    )];
+
+    while let Some((_req, to, m)) = migration
+        .iter()
+        .find(|(req, _to, _m)| req.matches(&version))
+    {
+        info!("Migrating database to {to}");
+        m(db)?;
+        version = to.clone();
+        if compatible.matches(&version) {
+            return create_version_file(&data_dir.join("VERSION"))
+                .context("failed to update VERSION");
+        }
+    }
+    Err(anyhow!("migration from {version} is not supported",))
 }
 
 fn retrieve_or_create_version(path: &Path) -> Result<Version> {
@@ -64,10 +86,120 @@ fn read_version_file(path: &Path) -> Result<Version> {
     Version::parse(&ver).context("cannot parse VERSION")
 }
 
+#[allow(clippy::too_many_lines)]
+fn migrate_0_10_to_0_12(db: &Database) -> Result<()> {
+    #[derive(Deserialize, Serialize)]
+    pub struct OldHttp {
+        pub orig_addr: IpAddr,
+        pub orig_port: u16,
+        pub resp_addr: IpAddr,
+        pub resp_port: u16,
+        pub proto: u8,
+        pub last_time: i64,
+        pub method: String,
+        pub host: String,
+        pub uri: String,
+        pub referrer: String,
+        pub version: String,
+        pub user_agent: String,
+        pub request_len: usize,
+        pub response_len: usize,
+        pub status_code: u16,
+        pub status_msg: String,
+        pub username: String,
+        pub password: String,
+        pub cookie: String,
+        pub content_encoding: String,
+        pub content_type: String,
+        pub cache_control: String,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    pub struct NewHttp {
+        pub orig_addr: IpAddr,
+        pub orig_port: u16,
+        pub resp_addr: IpAddr,
+        pub resp_port: u16,
+        pub proto: u8,
+        pub last_time: i64,
+        pub method: String,
+        pub host: String,
+        pub uri: String,
+        pub referrer: String,
+        pub version: String,
+        pub user_agent: String,
+        pub request_len: usize,
+        pub response_len: usize,
+        pub status_code: u16,
+        pub status_msg: String,
+        pub username: String,
+        pub password: String,
+        pub cookie: String,
+        pub content_encoding: String,
+        pub content_type: String,
+        pub cache_control: String,
+        pub orig_filenames: Vec<String>,
+        pub orig_mime_types: Vec<String>,
+        pub resp_filenames: Vec<String>,
+        pub resp_mime_types: Vec<String>,
+    }
+
+    impl From<OldHttp> for NewHttp {
+        fn from(input: OldHttp) -> Self {
+            Self {
+                orig_addr: input.orig_addr,
+                orig_port: input.orig_port,
+                resp_addr: input.resp_addr,
+                resp_port: input.resp_port,
+                proto: input.proto,
+                last_time: input.last_time,
+                method: input.method,
+                host: input.host,
+                uri: input.uri,
+                referrer: input.referrer,
+                version: input.version,
+                user_agent: input.user_agent,
+                request_len: input.request_len,
+                response_len: input.response_len,
+                status_code: input.status_code,
+                status_msg: input.status_msg,
+                username: input.username,
+                password: input.password,
+                cookie: input.cookie,
+                content_encoding: input.content_encoding,
+                content_type: input.content_type,
+                cache_control: input.cache_control,
+                orig_filenames: vec!["-".to_string()],
+                orig_mime_types: vec!["-".to_string()],
+                resp_filenames: vec!["-".to_string()],
+                resp_mime_types: vec!["-".to_string()],
+            }
+        }
+    }
+
+    let store = db.http_store()?;
+    for raw_event in store.iter_forward() {
+        let (key, val) = raw_event.context("Failed to read Database")?;
+        let old = bincode::deserialize::<OldHttp>(&val)?;
+        let convert_new: NewHttp = old.into();
+        let new = bincode::serialize(&convert_new)?;
+        store.append(&key, &new)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
+
+    use crate::storage::{Database, DbOptions};
+
     use super::COMPATIBLE_VERSION_REQ;
+    use chrono::Utc;
+    use giganto_client::ingest::network::Http;
     use semver::{Version, VersionReq};
+    use serde::{Deserialize, Serialize};
 
     #[test]
     fn version() {
@@ -88,5 +220,120 @@ mod tests {
             breaking
         };
         assert!(!compatible.matches(&breaking));
+    }
+
+    #[test]
+    fn migrate_0_10_to_0_12() {
+        #[derive(Deserialize, Serialize)]
+        pub struct OldHttp {
+            pub orig_addr: IpAddr,
+            pub orig_port: u16,
+            pub resp_addr: IpAddr,
+            pub resp_port: u16,
+            pub proto: u8,
+            pub last_time: i64,
+            pub method: String,
+            pub host: String,
+            pub uri: String,
+            pub referrer: String,
+            pub version: String,
+            pub user_agent: String,
+            pub request_len: usize,
+            pub response_len: usize,
+            pub status_code: u16,
+            pub status_msg: String,
+            pub username: String,
+            pub password: String,
+            pub cookie: String,
+            pub content_encoding: String,
+            pub content_type: String,
+            pub cache_control: String,
+        }
+
+        // open temp db & store
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
+        let store = db.http_store().unwrap();
+
+        // insert old http raw data
+        let timestamp = Utc::now().timestamp_nanos();
+        let source = "src1";
+        let mut key = Vec::with_capacity(source.len() + 1 + std::mem::size_of::<i64>());
+        key.extend_from_slice(source.as_bytes());
+        key.push(0);
+        key.extend(timestamp.to_be_bytes());
+
+        let old_http = OldHttp {
+            orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            orig_port: 46378,
+            resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            resp_port: 80,
+            proto: 17,
+            last_time: 1,
+            method: "POST".to_string(),
+            host: "einsis".to_string(),
+            uri: "/einsis.gif".to_string(),
+            referrer: "einsis.com".to_string(),
+            version: String::new(),
+            user_agent: "giganto".to_string(),
+            request_len: 0,
+            response_len: 0,
+            status_code: 200,
+            status_msg: String::new(),
+            username: String::new(),
+            password: String::new(),
+            cookie: String::new(),
+            content_encoding: String::new(),
+            content_type: String::new(),
+            cache_control: String::new(),
+        };
+        let ser_old_http = bincode::serialize(&old_http).unwrap();
+
+        store.append(&key, &ser_old_http).unwrap();
+
+        //migration 0.10.0 to 0.12.0
+        super::migrate_0_10_to_0_12(&db).unwrap();
+
+        //check migration
+        let start_key = key;
+        let mut end_key = Vec::with_capacity(source.len() + 1 + std::mem::size_of::<i64>());
+        end_key.extend_from_slice(source.as_bytes());
+        end_key.push(0);
+        end_key.extend((timestamp + 1).to_be_bytes());
+
+        let mut result_iter =
+            store.boundary_iter(&start_key, &end_key, rocksdb::Direction::Forward);
+
+        let new_http = Http {
+            orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            orig_port: 46378,
+            resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            resp_port: 80,
+            proto: 17,
+            last_time: 1,
+            method: "POST".to_string(),
+            host: "einsis".to_string(),
+            uri: "/einsis.gif".to_string(),
+            referrer: "einsis.com".to_string(),
+            version: String::new(),
+            user_agent: "giganto".to_string(),
+            request_len: 0,
+            response_len: 0,
+            status_code: 200,
+            status_msg: String::new(),
+            username: String::new(),
+            password: String::new(),
+            cookie: String::new(),
+            content_encoding: String::new(),
+            content_type: String::new(),
+            cache_control: String::new(),
+            orig_filenames: vec!["-".to_string()],
+            orig_mime_types: vec!["-".to_string()],
+            resp_filenames: vec!["-".to_string()],
+            resp_mime_types: vec!["-".to_string()],
+        };
+
+        let (_, value) = result_iter.next().unwrap().unwrap();
+        assert_eq!(new_http, value);
     }
 }


### PR DESCRIPTION
- Supports the TLS protocol.
- Supports migration to versions 0.12.0 and earlier.

Closes: #437, #439