### PR TITLE
Change key for sysmon events to source+timestamp like other protocol …

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -353,7 +353,7 @@ where
     (records, has_more)
 }
 
-pub fn get_timestamp(key: &[u8]) -> Result<DateTime<Utc>, anyhow::Error> {
+pub fn get_timestamp_from_key(key: &[u8]) -> Result<DateTime<Utc>, anyhow::Error> {
     if key.len() > TIMESTAMP_SIZE {
         let nanos = i64::from_be_bytes(key[(key.len() - TIMESTAMP_SIZE)..].try_into()?);
         return Ok(Utc.timestamp_nanos(nanos));

--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -1,4 +1,4 @@
-use super::{base64_engine, get_timestamp, load_connection, Engine, FromKeyValue};
+use super::{base64_engine, get_timestamp_from_key, load_connection, Engine, FromKeyValue};
 use crate::{
     graphql::{RawEventFilter, TimeRange},
     storage::{Database, KeyExtractor},
@@ -127,7 +127,7 @@ struct LogRawEvent {
 impl FromKeyValue<Log> for LogRawEvent {
     fn from_key_value(key: &[u8], l: Log) -> Result<Self> {
         Ok(LogRawEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             log: base64_engine.encode(l.log),
         })
     }
@@ -143,7 +143,7 @@ struct OpLogRawEvent {
 impl FromKeyValue<Oplog> for OpLogRawEvent {
     fn from_key_value(key: &[u8], l: Oplog) -> Result<Self> {
         Ok(OpLogRawEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             level: format!("{:?}", l.log_level),
             contents: l.contents,
         })

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unused_async)]
 use super::{
     base64_engine, check_address, check_port, collect_exist_timestamp, get_filtered_iter,
-    get_timestamp, load_connection, Engine, FromKeyValue,
+    get_timestamp_from_key, load_connection, Engine, FromKeyValue,
 };
 use crate::{
     graphql::{RawEventFilter, TimeRange},
@@ -458,7 +458,7 @@ macro_rules! from_key_value {
     ($to:ty, $from:ty, $($fields:ident),*) => {
         impl FromKeyValue<$from> for $to {
             fn from_key_value(key: &[u8], val: $from) -> Result<Self> {
-                let timestamp = get_timestamp(key)?;
+                let timestamp = get_timestamp_from_key(key)?;
                 Ok(Self {
                     timestamp,
                     orig_addr: val.orig_addr.to_string(),
@@ -479,7 +479,7 @@ macro_rules! from_key_value {
 impl FromKeyValue<Conn> for ConnRawEvent {
     fn from_key_value(key: &[u8], val: Conn) -> Result<Self> {
         Ok(ConnRawEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             orig_addr: val.orig_addr.to_string(),
             resp_addr: val.resp_addr.to_string(),
             orig_port: val.orig_port,
@@ -498,7 +498,7 @@ impl FromKeyValue<Conn> for ConnRawEvent {
 impl FromKeyValue<Ftp> for FtpRawEvent {
     fn from_key_value(key: &[u8], val: Ftp) -> Result<Self> {
         Ok(FtpRawEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             orig_addr: val.orig_addr.to_string(),
             resp_addr: val.resp_addr.to_string(),
             orig_port: val.orig_port,
@@ -1498,85 +1498,85 @@ fn network_connection(
 
     loop {
         let conn_ts = if let Some((ref key, _)) = conn_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let dns_ts = if let Some((ref key, _)) = dns_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let http_ts = if let Some((ref key, _)) = http_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let rdp_ts = if let Some((ref key, _)) = rdp_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let ntlm_ts = if let Some((ref key, _)) = ntlm_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let kerberos_ts = if let Some((ref key, _)) = kerberos_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let ssh_ts = if let Some((ref key, _)) = ssh_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let dce_rpc_ts = if let Some((ref key, _)) = dce_rpc_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let ftp_ts = if let Some((ref key, _)) = ftp_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let mqtt_ts = if let Some((ref key, _)) = mqtt_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let ldap_ts = if let Some((ref key, _)) = ldap_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let tls_ts = if let Some((ref key, _)) = tls_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let smb_ts = if let Some((ref key, _)) = smb_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };
 
         let nfs_ts = if let Some((ref key, _)) = nfs_data {
-            get_timestamp(key)?
+            get_timestamp_from_key(key)?
         } else {
             min_max_time(is_forward)
         };

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -1,6 +1,6 @@
 use super::{
-    collect_records, get_timestamp, load_connection, write_run_tcpdump, Direction, FromKeyValue,
-    RawEventFilter, TimeRange, TIMESTAMP_SIZE,
+    collect_records, get_timestamp_from_key, load_connection, write_run_tcpdump, Direction,
+    FromKeyValue, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
 };
 use crate::storage::{Database, KeyExtractor, StorageKey};
 use async_graphql::{
@@ -72,8 +72,8 @@ struct Pcap {
 impl FromKeyValue<pk> for Packet {
     fn from_key_value(key: &[u8], pk: pk) -> Result<Self> {
         Ok(Packet {
-            request_time: get_timestamp(&key[..key.len() - (TIMESTAMP_SIZE + 1)])?,
-            packet_time: get_timestamp(key)?,
+            request_time: get_timestamp_from_key(&key[..key.len() - (TIMESTAMP_SIZE + 1)])?,
+            packet_time: get_timestamp_from_key(key)?,
             packet: BASE64.encode(&pk.packet),
         })
     }

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -1,4 +1,4 @@
-use super::{get_timestamp, load_connection, FromKeyValue, RawEventFilter};
+use super::{get_timestamp_from_key, load_connection, FromKeyValue, RawEventFilter};
 use crate::{
     graphql::TimeRange,
     storage::{Database, KeyExtractor},
@@ -73,7 +73,7 @@ impl FromKeyValue<Statistics> for StatisticsRawEvent {
             .map(|(rt, cnt, size)| format!("{rt:?}/{size}/{cnt}"))
             .collect::<Vec<_>>();
         Ok(StatisticsRawEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             core: val.core,
             period: val.period,
             stats,

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -1,4 +1,4 @@
-use super::{get_timestamp, load_connection, FromKeyValue, RawEventFilter, TimeRange};
+use super::{get_timestamp_from_key, load_connection, FromKeyValue, RawEventFilter, TimeRange};
 use crate::storage::{Database, KeyExtractor};
 use async_graphql::{
     connection::{query, Connection},
@@ -263,7 +263,7 @@ macro_rules! from_key_value {
     ($to:ty, $from:ty, $($fields:ident),*) => {
         impl FromKeyValue<$from> for $to {
             fn from_key_value(key: &[u8], val: $from) -> Result<Self> {
-                let timestamp = get_timestamp(key)?;
+                let timestamp = get_timestamp_from_key(key)?;
                 Ok(Self {
                     timestamp,
                     process_guid: val.process_guid,
@@ -421,7 +421,7 @@ from_key_value!(
 impl FromKeyValue<NetworkConnection> for NetworkConnectionEvent {
     fn from_key_value(key: &[u8], value: NetworkConnection) -> Result<Self> {
         Ok(NetworkConnectionEvent {
-            timestamp: get_timestamp(key)?,
+            timestamp: get_timestamp_from_key(key)?,
             process_guid: value.process_guid,
             process_id: value.process_id,
             image: value.image,

--- a/src/graphql/timeseries.rs
+++ b/src/graphql/timeseries.rs
@@ -1,4 +1,4 @@
-use super::{get_timestamp, load_connection, FromKeyValue};
+use super::{get_timestamp_from_key, load_connection, FromKeyValue};
 use crate::{
     graphql::{RawEventFilter, TimeRange},
     storage::{Database, KeyExtractor},
@@ -65,7 +65,7 @@ struct TimeSeries {
 impl FromKeyValue<PeriodicTimeSeries> for TimeSeries {
     fn from_key_value(key: &[u8], p: PeriodicTimeSeries) -> Result<Self> {
         Ok(TimeSeries {
-            start: get_timestamp(key)?,
+            start: get_timestamp_from_key(key)?,
             id: p.id,
             data: p.data,
         })


### PR DESCRIPTION
Close: #502 
Change key for `sysmon` events to `source + timestamp` like other protocol events.

The inserted value `agent_name, agent_id` in the middle of key make it difficult to filter the events for GraphQL Query.