### PR TITLE
generate benchmark statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     provided for `all protocol`.
   - If filter has no value for the time field, it will provide the most `recent`
     statistics.
+- Add feature to generate benchmark statistics for ingest events.
 
 ## [0.13.0] - 2023-08-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 
 [dependencies]
@@ -41,3 +41,7 @@ x509-parser = "0.15"
 tempfile = "3"
 url = "2"
 regex = "1"
+
+[features]
+default = ["benchmark"]
+benchmark = []


### PR DESCRIPTION
Add benchmark statistics data to measure the hardware availability that Giganto runs.
