### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2023-11-08
+
+### Changed
+
+- Updated giganto-client to 0.15.0
+- Changed minimum/maximum version to 0.15.0 <= version < 0.16.0
+
 ## [0.14.0] - 2023-11-07
 
 ### Added
@@ -305,6 +312,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[0.15.0]: https://github.com/aicers/giganto/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/aicers/giganto/compare/0.13.1...0.14.0
 [0.13.1]: https://github.com/aicers/giganto/compare/0.13.0...0.13.1
 [0.13.0]: https://github.com/aicers/giganto/compare/0.12.3...0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
+checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
  "rand",
@@ -1987,7 +1987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
- "errno 0.3.5",
+ "errno 0.3.6",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -2110,18 +2110,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.191"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a834c4821019838224821468552240d4d95d14e751986442c816572d39a080c9"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.191"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fa52d5646bce91b680189fe5b1c049d2ea38dabb4e2e7c8d00ca12cfbfbcfd"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -53,7 +53,7 @@ const CHANNEL_CLOSE_MESSAGE: &[u8; 12] = b"channel done";
 const CHANNEL_CLOSE_TIMESTAMP: i64 = -1;
 const NO_TIMESTAMP: i64 = 0;
 const SOURCE_INTERVAL: u64 = 60 * 60 * 24;
-const INGEST_VERSION_REQ: &str = ">=0.13.1,<0.15.0";
+const INGEST_VERSION_REQ: &str = ">=0.15.0,<0.16.0";
 
 type SourceInfo = (String, DateTime<Utc>, ConnState, bool);
 pub type PacketSources = Arc<RwLock<HashMap<String, Connection>>>;

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -45,7 +45,7 @@ const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/root.pem";
 const HOST: &str = "localhost";
 const TEST_PORT: u16 = 60190;
-const PROTOCOL_VERSION: &str = "0.14.0";
+const PROTOCOL_VERSION: &str = "0.15.0";
 
 struct TestClient {
     conn: Connection,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -37,7 +37,7 @@ use tokio::{
 use toml_edit::Document;
 use tracing::{error, info, warn};
 
-const PEER_VERSION_REQ: &str = ">=0.12.0,<0.15.0";
+const PEER_VERSION_REQ: &str = ">=0.12.0,<0.16.0";
 const PEER_RETRY_INTERVAL: u64 = 5;
 
 pub type PeerSources = Arc<RwLock<HashMap<String, HashSet<String>>>>;

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -37,7 +37,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-const PUBLISH_VERSION_REQ: &str = ">=0.13.1,<0.15.0";
+const PUBLISH_VERSION_REQ: &str = ">=0.15.0,<0.16.0";
 
 pub struct Server {
     server_config: ServerConfig,

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -45,7 +45,7 @@ const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/root.pem";
 const HOST: &str = "localhost";
 const TEST_PORT: u16 = 60191;
-const PROTOCOL_VERSION: &str = "0.14.0";
+const PROTOCOL_VERSION: &str = "0.15.0";
 
 struct TestClient {
     send: SendStream,

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use tracing::info;
 
-const COMPATIBLE_VERSION_REQ: &str = ">0.13.0-alpha,<0.15.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">0.13.0-alpha,<0.16.0-alpha";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///


### PR DESCRIPTION
# Summary 
giganto-client 디펜던시를 0.15.0 으로 올리면서 하위호환성이 깨지므로, 버전업을 수행합니다. 다음 사항이 핵심입니다.
- 0.15.0으로 버전 업데이트 합니다.
- min/max version을 수정합니다.