### PR TITLE
Change MessageCode::RawData request processing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Change `MessageCode::RawData` request processing code to send raw events
+  to REconverge in the same format as `MessageCode::RangeData`.
+
 ## [0.15.1] - 2023-11-08
 
 ### Changed
@@ -318,25 +325,26 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
-[0.15.1]: https://github.com/aicers/giganto/compare/0.15.0...0.15.1
-[0.15.0]: https://github.com/aicers/giganto/compare/0.14.0...0.15.0
-[0.14.0]: https://github.com/aicers/giganto/compare/0.13.1...0.14.0
-[0.13.1]: https://github.com/aicers/giganto/compare/0.13.0...0.13.1
-[0.13.0]: https://github.com/aicers/giganto/compare/0.12.3...0.13.0
-[0.12.3]: https://github.com/aicers/giganto/compare/0.12.2...0.12.3
-[0.12.2]: https://github.com/aicers/giganto/compare/0.12.1...0.12.2
-[0.12.1]: https://github.com/aicers/giganto/compare/0.12.0...0.12.1
-[0.12.0]: https://github.com/aicers/giganto/compare/0.11.0...0.12.0
-[0.11.0]: https://github.com/aicers/giganto/compare/0.10.2...0.11.0
-[0.10.2]: https://github.com/aicers/giganto/compare/0.10.1...0.10.2
-[0.10.1]: https://github.com/aicers/giganto/compare/0.10.0...0.10.1
-[0.10.0]: https://github.com/aicers/giganto/compare/0.9.0...0.10.0
-[0.9.0]: https://github.com/aicers/giganto/compare/0.8.0...0.9.0
-[0.8.0]: https://github.com/aicers/giganto/compare/0.7.0...0.8.0
-[0.7.0]: https://github.com/aicers/giganto/compare/0.6.0...0.7.0
-[0.6.0]: https://github.com/aicers/giganto/compare/0.5.0...0.6.0
-[0.5.0]: https://github.com/aicers/giganto/compare/0.4.0...0.5.0
-[0.4.0]: https://github.com/aicers/giganto/compare/0.3.0...0.4.0
-[0.3.0]: https://github.com/aicers/giganto/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/aicers/giganto/compare/0.1.0...0.2.0
-[0.1.0]: https://github.com/aicers/giganto/tree/0.1.0
+[Unreleased]: https://github.com/aicers/giganto/compare/0.15.1...main
+[0.15.1]: <https://github.com/aicers/giganto/compare/0.15.0...0.15.1>
+[0.15.0]: <https://github.com/aicers/giganto/compare/0.14.0...0.15.0>
+[0.14.0]: <https://github.com/aicers/giganto/compare/0.13.1...0.14.0>
+[0.13.1]: <https://github.com/aicers/giganto/compare/0.13.0...0.13.1>
+[0.13.0]: <https://github.com/aicers/giganto/compare/0.12.3...0.13.0>
+[0.12.3]: <https://github.com/aicers/giganto/compare/0.12.2...0.12.3>
+[0.12.2]: <https://github.com/aicers/giganto/compare/0.12.1...0.12.2>
+[0.12.1]: <https://github.com/aicers/giganto/compare/0.12.0...0.12.1>
+[0.12.0]: <https://github.com/aicers/giganto/compare/0.11.0...0.12.0>
+[0.11.0]: <https://github.com/aicers/giganto/compare/0.10.2...0.11.0>
+[0.10.2]: <https://github.com/aicers/giganto/compare/0.10.1...0.10.2>
+[0.10.1]: <https://github.com/aicers/giganto/compare/0.10.0...0.10.1>
+[0.10.0]: <https://github.com/aicers/giganto/compare/0.9.0...0.10.0>
+[0.9.0]: <https://github.com/aicers/giganto/compare/0.8.0...0.9.0>
+[0.8.0]: <https://github.com/aicers/giganto/compare/0.7.0...0.8.0>
+[0.7.0]: <https://github.com/aicers/giganto/compare/0.6.0...0.7.0>
+[0.6.0]: <https://github.com/aicers/giganto/compare/0.5.0...0.6.0>
+[0.5.0]: <https://github.com/aicers/giganto/compare/0.4.0...0.5.0>
+[0.4.0]: <https://github.com/aicers/giganto/compare/0.3.0...0.4.0>
+[0.3.0]: <https://github.com/aicers/giganto/compare/0.2.0...0.3.0>
+[0.2.0]: <https://github.com/aicers/giganto/compare/0.1.0...0.2.0>
+[0.1.0]: <https://github.com/aicers/giganto/tree/0.1.0>


### PR DESCRIPTION
### Changed
Change MessageCode::RawData processing code:
* Modified to send events in the same format as MessageCode::RangeData

### Issue
REconverge request raw events for `Outliers` with the `MessageCode::RawData`, but the response raw events were  serialized structure instance values, so a problem occurred that could not be interpreted.
This PR modifies the response raw events to be sent in the same format as `MessageCode::RangeData`.