### PR TITLE
Rename and relocate PacketSources, Sources, StreamDirectChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Changed manual boundary check to boundary checking via `iterator_cf_opt`.
+- Rename type aliases `PacketSources` to `PcapSources`, `Sources` to
+  `IngestSources`, and `StreamDirectChannel` to `StreamDirectChannels`;
+  And move their definition location from `ingest.rs` to `main.rs`.
 
 ## [0.15.3] - 2023-11-09
 

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -1,5 +1,6 @@
 use super::Server;
 use crate::{
+    new_ingest_sources, new_pcap_sources, new_stream_direct_channels,
     storage::{Database, DbOptions},
     to_cert_chain, to_private_key,
 };
@@ -22,7 +23,6 @@ use giganto_client::{
 };
 use quinn::{Connection, Endpoint};
 use std::{
-    collections::HashMap,
     fs,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     path::Path,
@@ -30,7 +30,7 @@ use std::{
 };
 use tempfile::TempDir;
 use tokio::{
-    sync::{Mutex, Notify, RwLock},
+    sync::{Mutex, Notify},
     task::JoinHandle,
 };
 
@@ -1108,14 +1108,14 @@ async fn one_short_reproduce_channel_close() {
 
 fn run_server(db_dir: TempDir) -> JoinHandle<()> {
     let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let packet_sources = Arc::new(RwLock::new(HashMap::new()));
-    let sources = Arc::new(RwLock::new(HashMap::new()));
-    let stream_direct_channel = Arc::new(RwLock::new(HashMap::new()));
+    let pcap_sources = new_pcap_sources();
+    let ingest_sources = new_ingest_sources();
+    let stream_direct_channels = new_stream_direct_channels();
     tokio::spawn(server().run(
         db,
-        packet_sources,
-        sources,
-        stream_direct_channel,
+        pcap_sources,
+        ingest_sources,
+        stream_direct_channels,
         Arc::new(Notify::new()),
         Some(Arc::new(Notify::new())),
     ))

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -891,7 +891,7 @@ pub async fn retain_periodically(
     duration: Duration,
     retention_period: Duration,
     db: Database,
-    wait_shutdown: Arc<Notify>,
+    notify_shutdown: Arc<Notify>,
 ) -> Result<()> {
     // TODO: Add exceptional key column families include log_store.
     const DEFAULT_FROM: i64 = 61_000_000_000;
@@ -950,7 +950,7 @@ pub async fn retain_periodically(
                     log_store.flush()?;
                 }
             }
-            () = wait_shutdown.notified() => {
+            () = notify_shutdown.notified() => {
                 return Ok(());
             },
         }

--- a/src/web.rs
+++ b/src/web.rs
@@ -15,7 +15,7 @@ pub async fn serve(
     addr: SocketAddr,
     cert: Vec<u8>,
     key: Vec<u8>,
-    wait_shutdown: Arc<Notify>,
+    notify_shutdown: Arc<Notify>,
 ) {
     let filter = async_graphql_warp::graphql(schema).and_then(
         |(schema, request): (Schema, async_graphql::Request)| async move {
@@ -39,7 +39,7 @@ pub async fn serve(
         .tls()
         .cert(cert)
         .key(key)
-        .bind_with_graceful_shutdown(addr, async move { wait_shutdown.notified().await });
+        .bind_with_graceful_shutdown(addr, async move { notify_shutdown.notified().await });
 
     // start Graphql Server
     info!("listening on https://{addr:?}");


### PR DESCRIPTION
이슈에 기재된 것 이외에 통일성 관점에서 다음을 추가로 작업하였습니다.

1. main.rs에서 Arc<Notify> 류는 notify_xxxx 로 변경하였습니다. ( refer to : https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html)
2. StreamDirectChannel alias도 복수개의 아이템을 들고있는 Map 이므로, 복수형으로 변경하였습니다.


Resolves #596 