### PR TITLE
Added features related to acknowledge transmission control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added to call more flushes within the `handle_data` function of `ingest` that
   receive raw events. This change ensures that data is saved in all cases where the
   `handle_data` function terminates, such as when an `error` occurs.
+- Added functionality to control the sending of acknowledgments.
+  - Set the `ack transmission count` by reading from the config file.
+  - Changed the type of ack transmission count checked in `ingest` from `const u16`
+    to `AckTransmissionCount`(`Arc<RwLock<u16>>`).
+  - Added `set_ack_transmission_count` GraphQL query to set the ack transmission
+    count.This query changes the `AckTransmissionCount` used in ingest and
+    `ack_transmission` in the config file to the input `count` value.
+
+### Changed
+
+- Modify the `set_giganto_config` and `giganto_config` GraphQL queries to
+  read/write the ack transmission count.
+- Modify the `set_giganto_config` and `giganto_config` GraphQL queries so that
+  the fields that take integers read/write the config file for their respective
+  types.
+- Modify the `giganto_config` query so that config files that work in
+  `standalone mode` can also be read correctly.
 
 ## [0.15.4] - 2023-11-22
 

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -30,7 +30,7 @@ use std::{
 };
 use tempfile::TempDir;
 use tokio::{
-    sync::{Mutex, Notify},
+    sync::{Mutex, Notify, RwLock},
     task::JoinHandle,
 };
 
@@ -1118,5 +1118,6 @@ fn run_server(db_dir: TempDir) -> JoinHandle<()> {
         stream_direct_channels,
         Arc::new(Notify::new()),
         Some(Arc::new(Notify::new())),
+        Arc::new(RwLock::new(1024)),
     ))
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ const DEFAULT_INGEST_ADDRESS: &str = "[::]:38370";
 const DEFAULT_PUBLISH_ADDRESS: &str = "[::]:38371";
 const DEFAULT_GRAPHQL_ADDRESS: &str = "[::]:8443";
 const DEFAULT_INVALID_PEER_ADDRESS: &str = "254.254.254.254:38383";
+const DEFAULT_ACK_TRANSMISSION: u16 = 1024;
 
 /// The application settings.
 #[derive(Clone, Debug, Deserialize)]
@@ -38,6 +39,9 @@ pub struct Settings {
     #[serde(deserialize_with = "deserialize_peer_addr")]
     pub peer_address: Option<SocketAddr>, // IP address & port for peer connection
     pub peers: Option<HashSet<PeerInfo>>,
+
+    //ack transmission interval
+    pub ack_transmission: u16,
 }
 
 impl Settings {
@@ -118,7 +122,9 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .set_default("cfg_path", config_path.to_str().expect("path to string"))
         .expect("default config dir")
         .set_default("peer_address", DEFAULT_INVALID_PEER_ADDRESS)
-        .expect("peer address")
+        .expect("default ack transmission")
+        .set_default("ack_transmission", DEFAULT_ACK_TRANSMISSION)
+        .expect("ack_transmission")
 }
 
 /// Deserializes a socket address.

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -8,6 +8,7 @@ data_dir = "tests/data"
 retention = "100d"
 log_dir = "/data/logs/apps"
 export_dir = "tests/export"
+ack_transmission = 1024
 max_open_files = 8000
 max_mb_of_level_base = 512
 peer_address= "100.101.102.1:38383"


### PR DESCRIPTION
- Set the `ack transmission count` by reading from the config file.
- Added `set_ack_transmission_count` GraphQL query for setting the ACK transmission count.
- Changed the data type of the ack transmission count in ingest from `const u16` to `AckTransmissionCount`.

Close: #612