### PR TITLE
Fix for giganto ingest source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   requesting a sysmon events.
 - Added `SmtpRawEvent` to the return value union of `network_raw_events` GraphQL
   query.
+- Added `RunTimeIngestSources` type that checks for information from source
+  that is connected to ingest in real time. This type is not currently used,
+  but may be used in the future to provide real-time connection information.
 
 ### Changed
 
@@ -25,6 +28,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix the part of the `export` query about validating filters for protocols.
+- Fix to initialize `ingest_sources` value from `sources` cf on giganto startup.
+  This change is intended to ensure that `IngestSources` provide all source
+  information for stored data and `RunTimeIngestSources` provide real-time
+  connection source information.
 
 ## [0.16.0] - 2024-01-08
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1180,11 +1180,7 @@ where
 async fn is_current_giganto_in_charge<'ctx>(ctx: &Context<'ctx>, source_filter: &str) -> bool {
     let ingest_sources = ctx.data_opt::<IngestSources>();
     match ingest_sources {
-        Some(ingest_sources) => ingest_sources
-            .read()
-            .await
-            .iter()
-            .any(|(ingest_source_name, _last_conn_time)| ingest_source_name == source_filter),
+        Some(ingest_sources) => ingest_sources.read().await.contains(source_filter),
         None => false,
     }
 }
@@ -1227,7 +1223,7 @@ async fn find_who_are_in_charge(
             let ingest_sources = ingest_sources.read().await;
             let ingest_sources_set = ingest_sources
                 .iter()
-                .map(|(ingest_source_name, _last_conn_time)| ingest_source_name.as_str())
+                .map(std::string::String::as_str)
                 .collect::<HashSet<_>>();
 
             sources
@@ -1568,8 +1564,8 @@ mod tests {
             let ingest_sources = Arc::new(tokio::sync::RwLock::new(
                 CURRENT_GIGANTO_INGEST_SOURCES
                     .into_iter()
-                    .map(|source| (source.to_string(), Utc::now()))
-                    .collect::<HashMap<String, DateTime<Utc>>>(),
+                    .map(|source| source.to_string())
+                    .collect::<HashSet<String>>(),
             ));
 
             let peers = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
@@ -1580,8 +1576,8 @@ mod tests {
             let ingest_sources = Arc::new(tokio::sync::RwLock::new(
                 CURRENT_GIGANTO_INGEST_SOURCES
                     .into_iter()
-                    .map(|source| (source.to_string(), Utc::now()))
-                    .collect::<HashMap<String, DateTime<Utc>>>(),
+                    .map(|source| source.to_string())
+                    .collect::<HashSet<String>>(),
             ));
 
             let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -1,6 +1,6 @@
 use super::Server;
 use crate::{
-    new_ingest_sources, new_pcap_sources, new_stream_direct_channels,
+    new_ingest_sources, new_pcap_sources, new_runtime_ingest_sources, new_stream_direct_channels,
     storage::{Database, DbOptions},
     to_cert_chain, to_private_key, to_root_cert, Certs,
 };
@@ -1115,12 +1115,14 @@ async fn one_short_reproduce_channel_close() {
 fn run_server(db_dir: TempDir) -> JoinHandle<()> {
     let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
     let pcap_sources = new_pcap_sources();
-    let ingest_sources = new_ingest_sources();
+    let ingest_sources = new_ingest_sources(&db);
+    let runtime_ingest_sources = new_runtime_ingest_sources();
     let stream_direct_channels = new_stream_direct_channels();
     tokio::spawn(server().run(
         db,
         pcap_sources,
         ingest_sources,
+        runtime_ingest_sources,
         stream_direct_channels,
         Arc::new(Notify::new()),
         Some(Arc::new(Notify::new())),

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -46,7 +46,7 @@ use giganto_client::{
 use log_broker::{debug, error, info, warn, LogLocation};
 use quinn::{Connection, Endpoint, RecvStream, SendStream, ServerConfig};
 use serde::{de::DeserializeOwned, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
@@ -1860,7 +1860,7 @@ where
 }
 
 async fn is_current_giganto_in_charge(ingest_sources: IngestSources, source: &String) -> bool {
-    ingest_sources.read().await.contains_key(source)
+    ingest_sources.read().await.contains(source)
 }
 
 async fn peer_in_charge_publish_addr(peers: Peers, source: &String) -> Option<SocketAddr> {
@@ -2004,17 +2004,10 @@ async fn req_inputs_by_gigantos_in_charge(
     ingest_sources: IngestSources,
     req_inputs: Vec<(String, Vec<i64>)>,
 ) -> (Vec<(String, Vec<i64>)>, Vec<(String, Vec<i64>)>) {
-    let current_giganto_sources: HashSet<String> = ingest_sources
-        .read()
-        .await
-        .keys()
-        .cloned()
-        .collect::<HashSet<String>>();
-
     let mut handle_by_current_giganto = Vec::with_capacity(req_inputs.len());
     let mut handle_by_peer_gigantos = Vec::with_capacity(req_inputs.len());
     for req_input in req_inputs {
-        if current_giganto_sources.contains(&req_input.0) {
+        if ingest_sources.read().await.contains(&req_input.0) {
             handle_by_current_giganto.push(req_input);
         } else {
             handle_by_peer_gigantos.push(req_input);

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -709,8 +709,8 @@ async fn request_range_data_with_protocol() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| (source.to_string()))
+            .collect::<HashSet<String>>(),
     ));
     let (peers, peer_idents) = new_peers_data(None);
 
@@ -1708,8 +1708,8 @@ async fn request_range_data_with_log() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| source.to_string())
+            .collect::<HashSet<String>>(),
     ));
     let (peers, peer_idents) = new_peers_data(None);
 
@@ -1815,8 +1815,8 @@ async fn request_range_data_with_period_time_series() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| source.to_string())
+            .collect::<HashSet<String>>(),
     ));
     let (peers, peer_idents) = new_peers_data(None);
 
@@ -1961,8 +1961,8 @@ async fn request_network_event_stream() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| source.to_string())
+            .collect::<HashSet<String>>(),
     ));
     let (peers, peer_idents) = new_peers_data(None);
 
@@ -3632,8 +3632,8 @@ async fn request_raw_events() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| source.to_string())
+            .collect::<HashSet<String>>(),
     ));
     let (peers, peer_idents) = new_peers_data(None);
 
@@ -3719,8 +3719,8 @@ async fn request_range_data_with_protocol_giganto_cluster() {
         let ingest_sources = Arc::new(tokio::sync::RwLock::new(
             NODE2_GIGANTO_INGEST_SOURCES
                 .into_iter()
-                .map(|source| (source.to_string(), Utc::now()))
-                .collect::<HashMap<String, DateTime<Utc>>>(),
+                .map(|source| source.to_string())
+                .collect::<HashSet<String>>(),
         ));
 
         let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
@@ -3797,8 +3797,8 @@ async fn request_range_data_with_protocol_giganto_cluster() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| (source.to_string()))
+            .collect::<HashSet<String>>(),
     ));
 
     let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -3935,8 +3935,8 @@ async fn request_range_data_with_log_giganto_cluster() {
         let ingest_sources = Arc::new(tokio::sync::RwLock::new(
             NODE2_GIGANTO_INGEST_SOURCES
                 .into_iter()
-                .map(|source| (source.to_string(), Utc::now()))
-                .collect::<HashMap<String, DateTime<Utc>>>(),
+                .map(|source| source.to_string())
+                .collect::<HashSet<String>>(),
         ));
 
         let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
@@ -4013,8 +4013,8 @@ async fn request_range_data_with_log_giganto_cluster() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| (source.to_string()))
+            .collect::<HashSet<String>>(),
     ));
 
     let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -4140,8 +4140,8 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
         let ingest_sources = Arc::new(tokio::sync::RwLock::new(
             NODE2_GIGANTO_INGEST_SOURCES
                 .into_iter()
-                .map(|source| (source.to_string(), Utc::now()))
-                .collect::<HashMap<String, DateTime<Utc>>>(),
+                .map(|source| source.to_string())
+                .collect::<HashSet<String>>(),
         ));
 
         let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
@@ -4222,8 +4222,8 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| (source.to_string()))
+            .collect::<HashSet<String>>(),
     ));
 
     let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -4350,8 +4350,8 @@ async fn request_raw_events_giganto_cluster() {
         let ingest_sources = Arc::new(tokio::sync::RwLock::new(
             NODE2_GIGANTO_INGEST_SOURCES
                 .into_iter()
-                .map(|source| (source.to_string(), Utc::now()))
-                .collect::<HashMap<String, DateTime<Utc>>>(),
+                .map(|source| source.to_string())
+                .collect::<HashSet<String>>(),
         ));
 
         let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
@@ -4424,8 +4424,8 @@ async fn request_raw_events_giganto_cluster() {
     let ingest_sources = Arc::new(tokio::sync::RwLock::new(
         NODE1_GIGANTO_INGEST_SOURCES
             .into_iter()
-            .map(|source| (source.to_string(), Utc::now()))
-            .collect::<HashMap<String, DateTime<Utc>>>(),
+            .map(|source| (source.to_string()))
+            .collect::<HashSet<String>>(),
     ));
 
     let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(


### PR DESCRIPTION
- Fix to initialize `ingest_sources` value from `sources` cf on giganto startup.
- Add `RunTimeIngestSources` type for store real-time connection source.

Close: #660