### PR TITLE
Modify db save key and related queries in secuLog/netflow5/netflow9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Modify the `sources` query to return results that also include
   sources from its peers.
+- Change the prefix of the `Netflow5`/`Netflow9`/`SecuLog` db key to source.
+- Modify the related queries as the db key of `Netflow5`/`Netflow9`/`SecuLog`
+  is changed to source.(`netflow5_raw_events`/`netflow9_raw_events`/
+  `secu_log_raw_events`)
 
 ## [0.18.0]
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -656,10 +656,6 @@ fn check_contents(filter_str: &Option<String>, target_str: Option<String>) -> bo
     })
 }
 
-fn check_source(filter_src: &Option<String>, target_src: &Option<String>) -> bool {
-    filter_by_str(filter_src, target_src)
-}
-
 fn check_agent_id(filter_agent_id: &Option<String>, target_agent_id: &Option<String>) -> bool {
     filter_by_str(filter_agent_id, target_agent_id)
 }
@@ -1095,6 +1091,7 @@ macro_rules! paged_events_in_cluster {
 }
 pub(crate) use paged_events_in_cluster;
 
+#[allow(unused)]
 fn combine_results<N>(
     current_giganto_result: Connection<String, N>,
     peer_results: Vec<Connection<String, N>>,
@@ -1131,12 +1128,14 @@ where
     connection_to_return
 }
 
+#[allow(unused)]
 #[derive(PartialEq)]
 enum TakeDirection {
     First,
     Last,
 }
 
+#[allow(unused)]
 fn sort_and_trunk_edges<N>(
     mut edges: Vec<Edge<String, N, EmptyFields>>,
     before: &Option<String>,
@@ -1303,6 +1302,7 @@ where
         .map(|graphql_res| response_to_result_converter(graphql_res.data))
 }
 
+#[allow(unused_macros)]
 macro_rules! request_all_peers_for_paged_events_fut {
     ($ctx:expr,
      $filter:expr,
@@ -1376,6 +1376,7 @@ macro_rules! request_all_peers_for_paged_events_fut {
         futures_util::future::join_all(peer_requests)
     }};
 }
+#[allow(unused_imports)]
 pub(crate) use request_all_peers_for_paged_events_fut;
 
 macro_rules! request_selected_peers_for_events_fut {
@@ -1598,22 +1599,6 @@ mod tests {
             let request: async_graphql::Request = query.into();
             self.schema.execute(request).await
         }
-    }
-
-    #[test]
-    fn test_check_source() {
-        use super::check_source;
-        assert!(check_source(
-            &Some("test".to_string()),
-            &Some("test".to_string())
-        ));
-        assert!(!check_source(
-            &Some("test".to_string()),
-            &Some("test1".to_string())
-        ));
-        assert!(!check_source(&Some("test".to_string()), &None));
-        assert!(check_source(&None, &Some("test".to_string()),));
-        assert!(check_source(&None, &None));
     }
 
     #[derive(SimpleObject, Debug)]

--- a/src/graphql/client/schema/netflow5_raw_events.graphql
+++ b/src/graphql/client/schema/netflow5_raw_events.graphql
@@ -1,5 +1,5 @@
-query Netflow5RawEvents($filter: NetflowFilter!, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean ){
-    netflow5RawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
+query Netflow5RawEvents($filter: NetflowFilter!, $after: String, $before: String, $first: Int, $last: Int){
+    netflow5RawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,7 +10,6 @@ query Netflow5RawEvents($filter: NetflowFilter!, $after: String, $before: String
             cursor
             node {
                 timestamp
-                source
                 srcAddr
                 dstAddr
                 nextHop

--- a/src/graphql/client/schema/netflow9_raw_events.graphql
+++ b/src/graphql/client/schema/netflow9_raw_events.graphql
@@ -1,5 +1,5 @@
-query Netflow9RawEvents($filter: NetflowFilter!, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean ){
-    netflow9RawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
+query Netflow9RawEvents($filter: NetflowFilter!, $after: String, $before: String, $first: Int, $last: Int){
+    netflow9RawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,7 +10,6 @@ query Netflow9RawEvents($filter: NetflowFilter!, $after: String, $before: String
             cursor
             node {
                 timestamp
-                source
                 sequence
                 sourceId
                 templateId

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -639,7 +639,6 @@ type Mutation {
 
 type Netflow5RawEvent {
   timestamp: DateTime!
-  source: String!
   srcAddr: String!
   dstAddr: String!
   nextHop: String!
@@ -687,7 +686,6 @@ type Netflow5RawEventEdge {
 
 type Netflow9RawEvent {
   timestamp: DateTime!
-  source: String!
   sequence: Int!
   sourceId: Int!
   templateId: Int!
@@ -721,8 +719,7 @@ type Netflow9RawEventEdge {
 
 input NetflowFilter {
   time: TimeRange
-  source: String
-  kind: String
+  source: String!
   origAddr: IpRange
   respAddr: IpRange
   origPort: PortRange
@@ -1428,7 +1425,6 @@ type Query {
     before: String
     first: Int
     last: Int
-    requestFromPeer: Boolean
   ): SecuLogRawEventConnection!
   netflow5RawEvents(
     filter: NetflowFilter!
@@ -1436,7 +1432,6 @@ type Query {
     before: String
     first: Int
     last: Int
-    requestFromPeer: Boolean
   ): Netflow5RawEventConnection!
   netflow9RawEvents(
     filter: NetflowFilter!
@@ -1444,7 +1439,6 @@ type Query {
     before: String
     first: Int
     last: Int
-    requestFromPeer: Boolean
   ): Netflow9RawEventConnection!
 }
 
@@ -1561,7 +1555,7 @@ input SearchFilter {
 
 input SecuLogFilter {
   time: TimeRange
-  source: String
+  source: String!
   kind: String!
   origAddr: IpRange
   respAddr: IpRange
@@ -1572,7 +1566,6 @@ input SecuLogFilter {
 
 type SecuLogRawEvent {
   timestamp: DateTime!
-  source: String!
   logType: String!
   version: String!
   origAddr: String

--- a/src/graphql/client/schema/secu_log_raw_events.graphql
+++ b/src/graphql/client/schema/secu_log_raw_events.graphql
@@ -1,5 +1,5 @@
-query SecuLogRawEvents($filter: SecuLogFilter!, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
-    secuLogRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
+query SecuLogRawEvents($filter: SecuLogFilter!, $after: String, $before: String, $first: Int, $last: Int){
+    secuLogRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,7 +10,6 @@ query SecuLogRawEvents($filter: SecuLogFilter!, $after: String, $before: String,
             cursor
             node {
                 timestamp
-                source
                 logType
                 version
                 origAddr

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -83,7 +83,7 @@ const AGENT_PROTOCOL: [&str; 14] = [
     "process tamper",
     "file delete detected",
 ];
-const KIND_PROTOCOL: [&str; 2] = ["log", "sec log"];
+const KIND_PROTOCOL: [&str; 2] = ["log", "secu log"];
 
 #[derive(Default)]
 pub(super) struct ExportQuery;


### PR DESCRIPTION
- Change the prefix of the db key in secuLog/netflow5/netflow9 to source.
- Modify the queries for that protocol based on the search through the source.

Close: #682