### PR TITLE
Update configuration field names and handle single root usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `giganto.toml`, the temporary file is named as `giganto.toml.temp.toml`.
   - If the reload trigger succeeds, the new configuration is applied from the
     temporary file; otherwise, the temporary file is deleted.
+- Changed configuration field names.
+  - `ingest_address` to `ingest_srv_addr`.
+  - `publish_address` to `publish_srv_addr`.
+  - `graphql_address` to `graphql_srv_addr`.
+  - `roots` to `root` to handle using a single root.
 
 ## [0.19.0] - 2024-02-22
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ In the config file, you can specify the following options:
 ```toml
 key = "key.pem"                            # path to private key file
 cert = "cert.pem"                          # path to certificate file
-roots = ["ca1.pem", "ca2.pem", "ca3.pem"]  # paths to CA certificate files
-ingest_address = "0.0.0.0:38370"           # address to listen for ingest QUIC
-publish_address = "0.0.0.0:38371"          # address to listen for publish QUIC
-graphql_address = "127.0.0.1:8442"         # giganto's graphql address
+root = "root.pem"                          # path to CA certificate file
+ingest_srv_addr = "0.0.0.0:38370"          # address to listen for ingest QUIC
+publish_srv_addr = "0.0.0.0:38371"         # address to listen for publish QUIC
+graphql_srv_addr = "127.0.0.1:8442"        # giganto's graphql address
 data_dir = "tests/data"                    # path to directory to store data
 retention = "100d"                         # retention period for data
 log_dir = "/data/logs/apps"                # path to giganto's syslog file

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -12,9 +12,9 @@ use std::{
 use toml_edit::{value, Document, InlineTable};
 
 const GRAPHQL_REBOOT_DELAY: u64 = 100;
-const CONFIG_INGEST_ADDRESS: &str = "ingest_address";
-pub const CONFIG_PUBLISH_ADDRESS: &str = "publish_address";
-pub const CONFIG_GRAPHQL_ADDRESS: &str = "graphql_address";
+const CONFIG_INGEST_SRV_ADDR: &str = "ingest_srv_addr";
+pub const CONFIG_PUBLISH_SRV_ADDR: &str = "publish_srv_addr";
+pub const CONFIG_GRAPHQL_SRV_ADDR: &str = "graphql_srv_addr";
 const CONFIG_RETENTION: &str = "retention";
 const CONFIG_MAX_OPEN_FILES: &str = "max_open_files";
 const CONFIG_MAX_MB_OF_LEVEL_BASE: &str = "max_mb_of_level_base";
@@ -68,9 +68,9 @@ impl TomlPeers for PeerList {
 
 #[derive(SimpleObject, Debug)]
 struct GigantoConfig {
-    ingest_address: String,
-    publish_address: String,
-    graphql_address: String,
+    ingest_srv_addr: String,
+    publish_srv_addr: String,
+    graphql_srv_addr: String,
     retention: String,
     max_open_files: i32,
     max_mb_of_level_base: u64,
@@ -81,9 +81,9 @@ struct GigantoConfig {
 
 #[derive(InputObject)]
 struct UserConfig {
-    ingest_address: Option<String>,
-    publish_address: Option<String>,
-    graphql_address: Option<String>,
+    ingest_srv_addr: Option<String>,
+    publish_srv_addr: Option<String>,
+    graphql_srv_addr: Option<String>,
     retention: Option<String>,
     max_open_files: Option<i32>,
     max_mb_of_level_base: Option<u64>,
@@ -137,9 +137,9 @@ impl GigantoStatusQuery {
     async fn giganto_config<'ctx>(&self, ctx: &Context<'ctx>) -> Result<GigantoConfig> {
         let cfg_path = ctx.data::<String>()?;
         let doc = read_toml_file(cfg_path)?;
-        let ingest_address = parse_toml_element_to_string(CONFIG_INGEST_ADDRESS, &doc)?;
-        let publish_address = parse_toml_element_to_string(CONFIG_PUBLISH_ADDRESS, &doc)?;
-        let graphql_address = parse_toml_element_to_string(CONFIG_GRAPHQL_ADDRESS, &doc)?;
+        let ingest_srv_addr = parse_toml_element_to_string(CONFIG_INGEST_SRV_ADDR, &doc)?;
+        let publish_srv_addr = parse_toml_element_to_string(CONFIG_PUBLISH_SRV_ADDR, &doc)?;
+        let graphql_srv_addr = parse_toml_element_to_string(CONFIG_GRAPHQL_SRV_ADDR, &doc)?;
         let retention = parse_toml_element_to_string(CONFIG_RETENTION, &doc)?;
         let max_open_files = parse_toml_element_to_integer(CONFIG_MAX_OPEN_FILES, &doc)?;
         let max_mb_of_level_base =
@@ -176,9 +176,9 @@ impl GigantoStatusQuery {
         };
 
         Ok(GigantoConfig {
-            ingest_address,
-            publish_address,
-            graphql_address,
+            ingest_srv_addr,
+            publish_srv_addr,
+            graphql_srv_addr,
             retention,
             max_open_files,
             max_mb_of_level_base,
@@ -205,9 +205,9 @@ impl GigantoConfigMutation {
         let cfg_path = ctx.data::<String>()?;
         let new_path = copy_toml_file(cfg_path)?;
         let mut doc = read_toml_file(&new_path)?;
-        insert_toml_element(CONFIG_INGEST_ADDRESS, &mut doc, field.ingest_address);
-        insert_toml_element(CONFIG_PUBLISH_ADDRESS, &mut doc, field.publish_address);
-        insert_toml_element(CONFIG_GRAPHQL_ADDRESS, &mut doc, field.graphql_address);
+        insert_toml_element(CONFIG_INGEST_SRV_ADDR, &mut doc, field.ingest_srv_addr);
+        insert_toml_element(CONFIG_PUBLISH_SRV_ADDR, &mut doc, field.publish_srv_addr);
+        insert_toml_element(CONFIG_GRAPHQL_SRV_ADDR, &mut doc, field.graphql_srv_addr);
         insert_toml_element(CONFIG_RETENTION, &mut doc, field.retention);
         let convert_open_file = field.max_open_files.map(i64::from);
         insert_toml_element(CONFIG_MAX_OPEN_FILES, &mut doc, convert_open_file);

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -33,7 +33,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     net::{IpAddr, Ipv6Addr, SocketAddr},
-    path::{Path, PathBuf},
+    path::Path,
     sync::{Arc, OnceLock},
 };
 use tokio::sync::{Mutex, Notify, RwLock};
@@ -44,7 +44,7 @@ fn get_token() -> &'static Mutex<u32> {
     TOKEN.get_or_init(|| Mutex::new(0))
 }
 
-const CA_CERT_PATH: &str = "tests/certs/root.pem";
+const ROOT_PATH: &str = "tests/certs/root.pem";
 const PROTOCOL_VERSION: &str = "0.17.0";
 
 const NODE1_CERT_PATH: &str = "tests/certs/node1/cert.pem";
@@ -93,13 +93,13 @@ fn server() -> Server {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     Server::new(
@@ -163,7 +163,7 @@ fn init_client() -> Endpoint {
     };
 
     let mut server_root = rustls::RootCertStore::empty();
-    let file = fs::read(CA_CERT_PATH).expect("Failed to read file");
+    let file = fs::read(ROOT_PATH).expect("Failed to read file");
     let root_cert: Vec<rustls::Certificate> = rustls_pemfile::certs(&mut &*file)
         .expect("invalid PEM-encoded certificate")
         .into_iter()
@@ -718,13 +718,13 @@ async fn request_range_data_with_protocol() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -1717,13 +1717,13 @@ async fn request_range_data_with_log() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -1824,13 +1824,13 @@ async fn request_range_data_with_period_time_series() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -1970,13 +1970,13 @@ async fn request_network_event_stream() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -3641,13 +3641,13 @@ async fn request_raw_events() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -3727,12 +3727,12 @@ async fn request_range_data_with_protocol_giganto_cluster() {
         let cert = to_cert_chain(&cert_pem).unwrap();
         let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
         let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-        let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+        let root_pem = fs::read(ROOT_PATH).unwrap();
+        let root = to_root_cert(&root_pem).unwrap();
         let certs = Arc::new(Certs {
             certs: cert,
             key,
-            ca_certs,
+            root,
         });
 
         let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -3824,13 +3824,13 @@ async fn request_range_data_with_protocol_giganto_cluster() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -3943,12 +3943,12 @@ async fn request_range_data_with_log_giganto_cluster() {
         let cert = to_cert_chain(&cert_pem).unwrap();
         let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
         let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-        let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+        let root_pem = fs::read(ROOT_PATH).unwrap();
+        let root = to_root_cert(&root_pem).unwrap();
         let certs = Arc::new(Certs {
             certs: cert,
             key,
-            ca_certs,
+            root,
         });
 
         let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -4040,13 +4040,13 @@ async fn request_range_data_with_log_giganto_cluster() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -4148,12 +4148,12 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
         let cert = to_cert_chain(&cert_pem).unwrap();
         let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
         let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-        let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+        let root_pem = fs::read(ROOT_PATH).unwrap();
+        let root = to_root_cert(&root_pem).unwrap();
         let certs = Arc::new(Certs {
             certs: cert,
             key,
-            ca_certs,
+            root,
         });
 
         let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -4250,13 +4250,13 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(
@@ -4358,12 +4358,12 @@ async fn request_raw_events_giganto_cluster() {
         let cert = to_cert_chain(&cert_pem).unwrap();
         let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
         let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-        let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+        let root_pem = fs::read(ROOT_PATH).unwrap();
+        let root = to_root_cert(&root_pem).unwrap();
         let certs = Arc::new(Certs {
             certs: cert,
             key,
-            ca_certs,
+            root,
         });
 
         let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
@@ -4452,13 +4452,13 @@ async fn request_raw_events_giganto_cluster() {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path: Vec<PathBuf> = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_root_cert(&ca_cert_path).unwrap();
+    let root_pem = fs::read(ROOT_PATH).unwrap();
+    let root = to_root_cert(&root_pem).unwrap();
 
     let certs = Arc::new(Certs {
         certs: cert,
         key,
-        ca_certs,
+        root,
     });
 
     tokio::spawn(server().run(

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,13 +15,12 @@ const KEEP_ALIVE_INTERVAL: Duration = Duration::from_millis(5_000);
 pub struct Certs {
     pub certs: Vec<Certificate>,
     pub key: PrivateKey,
-    pub ca_certs: RootCertStore,
+    pub root: RootCertStore,
 }
 
 #[allow(clippy::module_name_repetitions)]
 pub fn config_server(certs: &Arc<Certs>) -> Result<ServerConfig> {
-    let client_auth =
-        rustls::server::AllowAnyAuthenticatedClient::new(certs.ca_certs.clone()).boxed();
+    let client_auth = rustls::server::AllowAnyAuthenticatedClient::new(certs.root.clone()).boxed();
     let server_crypto = rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_client_cert_verifier(client_auth)
@@ -78,7 +77,7 @@ pub fn certificate_info(cert_info: &[Certificate]) -> Result<(String, String)> {
 pub fn config_client(certs: &Arc<Certs>) -> Result<ClientConfig> {
     let tls_config = rustls::ClientConfig::builder()
         .with_safe_defaults()
-        .with_root_certificates(certs.ca_certs.clone())
+        .with_root_certificates(certs.root.clone())
         .with_client_auth_cert(certs.certs.clone(), certs.key.clone())?;
 
     let mut transport = TransportConfig::default();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,9 +4,9 @@ use config::{builder::DefaultState, Config, ConfigBuilder, ConfigError, File};
 use serde::{de::Error, Deserialize, Deserializer};
 use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
 
-const DEFAULT_INGEST_ADDRESS: &str = "[::]:38370";
-const DEFAULT_PUBLISH_ADDRESS: &str = "[::]:38371";
-const DEFAULT_GRAPHQL_ADDRESS: &str = "[::]:8442";
+const DEFAULT_INGEST_SRV_ADDR: &str = "[::]:38370";
+const DEFAULT_PUBLISH_SRV_ADDR: &str = "[::]:38371";
+const DEFAULT_GRAPHQL_SRV_ADDR: &str = "[::]:8442";
 const DEFAULT_INVALID_PEER_ADDRESS: &str = "254.254.254.254:38383";
 const DEFAULT_ACK_TRANSMISSION: u16 = 1024;
 const DEFAULT_RETENTION: &str = "100d";
@@ -16,19 +16,19 @@ const DEFAULT_MAX_MB_OF_LEVEL_BASE: u64 = 512;
 /// The application settings.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
-    pub cert: PathBuf,       // Path to the certificate file
-    pub key: PathBuf,        // Path to the private key file
-    pub roots: Vec<PathBuf>, // Path to the rootCA file
+    pub cert: PathBuf, // Path to the certificate file
+    pub key: PathBuf,  // Path to the private key file
+    pub root: PathBuf, // Path to the rootCA file
     #[serde(deserialize_with = "deserialize_socket_addr")]
-    pub ingest_address: SocketAddr, // IP address & port to ingest data
+    pub ingest_srv_addr: SocketAddr, // IP address & port to ingest data
     #[serde(deserialize_with = "deserialize_socket_addr")]
-    pub publish_address: SocketAddr, // IP address & port to publish data
-    pub data_dir: PathBuf,   // DB storage path
+    pub publish_srv_addr: SocketAddr, // IP address & port to publish data
+    pub data_dir: PathBuf, // DB storage path
     #[serde(with = "humantime_serde")]
     pub retention: Duration, // Data retention period
     #[serde(deserialize_with = "deserialize_socket_addr")]
-    pub graphql_address: SocketAddr, // IP address & port to graphql
-    pub log_dir: PathBuf,    //giganto's syslog path
+    pub graphql_srv_addr: SocketAddr, // IP address & port to graphql
+    pub log_dir: PathBuf, //giganto's syslog path
     pub export_dir: PathBuf, //giganto's export file path
 
     // db options
@@ -104,11 +104,11 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .expect("default cert dir")
         .set_default("key", key_path.to_str().expect("path to string"))
         .expect("default key dir")
-        .set_default("ingest_address", DEFAULT_INGEST_ADDRESS)
+        .set_default("ingest_srv_addr", DEFAULT_INGEST_SRV_ADDR)
         .expect("valid address")
-        .set_default("publish_address", DEFAULT_PUBLISH_ADDRESS)
+        .set_default("publish_srv_addr", DEFAULT_PUBLISH_SRV_ADDR)
         .expect("valid address")
-        .set_default("graphql_address", DEFAULT_GRAPHQL_ADDRESS)
+        .set_default("graphql_srv_addr", DEFAULT_GRAPHQL_SRV_ADDR)
         .expect("local address")
         .set_default("data_dir", db_path)
         .expect("data dir")

--- a/tests/certs/node1/config.toml
+++ b/tests/certs/node1/config.toml
@@ -1,9 +1,9 @@
 key = "key.pem"
 cert = "cert.pem"
-roots = ["ca1.pem", "ca2.pem", "ca3.pem"]
-ingest_address = "0.0.0.0:38370"
-publish_address = "0.0.0.0:38371"
-graphql_address = "127.0.0.1:8442"
+root = "root.pem"
+ingest_srv_addr = "0.0.0.0:38370"
+publish_srv_addr = "0.0.0.0:38371"
+graphql_srv_addr = "127.0.0.1:8442"
 data_dir = "tests/data"
 retention = "100d"
 log_dir = "/data/logs/apps"


### PR DESCRIPTION
- Renamed configuration fields:
  - `ingest_address` to `ingest_srv_addr`.
  - `publish_address` to `publish_srv_addr`.
  - `graphql_address` to `graphql_srv_addr`.
- Changed `roots` to `root` to handle using a single root.

Close: #710