### PR TITLE
Modify rocks opt to improve compaction performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added graphql query `ping` and mutation `stop`, `reboot`, `shutdown`.
+- Added rocksdb's `increase_parallelism` option. This option is set by
+  reading the value from `number_of_thread` in config file.
+- Added rocksdb's `set_max_subcompactions` option. This option is set by
+  reading the value from `max_sub_compactions` in config file.
 
 ### Changed
 
@@ -29,6 +33,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `publish_address` to `publish_srv_addr`.
   - `graphql_address` to `graphql_srv_addr`.
   - `roots` to `root` to handle using a single root.
+
+### Removed
+
+- Remove `max_background_jobs` rocksdb option. This option is automatically set
+  to the appropriate value when `increase_parallelism` is set.
 
 ## [0.19.0] - 2024-02-22
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,22 @@ giganto <path to config file>
 In the config file, you can specify the following options:
 
 ```toml
-key = "key.pem"                            # path to private key file
-cert = "cert.pem"                          # path to certificate file
-root = "root.pem"                          # path to CA certificate file
-ingest_srv_addr = "0.0.0.0:38370"          # address to listen for ingest QUIC
-publish_srv_addr = "0.0.0.0:38371"         # address to listen for publish QUIC
-graphql_srv_addr = "127.0.0.1:8442"        # giganto's graphql address
-data_dir = "tests/data"                    # path to directory to store data
-retention = "100d"                         # retention period for data
-log_dir = "/data/logs/apps"                # path to giganto's syslog file
-export_dir = "tests/export"                # path to giganto's export file
-max_open_files = 8000                      # db options max open files,
-max_mb_of_level_base = 512                 # db options max MB of rocksDB Level 1
+key = "key.pem"                            # path to private key file.
+cert = "cert.pem"                          # path to certificate file.
+root = "root.pem"                          # path to CA certificate file.
+ingest_srv_addr = "0.0.0.0:38370"          # address to listen for ingest QUIC.
+publish_srv_addr = "0.0.0.0:38371"         # address to listen for publish QUIC.
+graphql_srv_addr = "127.0.0.1:8442"        # giganto's graphql address.
+data_dir = "tests/data"                    # path to directory to store data.
+retention = "100d"                         # retention period for data.
+log_dir = "/data/logs/apps"                # path to giganto's syslog file.
+export_dir = "tests/export"                # path to giganto's export file.
+max_open_files = 8000                      # db options max open files.
+max_mb_of_level_base = 512                 # db options max MB of rocksDB Level 1.
+num_of_thread = 8                          # db options for background thread.
+max_sub_compactions = 2                    # db options for sub-compaction.
 ack_transmission = 1024                    # ack count for ingestion data.
-peer_address = "10.10.11.1:38383"          # address to listen for peers QUIC
+peer_address = "10.10.11.1:38383"          # address to listen for peers QUIC.
 peers=[{address = "10.10.12.1:38383", host_name = "ai"}]     # list of peer info.
 ```
 
@@ -76,7 +78,7 @@ cargo run -- tests/config.toml
 
 ## License
 
-Copyright 2022-2023 ClumL Inc.
+Copyright 2022-2024 ClumL Inc.
 
 Licensed under [Apache License, Version 2.0][apache-license] (the "License");
 you may not use this crate except in compliance with the License.

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,12 @@ async fn main() -> Result<()> {
     let _guard = init_tracing(&settings.log_dir)?;
 
     let db_path = settings.data_dir.join("db");
-    let db_options =
-        crate::storage::DbOptions::new(settings.max_open_files, settings.max_mb_of_level_base);
+    let db_options = crate::storage::DbOptions::new(
+        settings.max_open_files,
+        settings.max_mb_of_level_base,
+        settings.num_of_thread,
+        settings.max_sub_compactions,
+    );
     if repair {
         let start = Instant::now();
         let (db_opts, _) = storage::rocksdb_options(&db_options);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,6 +12,8 @@ const DEFAULT_ACK_TRANSMISSION: u16 = 1024;
 const DEFAULT_RETENTION: &str = "100d";
 const DEFAULT_MAX_OPEN_FILES: i32 = 8000;
 const DEFAULT_MAX_MB_OF_LEVEL_BASE: u64 = 512;
+const DEFAULT_NUM_OF_THREAD: i32 = 8;
+const DEFAULT_MAX_SUBCOMPACTIONS: u32 = 2;
 
 /// The application settings.
 #[derive(Clone, Debug, Deserialize)]
@@ -34,6 +36,8 @@ pub struct Settings {
     // db options
     pub max_open_files: i32,
     pub max_mb_of_level_base: u64,
+    pub num_of_thread: i32,
+    pub max_sub_compactions: u32,
 
     // config file path
     pub cfg_path: String,
@@ -122,6 +126,10 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .expect("default max open files")
         .set_default("max_mb_of_level_base", DEFAULT_MAX_MB_OF_LEVEL_BASE)
         .expect("default max mb of level base")
+        .set_default("num_of_thread", DEFAULT_NUM_OF_THREAD)
+        .expect("default number of thread")
+        .set_default("max_sub_compactions", DEFAULT_MAX_SUBCOMPACTIONS)
+        .expect("default max subcompactions")
         .set_default("cfg_path", config_path.to_str().expect("path to string"))
         .expect("default config dir")
         .set_default("peer_address", DEFAULT_INVALID_PEER_ADDRESS)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -121,6 +121,8 @@ pub struct CfProperties {
 pub struct DbOptions {
     max_open_files: i32,
     max_mb_of_level_base: u64,
+    num_of_thread: i32,
+    max_sub_compactions: u32,
 }
 
 impl Default for DbOptions {
@@ -128,15 +130,24 @@ impl Default for DbOptions {
         Self {
             max_open_files: 8000,
             max_mb_of_level_base: 512,
+            num_of_thread: 8,
+            max_sub_compactions: 2,
         }
     }
 }
 
 impl DbOptions {
-    pub fn new(max_open_files: i32, max_mb_of_level_base: u64) -> Self {
+    pub fn new(
+        max_open_files: i32,
+        max_mb_of_level_base: u64,
+        num_of_thread: i32,
+        max_sub_compactions: u32,
+    ) -> Self {
         DbOptions {
             max_open_files,
             max_mb_of_level_base,
+            num_of_thread,
+            max_sub_compactions,
         }
     }
 }
@@ -974,7 +985,8 @@ pub(crate) fn rocksdb_options(db_options: &DbOptions) -> (Options, Options) {
     db_opts.set_stats_dump_period_sec(3600);
     db_opts.set_max_total_wal_size(max_bytes);
     db_opts.set_manual_wal_flush(true);
-    db_opts.set_max_background_jobs(6);
+    db_opts.increase_parallelism(db_options.num_of_thread);
+    db_opts.set_max_subcompactions(db_options.max_sub_compactions);
 
     let mut cf_opts = Options::default();
     cf_opts.set_write_buffer_size((max_bytes / 4).try_into().expect("u64 to usize"));

--- a/tests/certs/node1/config.toml
+++ b/tests/certs/node1/config.toml
@@ -11,7 +11,7 @@ export_dir = "tests/export"
 ack_transmission = 1024
 max_open_files = 8000
 max_mb_of_level_base = 512
-peer_address= "127.0.0.1:48383"
-peers=[
-	{ address = "127.0.0.1:60192", host_name = "node2"},
-]
+num_of_thread = 8
+max_sub_compactions = 2
+peer_address = "127.0.0.1:48383"
+peers = [{ address = "127.0.0.1:60192", host_name = "node2" }]


### PR DESCRIPTION
## PR 설명

- 이 pr에서는  rocksdb compaction 성능 향상을 위해 `increase_parallelism`/ `set_max_subcompactions` 옵션을 추가하였습니다.
- `increase_parallelism` 옵션은 rocksdb의 flush/ compaction 을 위한 thread 갯수를 설정 합니다. (기본: flush/compaction 각각 1 thread만 사용)
-  `set_max_subcompactions` 옵션은 rocksdb compaction시 해당 작업을 여러개로 분할하여 concurrently 하게 수행할 최대 thread 수를 설정합니다.(기본: 1 로 subcompaction 미사용을 의미)
- `increase_parallelism` / `set_max_subcompactions` 옵션을 적절히 줄 경우, compaction을 위한 background thread/ job이 증가하고,  compaction 작업을 분할해서 처리하게 되므로 compaction의 성능이 향상 될 것입니다.

Close: #732 