### PR TITLE
Support giganto-client 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Update giganto-client to version `0.17.0`. Updating to this version results
+  in the following changes.
+  - Bump dependencies.
+    - Update quinn to version `0.11`.
+    - Update rustls to version `0.23`.
+  - Fixed code and structures based on changes to the conn, http, smtp, ntlm,
+    ssh, tls protocols field.
+  - Update the compatibility version of the quic communication modules.
+    - Changed `PEER_VERSION_REQ` to ">=0.21.0-alpha.1,<0.22."
+    - Changed `INGEST_VERSION_REQ` to ">=0.21.0-alpha.1,<0.22."
+    - Changed `PUBLISH_VERSION_REQ` to ">=0.21.0-alpha.1,<0.22."
+  - Fixed code related to migration.
+    - Changed `COMPATIBLE_VERSION_REQ` to “>=0.21.0-alpha.1,<0.22.0”
+    - Added migration function in `migrate_0_19_to_0_21_0_alpha_1`. This feature
+      change values for conn, http, smtp, ntlm, ssh, tls protocol's fields in
+      versions `0.19.0` and later, and in versions prior to `0.21.0-alpha.1`.
+
 ## [0.20.0] - 2024-05-17
 
 ### Added
@@ -498,6 +519,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.20.0...main
 [0.20.0]: https://github.com/aicers/giganto/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/aicers/giganto/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/aicers/giganto/compare/0.17.0...0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +421,7 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.3",
+ "libloading",
 ]
 
 [[package]]
@@ -439,6 +445,16 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -900,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.20.0"
+version = "0.21.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -930,8 +946,8 @@ dependencies = [
  "reqwest",
  "rocksdb",
  "roxy",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls 0.23.6",
+ "rustls-pemfile",
  "semver",
  "serde",
  "serde_json",
@@ -950,8 +966,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.15.2"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.15.2#797e31ad7d06020deb5b4198ab35dc0c1237da96"
+version = "0.17.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.17.0#9747b0330e19b2b57c27d26eefa12884a8922c79"
 dependencies = [
  "anyhow",
  "bincode",
@@ -960,8 +976,8 @@ dependencies = [
  "quinn",
  "semver",
  "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -996,7 +1012,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
- "combine",
+ "combine 3.8.1",
  "thiserror",
 ]
 
@@ -1444,6 +1460,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine 4.6.7",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,16 +1514,6 @@ name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
-
-[[package]]
-name = "libloading"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libloading"
@@ -1664,7 +1690,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
@@ -1681,7 +1707,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
@@ -1937,14 +1963,14 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pcap"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e935fc73d54a89fff576526c2ccd42bbf8247aae05b358693475b14fd4ff79"
+checksum = "45f1686828a29fd8002fbf9c01506b4b2dd575c2305e1b884da3731abae8b9e0"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
  "libc",
- "libloading 0.6.7",
+ "libloading",
  "pkg-config",
  "regex",
  "windows-sys 0.36.1",
@@ -2172,16 +2198,16 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+checksum = "4bb80dc034523335a9fcc34271931dd97e9132d1fb078695db500339eb72e712"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.21.12",
+ "rustls 0.23.6",
  "thiserror",
  "tokio",
  "tracing",
@@ -2189,16 +2215,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+checksum = "a063a47a1aaee4b3b1c2dd44edb7867c10107a2ef171f3543ac40ec5e9092002"
 dependencies = [
  "bytes",
  "rand",
- "ring 0.16.20",
+ "ring",
  "rustc-hash",
- "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls 0.23.6",
+ "rustls-platform-verifier",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2207,15 +2233,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+checksum = "cb7ad7bc932e4968523fa7d9c320ee135ff779de720e9350fee8728838551764"
 dependencies = [
- "bytes",
  "libc",
+ "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2369,7 +2395,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2390,21 +2416,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -2413,8 +2424,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2492,49 +2503,43 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.3",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cf0812de1f0cee6b163ce35c2f57b90e1ef5a2bed57bcf07c16475bac8c852"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2554,14 +2559,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "b5f0d26fa1ce3c790f9590868f0109289a044acb954525f933e2aa3b871c157d"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.6",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-webpki"
@@ -2569,9 +2591,9 @@ version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2585,6 +2607,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -2617,16 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sdd"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2663,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -2848,12 +2870,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3411,12 +3427,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3473,6 +3483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,7 +3519,7 @@ dependencies = [
  "multer 2.1.0",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -3618,6 +3638,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.20.0"
+version = "0.21.0-alpha.1"
 edition = "2021"
 
 [lib]
@@ -23,22 +23,25 @@ data-encoding = "2.4"
 deluxe = "0.5"
 directories = "5.0"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.15.2" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.17.0" }
 graphql_client = "0.14"
 humantime = "2.1"
 humantime-serde = "1"
 libc = "0.2"
 num_enum = "0.7"
 num-traits = "0.2"
-pcap = "1"
+pcap = "2"
 proc-macro2 = "1.0"
-quinn = "0.10"
+quinn = { version = "0.11", features = ["ring"] }
 quote = "1.0"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
 rocksdb = "0.22"
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
-rustls = "0.21"
-rustls-pemfile = "1.0"
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+] }
+rustls-pemfile = "2.0"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/graphql/client/schema/conn_raw_events.graphql
+++ b/src/graphql/client/schema/conn_raw_events.graphql
@@ -15,6 +15,7 @@ query ConnRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
                 origPort
                 respPort
                 proto
+                connState
                 service
                 duration
                 origBytes

--- a/src/graphql/client/schema/http_raw_events.graphql
+++ b/src/graphql/client/schema/http_raw_events.graphql
@@ -36,6 +36,8 @@ query HttpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
                 origMimeTypes
                 respFilenames
                 respMimeTypes
+                postBody
+                state
             }
         }
     }

--- a/src/graphql/client/schema/network_raw_events.graphql
+++ b/src/graphql/client/schema/network_raw_events.graphql
@@ -17,6 +17,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     origPort
                     respPort
                     proto
+                    connState
                     service
                     duration
                     origBytes
@@ -73,6 +74,8 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     origMimeTypes
                     respFilenames
                     respMimeTypes
+                    postBody
+                    state
                 }
                 ... on RdpRawEvent {
                     timestamp
@@ -95,10 +98,8 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     username
                     hostname
                     domainname
-                    serverNbComputerName
-                    serverDnsComputerName
-                    serverTreeName
                     success
+                    protocol
                 }
                 ... on KerberosRawEvent {
                     timestamp
@@ -126,10 +127,6 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     respPort
                     proto
                     lastTime
-                    version
-                    authSuccess
-                    authAttempts
-                    direction
                     client
                     server
                     cipherAlg
@@ -137,7 +134,12 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     compressionAlg
                     kexAlg
                     hostKeyAlg
-                    hostKey
+                    hasshAlgorithms
+                    hassh
+                    hasshServerAlgorithms
+                    hasshServer
+                    clientShka
+                    serverShka
                 }
                 ... on DceRpcRawEvent {
                     timestamp
@@ -216,7 +218,10 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     alpnProtocol
                     ja3
                     version
+                    clientCipherSuites
+                    clientExtensions
                     cipher
+                    extensions
                     ja3S
                     serial
                     subjectCountry
@@ -276,6 +281,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     to
                     subject
                     agent
+                    state
                 }
             }
         }

--- a/src/graphql/client/schema/ntlm_raw_events.graphql
+++ b/src/graphql/client/schema/ntlm_raw_events.graphql
@@ -19,10 +19,8 @@ query NtlmRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
                 username
                 hostname
                 domainname
-                serverNbComputerName
-                serverDnsComputerName
-                serverTreeName
                 success
+                protocol
             }
         }
     }

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -5,6 +5,7 @@ type ConnRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
+  connState: String!
   duration: Int!
   service: String!
   origBytes: Int!
@@ -369,9 +370,9 @@ type FtpRawEventEdge {
 }
 
 type GigantoConfig {
-  ingestAddress: String!
-  publishAddress: String!
-  graphqlAddress: String!
+  ingestSrvAddr: String!
+  publishSrvAddr: String!
+  graphqlSrvAddr: String!
   retention: String!
   maxOpenFiles: Int!
   maxMbOfLevelBase: Int!
@@ -417,6 +418,8 @@ type HttpRawEvent {
   origMimeTypes: [String!]!
   respFilenames: [String!]!
   respMimeTypes: [String!]!
+  postBody: [Int!]!
+  state: String!
 }
 
 type HttpRawEventConnection {
@@ -864,10 +867,8 @@ type NtlmRawEvent {
   username: String!
   hostname: String!
   domainname: String!
-  serverNbComputerName: String!
-  serverDnsComputerName: String!
-  serverTreeName: String!
   success: String!
+  protocol: String!
 }
 
 type NtlmRawEventConnection {
@@ -1655,6 +1656,7 @@ type SmtpRawEvent {
   to: String!
   subject: String!
   agent: String!
+  state: String!
 }
 
 type SmtpRawEventConnection {
@@ -1685,10 +1687,6 @@ type SshRawEvent {
   respPort: Int!
   proto: Int!
   lastTime: Int!
-  version: Int!
-  authSuccess: String!
-  authAttempts: Int!
-  direction: String!
   client: String!
   server: String!
   cipherAlg: String!
@@ -1696,7 +1694,12 @@ type SshRawEvent {
   compressionAlg: String!
   kexAlg: String!
   hostKeyAlg: String!
-  hostKey: String!
+  hasshAlgorithms: String!
+  hassh: String!
+  hasshServerAlgorithms: String!
+  hasshServer: String!
+  clientShka: String!
+  serverShka: String!
 }
 
 type SshRawEventConnection {
@@ -1820,7 +1823,10 @@ type TlsRawEvent {
   alpnProtocol: String!
   ja3: String!
   version: String!
+  clientCipherSuites: [Int!]!
+  clientExtensions: [Int!]!
   cipher: Int!
+  extensions: [Int!]!
   ja3S: String!
   serial: String!
   subjectCountry: String!
@@ -1857,9 +1863,9 @@ type TlsRawEventEdge {
 }
 
 input UserConfig {
-  ingestAddress: String
-  publishAddress: String
-  graphqlAddress: String
+  ingestSrvAddr: String
+  publishSrvAddr: String
+  graphqlSrvAddr: String
   retention: String
   maxOpenFiles: Int
   maxMbOfLevelBase: Int

--- a/src/graphql/client/schema/smtp_raw_events.graphql
+++ b/src/graphql/client/schema/smtp_raw_events.graphql
@@ -22,6 +22,7 @@ query SmtpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
                 to
                 subject
                 agent
+                state
             }
         }
     }

--- a/src/graphql/client/schema/ssh_raw_events.graphql
+++ b/src/graphql/client/schema/ssh_raw_events.graphql
@@ -16,10 +16,6 @@ query SshRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
                 respPort
                 proto
                 lastTime
-                version
-                authSuccess
-                authAttempts
-                direction
                 client
                 server
                 cipherAlg
@@ -27,7 +23,12 @@ query SshRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
                 compressionAlg
                 kexAlg
                 hostKeyAlg
-                hostKey
+                hasshAlgorithms
+                hassh
+                hasshServerAlgorithms
+                hasshServer
+                clientShka
+                serverShka
             }
         }
     }

--- a/src/graphql/client/schema/tls_raw_events.graphql
+++ b/src/graphql/client/schema/tls_raw_events.graphql
@@ -20,7 +20,10 @@ query TlsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
                 alpnProtocol
                 ja3
                 version
+                clientCipherSuites
+                clientExtensions
                 cipher
+                extensions
                 ja3S
                 serial
                 subjectCountry

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -97,6 +97,7 @@ struct ConnJsonOutput {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
+    conn_state: String,
     duration: i64,
     service: String,
     orig_bytes: u64,
@@ -160,6 +161,8 @@ struct HttpJsonOutput {
     orig_mime_types: Vec<String>,
     resp_filenames: Vec<String>,
     resp_mime_types: Vec<String>,
+    post_body: Vec<u8>,
+    state: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -191,6 +194,7 @@ struct SmtpJsonOutput {
     to: String,
     subject: String,
     agent: String,
+    state: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -206,10 +210,8 @@ struct NtlmJsonOutput {
     username: String,
     hostname: String,
     domainname: String,
-    server_nb_computer_name: String,
-    server_dns_computer_name: String,
-    server_tree_name: String,
     success: String,
+    protocol: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -243,10 +245,6 @@ struct SshJsonOutput {
     resp_port: u16,
     proto: u8,
     last_time: i64,
-    version: i64,
-    auth_success: String,
-    auth_attempts: i64,
-    direction: String,
     client: String,
     server: String,
     cipher_alg: String,
@@ -254,7 +252,12 @@ struct SshJsonOutput {
     compression_alg: String,
     kex_alg: String,
     host_key_alg: String,
-    host_key: String,
+    hassh_algorithms: String,
+    hassh: String,
+    hassh_server_algorithms: String,
+    hassh_server: String,
+    client_shka: String,
+    server_shka: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -348,7 +351,10 @@ struct TlsJsonOutput {
     alpn_protocol: String,
     ja3: String,
     version: String,
+    client_cipher_suites: Vec<u16>,
+    client_extensions: Vec<u16>,
     cipher: u16,
+    extensions: Vec<u16>,
     ja3s: String,
     serial: String,
     subject_country: String,
@@ -773,7 +779,9 @@ convert_json_output!(
     orig_filenames,
     orig_mime_types,
     resp_filenames,
-    resp_mime_types
+    resp_mime_types,
+    post_body,
+    state
 );
 
 convert_json_output!(RdpJsonOutput, Rdp, cookie);
@@ -786,7 +794,8 @@ convert_json_output!(
     from,
     to,
     subject,
-    agent
+    agent,
+    state
 );
 
 convert_json_output!(
@@ -795,10 +804,8 @@ convert_json_output!(
     username,
     hostname,
     domainname,
-    server_nb_computer_name,
-    server_dns_computer_name,
-    server_tree_name,
-    success
+    success,
+    protocol
 );
 
 convert_json_output!(
@@ -818,10 +825,6 @@ convert_json_output!(
 convert_json_output!(
     SshJsonOutput,
     Ssh,
-    version,
-    auth_success,
-    auth_attempts,
-    direction,
     client,
     server,
     cipher_alg,
@@ -829,7 +832,12 @@ convert_json_output!(
     compression_alg,
     kex_alg,
     host_key_alg,
-    host_key
+    hassh_algorithms,
+    hassh,
+    hassh_server_algorithms,
+    hassh_server,
+    client_shka,
+    server_shka
 );
 
 convert_json_output!(
@@ -860,7 +868,10 @@ convert_json_output!(
     alpn_protocol,
     ja3,
     version,
+    client_cipher_suites,
+    client_extensions,
     cipher,
+    extensions,
     ja3s,
     serial,
     subject_country,
@@ -904,6 +915,7 @@ impl JsonOutput<ConnJsonOutput> for Conn {
             resp_addr: self.resp_addr.to_string(),
             resp_port: self.resp_port,
             proto: self.proto,
+            conn_state: self.conn_state.clone(),
             duration: self.duration,
             service: self.service.clone(),
             orig_bytes: self.orig_bytes,

--- a/src/graphql/export/tests.rs
+++ b/src/graphql/export/tests.rs
@@ -133,6 +133,7 @@ fn insert_conn_raw_event(store: &RawEventStore<Conn>, source: &str, timestamp: i
         resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         resp_port: 80,
         proto: 6,
+        conn_state: "sf".to_string(),
         duration: tmp_dur.num_nanoseconds().unwrap(),
         service: "-".to_string(),
         orig_bytes: 77,
@@ -307,6 +308,8 @@ fn insert_http_raw_event(store: &RawEventStore<Http>, source: &str, timestamp: i
         orig_mime_types: Vec::new(),
         resp_filenames: Vec::new(),
         resp_mime_types: Vec::new(),
+        post_body: Vec::new(),
+        state: String::new(),
     };
     let ser_http_body = bincode::serialize(&http_body).unwrap();
 
@@ -450,6 +453,7 @@ fn insert_smtp_raw_event(store: &RawEventStore<Smtp>, source: &str, timestamp: i
         to: "to".to_string(),
         subject: "subject".to_string(),
         agent: "agent".to_string(),
+        state: String::new(),
     };
     let ser_smtp_body = bincode::serialize(&smtp_body).unwrap();
 
@@ -521,10 +525,8 @@ fn insert_ntlm_raw_event(store: &RawEventStore<Ntlm>, source: &str, timestamp: i
         username: "bly".to_string(),
         hostname: "host".to_string(),
         domainname: "domain".to_string(),
-        server_nb_computer_name: "NB".to_string(),
-        server_dns_computer_name: "dns".to_string(),
-        server_tree_name: "tree".to_string(),
         success: "tf".to_string(),
+        protocol: "protocol".to_string(),
     };
     let ser_ntlm_body = bincode::serialize(&ntlm_body).unwrap();
 
@@ -669,10 +671,6 @@ fn insert_ssh_raw_event(store: &RawEventStore<Ssh>, source: &str, timestamp: i64
         resp_port: 80,
         proto: 6,
         last_time: 1,
-        version: 01,
-        auth_success: "auth_success".to_string(),
-        auth_attempts: 3,
-        direction: "direction".to_string(),
         client: "client".to_string(),
         server: "server".to_string(),
         cipher_alg: "cipher_alg".to_string(),
@@ -680,7 +678,12 @@ fn insert_ssh_raw_event(store: &RawEventStore<Ssh>, source: &str, timestamp: i64
         compression_alg: "compression_alg".to_string(),
         kex_alg: "kex_alg".to_string(),
         host_key_alg: "host_key_alg".to_string(),
-        host_key: "host_key".to_string(),
+        hassh_algorithms: "hassh_algorithms".to_string(),
+        hassh: "hassh".to_string(),
+        hassh_server_algorithms: "hassh_server_algorithms".to_string(),
+        hassh_server: "hassh_server".to_string(),
+        client_shka: "client_shka".to_string(),
+        server_shka: "server_shka".to_string(),
     };
     let ser_ssh_body = bincode::serialize(&ssh_body).unwrap();
 
@@ -1243,7 +1246,10 @@ fn insert_tls_raw_event(store: &RawEventStore<Tls>, source: &str, timestamp: i64
         alpn_protocol: "alpn_protocol".to_string(),
         ja3: "ja3".to_string(),
         version: "version".to_string(),
+        client_cipher_suites: vec![771, 769, 770],
+        client_extensions: vec![0, 1, 2],
         cipher: 10,
+        extensions: vec![0, 1],
         ja3s: "ja3s".to_string(),
         serial: "serial".to_string(),
         subject_country: "sub_country".to_string(),

--- a/src/graphql/network/tests.rs
+++ b/src/graphql/network/tests.rs
@@ -150,6 +150,7 @@ fn insert_conn_raw_event(store: &RawEventStore<Conn>, source: &str, timestamp: i
         resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
         resp_port: 80,
         proto: 6,
+        conn_state: "sf".to_string(),
         duration: tmp_dur.num_nanoseconds().unwrap(),
         service: "-".to_string(),
         orig_bytes: 77,
@@ -207,6 +208,7 @@ async fn conn_with_data_giganto_cluster() {
                             "origPort": 46378,
                             "respPort": 443,
                             "proto": 6,
+                            "connState": "-",
                             "service": "-",
                             "duration": 324234,
                             "origBytes": 0,
@@ -220,7 +222,6 @@ async fn conn_with_data_giganto_cluster() {
         }
     }
     "#;
-
     let mock = peer_server
         .mock("POST", "/graphql")
         .with_status(200)
@@ -670,6 +671,8 @@ fn insert_http_raw_event(store: &RawEventStore<Http>, source: &str, timestamp: i
         orig_mime_types: Vec::new(),
         resp_filenames: Vec::new(),
         resp_mime_types: Vec::new(),
+        post_body: Vec::new(),
+        state: String::new(),
     };
     let ser_http_body = bincode::serialize(&http_body).unwrap();
 
@@ -753,7 +756,12 @@ async fn http_with_data_giganto_cluster() {
                             "respMimeTypes": [
                                 "text/plain",
                                 "text/plain"
-                                ]
+                            ],
+                            "postBody": [
+                                200,
+                                300
+                            ],
+                            "state": "OK"
                             }
                         }
                     ]
@@ -1061,6 +1069,7 @@ fn insert_smtp_raw_event(store: &RawEventStore<Smtp>, source: &str, timestamp: i
         to: "to".to_string(),
         subject: "subject".to_string(),
         agent: "agent".to_string(),
+        state: String::new(),
     };
     let ser_smtp_body = bincode::serialize(&smtp_body).unwrap();
 
@@ -1111,7 +1120,8 @@ async fn smtp_with_data_giganto_cluster() {
                             "from": "sender@example.com",
                             "to": "recipient@example.com",
                             "subject": "Test Email",
-                            "agent": "SMTP Client 1.0"
+                            "agent": "SMTP Client 1.0",
+                            "state": "OK"
                         }
                     }
                 ]
@@ -1191,10 +1201,8 @@ fn insert_ntlm_raw_event(store: &RawEventStore<Ntlm>, source: &str, timestamp: i
         username: "bly".to_string(),
         hostname: "host".to_string(),
         domainname: "domain".to_string(),
-        server_nb_computer_name: "NB".to_string(),
-        server_dns_computer_name: "dns".to_string(),
-        server_tree_name: "tree".to_string(),
         success: "tf".to_string(),
+        protocol: "protocol".to_string(),
     };
     let ser_ntlm_body = bincode::serialize(&ntlm_body).unwrap();
 
@@ -1243,10 +1251,8 @@ async fn ntlm_with_data_giganto_cluster() {
                             "username": "john_doe",
                             "hostname": "client_machine",
                             "domainname": "example.com",
-                            "serverNbComputerName": "server_nb_computer",
-                            "serverDnsComputerName": "server_dns_computer",
-                            "serverTreeName": "server_tree",
-                            "success": "true"
+                            "success": "true",
+                            "protocol": "6"
                         }
                     }
                 ]
@@ -1467,10 +1473,6 @@ fn insert_ssh_raw_event(store: &RawEventStore<Ssh>, source: &str, timestamp: i64
         resp_port: 80,
         proto: 17,
         last_time: 1,
-        version: 01,
-        auth_success: "auth_success".to_string(),
-        auth_attempts: 3,
-        direction: "direction".to_string(),
         client: "client".to_string(),
         server: "server".to_string(),
         cipher_alg: "cipher_alg".to_string(),
@@ -1478,7 +1480,12 @@ fn insert_ssh_raw_event(store: &RawEventStore<Ssh>, source: &str, timestamp: i64
         compression_alg: "compression_alg".to_string(),
         kex_alg: "kex_alg".to_string(),
         host_key_alg: "host_key_alg".to_string(),
-        host_key: "host_key".to_string(),
+        hassh_algorithms: "hassh_algorithms".to_string(),
+        hassh: "hassh".to_string(),
+        hassh_server_algorithms: "hassh_server_algorithms".to_string(),
+        hassh_server: "hassh_server".to_string(),
+        client_shka: "client_shka".to_string(),
+        server_shka: "server_shka".to_string(),
     };
     let ser_ssh_body = bincode::serialize(&ssh_body).unwrap();
 
@@ -1524,10 +1531,6 @@ async fn ssh_with_data_giganto_cluster() {
                             "respPort": 54321,
                             "proto": 6,
                             "lastTime": 987654321,
-                            "version": 2,
-                            "authSuccess": "true",
-                            "authAttempts": 3,
-                            "direction": "inbound",
                             "client": "ssh_client",
                             "server": "ssh_server",
                             "cipherAlg": "aes256-ctr",
@@ -1535,7 +1538,12 @@ async fn ssh_with_data_giganto_cluster() {
                             "compressionAlg": "none",
                             "kexAlg": "diffie-hellman-group14-sha1",
                             "hostKeyAlg": "ssh-rsa",
-                            "hostKey": "ssh_host_key"
+                            "hasshAlgorithms": "hassh_algorithms",
+                            "hassh": "hassh",
+                            "hasshServerAlgorithms": "hassh_server_algorithms",
+                            "hasshServer": "hassh_server",
+                            "clientShka": "client_shka",
+                            "serverShka": "server_shka"
                         }
                     }
                 ]
@@ -2177,7 +2185,10 @@ fn insert_tls_raw_event(store: &RawEventStore<Tls>, source: &str, timestamp: i64
         alpn_protocol: "alpn_protocol".to_string(),
         ja3: "ja3".to_string(),
         version: "version".to_string(),
+        client_cipher_suites: vec![771, 769, 770],
+        client_extensions: vec![0, 1, 2],
         cipher: 10,
+        extensions: vec![0, 1],
         ja3s: "ja3s".to_string(),
         serial: "serial".to_string(),
         subject_country: "sub_country".to_string(),
@@ -2240,7 +2251,21 @@ async fn tls_with_data_giganto_cluster() {
                             "alpnProtocol": "h2",
                             "ja3": "aabbccddeeff",
                             "version": "TLSv1.2",
+                            "clientCipherSuites": [
+                                771,
+                                769,
+                                770
+                            ],
+                            "clientExtensions": [
+                                0,
+                                1,
+                                2
+                            ],
                             "cipher": 256,
+                            "extensions": [
+                                0,
+                                1
+                            ],
                             "ja3S": "1122334455",
                             "serial": "1234567890",
                             "subjectCountry": "US",

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -56,7 +56,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-const PUBLISH_VERSION_REQ: &str = ">=0.17.0,<0.21.0";
+const PUBLISH_VERSION_REQ: &str = ">=0.21.0-alpha.1,<0.22.0";
 
 pub struct Server {
     server_config: ServerConfig,
@@ -134,7 +134,7 @@ impl Server {
 
 #[allow(clippy::too_many_arguments)]
 async fn handle_connection(
-    conn: quinn::Connecting,
+    conn: quinn::Incoming,
     db: Database,
     pcap_sources: PcapSources,
     stream_direct_channels: StreamDirectChannels,
@@ -1842,7 +1842,7 @@ where
         )
     }
     send_range_data::<T>(send, None).await?;
-    send.finish().await?;
+    send.finish()?;
     Ok(())
 }
 
@@ -1983,7 +1983,7 @@ where
     }
 
     send_range_data::<T>(send, None).await?;
-    send.finish().await?;
+    send.finish()?;
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,12 @@
 use anyhow::{bail, Context, Result};
-use quinn::{ClientConfig, Connection, ServerConfig, TransportConfig};
-use rustls::{Certificate, PrivateKey, RootCertStore};
+use quinn::{
+    crypto::rustls::{QuicClientConfig, QuicServerConfig},
+    ClientConfig, Connection, ServerConfig, TransportConfig,
+};
+use rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    RootCertStore,
+};
 use std::{sync::Arc, time::Duration};
 use tracing::info;
 use x509_parser::nom::Parser;
@@ -11,23 +17,34 @@ pub const SERVER_CONNNECTION_DELAY: u64 = 200;
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_millis(5_000);
 
 #[allow(clippy::module_name_repetitions, clippy::struct_field_names)]
-#[derive(Clone)]
 pub struct Certs {
-    pub certs: Vec<Certificate>,
-    pub key: PrivateKey,
+    pub certs: Vec<CertificateDer<'static>>,
+    pub key: PrivateKeyDer<'static>,
     pub root: RootCertStore,
+}
+
+impl Clone for Certs {
+    fn clone(&self) -> Self {
+        Self {
+            certs: self.certs.clone(),
+            key: self.key.clone_key(),
+            root: self.root.clone(),
+        }
+    }
 }
 
 #[allow(clippy::module_name_repetitions)]
 pub fn config_server(certs: &Arc<Certs>) -> Result<ServerConfig> {
-    let client_auth = rustls::server::AllowAnyAuthenticatedClient::new(certs.root.clone()).boxed();
+    let client_auth =
+        rustls::server::WebPkiClientVerifier::builder(Arc::new(certs.root.clone())).build()?;
+
     let server_crypto = rustls::ServerConfig::builder()
-        .with_safe_defaults()
         .with_client_cert_verifier(client_auth)
-        .with_single_cert(certs.certs.clone(), certs.key.clone())
+        .with_single_cert(certs.certs.clone(), certs.key.clone_key())
         .context("server config error")?;
 
-    let mut server_config = ServerConfig::with_crypto(Arc::new(server_crypto));
+    let mut server_config =
+        ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(server_crypto)?));
 
     Arc::get_mut(&mut server_config.transport)
         .expect("safe value")
@@ -36,20 +53,17 @@ pub fn config_server(certs: &Arc<Certs>) -> Result<ServerConfig> {
     Ok(server_config)
 }
 
-pub fn extract_cert_from_conn(connection: &Connection) -> Result<Vec<Certificate>> {
+pub fn extract_cert_from_conn(connection: &Connection) -> Result<Vec<CertificateDer>> {
     let Some(conn_info) = connection.peer_identity() else {
         bail!("no peer identity");
     };
-    let Some(cert_info) = conn_info
-        .downcast_ref::<Vec<rustls::Certificate>>()
-        .cloned()
-    else {
+    let Some(cert_info) = conn_info.downcast_ref::<Vec<CertificateDer>>().cloned() else {
         bail!("non-certificate identity");
     };
     Ok(cert_info)
 }
 
-pub fn certificate_info(cert_info: &[Certificate]) -> Result<(String, String)> {
+pub fn certificate_info(cert_info: &[CertificateDer]) -> Result<(String, String)> {
     let Some(cert) = cert_info.first() else {
         bail!("no certificate in identity");
     };
@@ -76,14 +90,13 @@ pub fn certificate_info(cert_info: &[Certificate]) -> Result<(String, String)> {
 
 pub fn config_client(certs: &Arc<Certs>) -> Result<ClientConfig> {
     let tls_config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(certs.root.clone())
-        .with_client_auth_cert(certs.certs.clone(), certs.key.clone())?;
+        .with_client_auth_cert(certs.certs.clone(), certs.key.clone_key())?;
 
     let mut transport = TransportConfig::default();
     transport.keep_alive_interval(Some(KEEP_ALIVE_INTERVAL));
 
-    let mut config = ClientConfig::new(Arc::new(tls_config));
+    let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config)?));
     config.transport_config(Arc::new(transport));
     Ok(config)
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,12 +8,11 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+pub use giganto_client::ingest::network::{Conn, Http, Ntlm, Smtp, Ssh, Tls};
 use giganto_client::ingest::{
     log::{Log, OpLog, SecuLog},
     netflow::{Netflow5, Netflow9},
-    network::{
-        Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp, Ssh, Tls,
-    },
+    network::{DceRpc, Dns, Ftp, Kerberos, Ldap, Mqtt, Nfs, Rdp, Smb},
     statistics::Statistics,
     sysmon::{
         DnsEvent, FileCreate, FileCreateStreamHash, FileCreationTimeChanged, FileDelete,

--- a/src/storage/migration/migration_structures.rs
+++ b/src/storage/migration/migration_structures.rs
@@ -1,0 +1,342 @@
+use crate::storage::{
+    Conn as ConnFromV21, Http as HttpFromV21, Ntlm as NtlmFromV21, Smtp as SmtpFromV21,
+    Ssh as SshFromV21, Tls as TlsFromV21,
+};
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+#[derive(Deserialize, Serialize)]
+pub struct HttpBeforeV12 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct HttpFromV12BeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+    pub orig_filenames: Vec<String>,
+    pub orig_mime_types: Vec<String>,
+    pub resp_filenames: Vec<String>,
+    pub resp_mime_types: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ConnBeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub duration: i64,
+    pub service: String,
+    pub orig_bytes: u64,
+    pub resp_bytes: u64,
+    pub orig_pkts: u64,
+    pub resp_pkts: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct SmtpBeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub mailfrom: String,
+    pub date: String,
+    pub from: String,
+    pub to: String,
+    pub subject: String,
+    pub agent: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct NtlmBeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub username: String,
+    pub hostname: String,
+    pub domainname: String,
+    pub server_nb_computer_name: String,
+    pub server_dns_computer_name: String,
+    pub server_tree_name: String,
+    pub success: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct SshBeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub version: i64,
+    pub auth_success: String,
+    pub auth_attempts: i64,
+    pub direction: String,
+    pub client: String,
+    pub server: String,
+    pub cipher_alg: String,
+    pub mac_alg: String,
+    pub compression_alg: String,
+    pub kex_alg: String,
+    pub host_key_alg: String,
+    pub host_key: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct TlsBeforeV21 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub server_name: String,
+    pub alpn_protocol: String,
+    pub ja3: String,
+    pub version: String,
+    pub cipher: u16,
+    pub ja3s: String,
+    pub serial: String,
+    pub subject_country: String,
+    pub subject_org_name: String,
+    pub subject_common_name: String,
+    pub validity_not_before: i64,
+    pub validity_not_after: i64,
+    pub subject_alt_name: String,
+    pub issuer_country: String,
+    pub issuer_org_name: String,
+    pub issuer_org_unit_name: String,
+    pub issuer_common_name: String,
+    pub last_alert: u8,
+}
+
+impl From<HttpBeforeV12> for HttpFromV12BeforeV21 {
+    fn from(input: HttpBeforeV12) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referrer: input.referrer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: vec!["-".to_string()],
+            orig_mime_types: vec!["-".to_string()],
+            resp_filenames: vec!["-".to_string()],
+            resp_mime_types: vec!["-".to_string()],
+        }
+    }
+}
+
+impl From<ConnBeforeV21> for ConnFromV21 {
+    fn from(input: ConnBeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            conn_state: String::new(),
+            duration: input.duration,
+            service: input.service,
+            orig_bytes: input.orig_bytes,
+            resp_bytes: input.resp_bytes,
+            orig_pkts: input.orig_pkts,
+            resp_pkts: input.resp_pkts,
+        }
+    }
+}
+
+impl From<HttpFromV12BeforeV21> for HttpFromV21 {
+    fn from(input: HttpFromV12BeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referrer: input.referrer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
+            post_body: Vec::new(),
+            state: String::new(),
+        }
+    }
+}
+impl From<SmtpBeforeV21> for SmtpFromV21 {
+    fn from(input: SmtpBeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            mailfrom: input.mailfrom,
+            date: input.date,
+            from: input.from,
+            to: input.to,
+            subject: input.subject,
+            agent: input.agent,
+            state: String::new(),
+        }
+    }
+}
+impl From<NtlmBeforeV21> for NtlmFromV21 {
+    fn from(input: NtlmBeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            protocol: String::new(),
+            username: input.username,
+            hostname: input.hostname,
+            domainname: input.domainname,
+            success: input.success,
+        }
+    }
+}
+impl From<SshBeforeV21> for SshFromV21 {
+    fn from(input: SshBeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            client: input.client,
+            server: input.server,
+            cipher_alg: input.cipher_alg,
+            mac_alg: input.mac_alg,
+            compression_alg: input.compression_alg,
+            kex_alg: input.kex_alg,
+            host_key_alg: input.host_key_alg,
+            hassh_algorithms: String::new(),
+            hassh: String::new(),
+            hassh_server_algorithms: String::new(),
+            hassh_server: String::new(),
+            client_shka: String::new(),
+            server_shka: String::new(),
+        }
+    }
+}
+
+impl From<TlsBeforeV21> for TlsFromV21 {
+    fn from(input: TlsBeforeV21) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            server_name: input.server_name,
+            alpn_protocol: input.alpn_protocol,
+            ja3: input.ja3,
+            version: input.version,
+            client_cipher_suites: Vec::new(),
+            client_extensions: Vec::new(),
+            cipher: input.cipher,
+            extensions: Vec::new(),
+            ja3s: input.ja3s,
+            serial: input.serial,
+            subject_country: input.subject_country,
+            subject_org_name: input.subject_org_name,
+            subject_common_name: input.subject_common_name,
+            validity_not_before: input.validity_not_before,
+            validity_not_after: input.validity_not_after,
+            subject_alt_name: input.subject_alt_name,
+            issuer_country: input.issuer_country,
+            issuer_org_name: input.issuer_org_name,
+            issuer_org_unit_name: input.issuer_org_unit_name,
+            issuer_common_name: input.issuer_common_name,
+            last_alert: input.last_alert,
+        }
+    }
+}


### PR DESCRIPTION
- Update quinn, rustls version.
- Fixed code and structures based on changes to the conn, http, smtp, ntlm, ssh, tls protocols field.
- Update the compatibility version of the quic communication modules.
- Update the compatibility version for migration.
- Added migration function `migrate_0_19_to_0_21_0_alpha_1`.

Close: #730