### PR TITLE
Support giganto-client 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     requests are submitted.
   - Add `--config group_imports=StdExternalCrate` to the CI process like:
     - `cargo fmt -- --check --config group_imports=StdExternalCrate`
+- Update giganto-client to version `0.19.0`. Updating to this version results
+  in the following changes.
+  - Support bootp, dhcp events.
+  - Fixed code and structures based on changes to the conn protocols field.
+  - Update the compatibility version of the quic communication modules.
+    - Changed `PEER_VERSION_REQ` to ">=0.21.0-alpha.2,<0.22."
+    - Changed `INGEST_VERSION_REQ` to ">=0.21.0-alpha.2,<0.22."
+    - Changed `PUBLISH_VERSION_REQ` to ">=0.21.0-alpha.2,<0.22."
+  - Fixed code related to migration.
+    - Changed `COMPATIBLE_VERSION_REQ` to “>=0.21.0-alpha.2,<0.22.0”
+    - Added migration function in `migrate_0_21_0_alpha_1_to_0_21_0_alpha_2`.
+      This feature performs migration for changes to the conn protocol field
+      in version `0.21.0-alpha.2`.
 
 ## [0.20.0] - 2024-05-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.21.0-alpha.1"
+version = "0.21.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1017,8 +1017,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.17.0"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.17.0#9747b0330e19b2b57c27d26eefa12884a8922c79"
+version = "0.19.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.19.0#e8f25b78a3a465eb203c3802eb19675ba4294279"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.21.0-alpha.1"
+version = "0.21.0-alpha.2"
 edition = "2021"
 
 [lib]
@@ -23,7 +23,7 @@ data-encoding = "2.4"
 deluxe = "0.5"
 directories = "5.0"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.17.0" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.19.0" }
 graphql_client = "0.14"
 humantime = "2.1"
 humantime-serde = "1"

--- a/src/graphql/client/derives.rs
+++ b/src/graphql/client/derives.rs
@@ -64,6 +64,22 @@ pub struct RdpRawEvents;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/graphql/client/schema/schema.graphql",
+    query_path = "src/graphql/client/schema/bootp_raw_events.graphql",
+    response_derives = "Clone, Default, PartialEq"
+)]
+pub struct BootpRawEvents;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/client/schema/schema.graphql",
+    query_path = "src/graphql/client/schema/dhcp_raw_events.graphql",
+    response_derives = "Clone, Default, PartialEq"
+)]
+pub struct DhcpRawEvents;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/client/schema/schema.graphql",
     query_path = "src/graphql/client/schema/periodic_time_series.graphql",
     response_derives = "Clone, Default, PartialEq"
 )]
@@ -396,6 +412,22 @@ pub struct SearchSmbRawEvents;
     response_derives = "Clone, Default, PartialEq"
 )]
 pub struct SearchNfsRawEvents;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/client/schema/schema.graphql",
+    query_path = "src/graphql/client/schema/search_bootp_raw_events.graphql",
+    response_derives = "Clone, Default, PartialEq"
+)]
+pub struct SearchBootpRawEvents;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/client/schema/schema.graphql",
+    query_path = "src/graphql/client/schema/search_dhcp_raw_events.graphql",
+    response_derives = "Clone, Default, PartialEq"
+)]
+pub struct SearchDhcpRawEvents;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/graphql/client/schema/bootp_raw_events.graphql
+++ b/src/graphql/client/schema/bootp_raw_events.graphql
@@ -1,0 +1,33 @@
+query BootpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
+    bootpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+            startCursor
+            endCursor
+        }
+        edges {
+            cursor
+            node {
+                timestamp
+                origAddr
+                respAddr
+                origPort
+                respPort
+                proto
+                lastTime
+                op
+                htype
+                hops
+                xid
+                ciaddr
+                yiaddr
+                siaddr
+                giaddr
+                chwaddr
+                sname
+                file
+            }
+        }
+    }
+}

--- a/src/graphql/client/schema/conn_raw_events.graphql
+++ b/src/graphql/client/schema/conn_raw_events.graphql
@@ -22,6 +22,8 @@ query ConnRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
                 respBytes
                 origPkts
                 respPkts
+                origL2Bytes
+                respL2Bytes
             }
         }
     }

--- a/src/graphql/client/schema/dhcp_raw_events.graphql
+++ b/src/graphql/client/schema/dhcp_raw_events.graphql
@@ -1,0 +1,40 @@
+query DhcpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
+    dhcpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+        pageInfo {
+            hasPreviousPage
+            hasNextPage
+            startCursor
+            endCursor
+        }
+        edges {
+            cursor
+            node {
+                timestamp
+                origAddr
+                respAddr
+                origPort
+                respPort
+                proto
+                lastTime
+                msgType
+                ciaddr
+                yiaddr
+                siaddr
+                giaddr
+                subnetMask
+                router
+                domainNameServer
+                reqIpAddr
+                leaseTime
+                serverId
+                paramReqList
+                message
+                renewalTime
+                rebindingTime
+                classId
+                clientIdType
+                clientId
+            }
+        }
+    }
+}

--- a/src/graphql/client/schema/network_raw_events.graphql
+++ b/src/graphql/client/schema/network_raw_events.graphql
@@ -24,6 +24,8 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     respBytes
                     origPkts
                     respPkts
+                    origL2Bytes
+                    respL2Bytes
                 }
                 ... on DnsRawEvent {
                     timestamp
@@ -282,6 +284,53 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                     subject
                     agent
                     state
+                }
+                ... on BootpRawEvent {
+                    timestamp
+                    origAddr
+                    respAddr
+                    origPort
+                    respPort
+                    proto
+                    lastTime
+                    op
+                    htype
+                    hops
+                    xid
+                    ciaddr
+                    yiaddr
+                    siaddr
+                    giaddr
+                    chwaddr
+                    sname
+                    file
+                }
+                ... on DhcpRawEvent {
+                    timestamp
+                    origAddr
+                    respAddr
+                    origPort
+                    respPort
+                    proto
+                    lastTime
+                    msgType
+                    ciaddr
+                    yiaddr
+                    siaddr
+                    giaddr
+                    subnetMask
+                    router
+                    domainNameServer
+                    reqIpAddr
+                    leaseTime
+                    serverId
+                    paramReqList
+                    message
+                    renewalTime
+                    rebindingTime
+                    classId
+                    clientIdType
+                    clientId
                 }
             }
         }

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -1,3 +1,44 @@
+type BootpRawEvent {
+  timestamp: DateTime!
+  origAddr: String!
+  origPort: Int!
+  respAddr: String!
+  respPort: Int!
+  proto: Int!
+  lastTime: Int!
+  op: Int!
+  htype: Int!
+  hops: Int!
+  xid: Int!
+  ciaddr: String!
+  yiaddr: String!
+  siaddr: String!
+  giaddr: String!
+  chwaddr: [Int!]!
+  sname: String!
+  file: String!
+}
+
+type BootpRawEventConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [BootpRawEventEdge!]!
+
+  # A list of nodes.
+  nodes: [BootpRawEvent!]!
+}
+
+# An edge in a connection.
+type BootpRawEventEdge {
+  # The item at the end of the edge
+  node: BootpRawEvent!
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
 type ConnRawEvent {
   timestamp: DateTime!
   origAddr: String!
@@ -12,6 +53,8 @@ type ConnRawEvent {
   respBytes: Int!
   origPkts: Int!
   respPkts: Int!
+  origL2Bytes: Int!
+  respL2Bytes: Int!
 }
 
 type ConnRawEventConnection {
@@ -68,6 +111,54 @@ type DceRpcRawEventConnection {
 type DceRpcRawEventEdge {
   # The item at the end of the edge
   node: DceRpcRawEvent!
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+type DhcpRawEvent {
+  timestamp: DateTime!
+  origAddr: String!
+  origPort: Int!
+  respAddr: String!
+  respPort: Int!
+  proto: Int!
+  lastTime: Int!
+  msgType: Int!
+  ciaddr: String!
+  yiaddr: String!
+  siaddr: String!
+  giaddr: String!
+  subnetMask: String!
+  router: [String!]!
+  domainNameServer: [String!]!
+  reqIpAddr: String!
+  leaseTime: Int!
+  serverId: String!
+  paramReqList: [Int!]!
+  message: String!
+  renewalTime: Int!
+  rebindingTime: Int!
+  classId: [Int!]!
+  clientIdType: Int!
+  clientId: [Int!]!
+}
+
+type DhcpRawEventConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [DhcpRawEventEdge!]!
+
+  # A list of nodes.
+  nodes: [DhcpRawEvent!]!
+}
+
+# An edge in a connection.
+type DhcpRawEventEdge {
+  # The item at the end of the edge
+  node: DhcpRawEvent!
 
   # A cursor for use in pagination
   cursor: String!
@@ -803,6 +894,8 @@ union NetworkRawEvents =
   | SmbRawEvent
   | NfsRawEvent
   | SmtpRawEvent
+  | BootpRawEvent
+  | DhcpRawEvent
 
 type NetworkRawEventsConnection {
   # Information to aid in pagination.
@@ -1256,6 +1349,20 @@ type Query {
     first: Int
     last: Int
   ): NfsRawEventConnection!
+  bootpRawEvents(
+    filter: NetworkFilter!
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): BootpRawEventConnection!
+  dhcpRawEvents(
+    filter: NetworkFilter!
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): DhcpRawEventConnection!
   networkRawEvents(
     filter: NetworkFilter!
     after: String
@@ -1278,6 +1385,8 @@ type Query {
   searchTlsRawEvents(filter: SearchFilter!): [DateTime!]!
   searchSmbRawEvents(filter: SearchFilter!): [DateTime!]!
   searchNfsRawEvents(filter: SearchFilter!): [DateTime!]!
+  searchBootpRawEvents(filter: SearchFilter!): [DateTime!]!
+  searchDhcpRawEvents(filter: SearchFilter!): [DateTime!]!
   export(exportType: String!, filter: ExportFilter!): String!
   packets(
     filter: PacketFilter!

--- a/src/graphql/client/schema/search_bootp_raw_events.graphql
+++ b/src/graphql/client/schema/search_bootp_raw_events.graphql
@@ -1,0 +1,3 @@
+query SearchBootpRawEvents($filter: SearchFilter!){
+    searchBootpRawEvents(filter: $filter)
+}

--- a/src/graphql/client/schema/search_dhcp_raw_events.graphql
+++ b/src/graphql/client/schema/search_dhcp_raw_events.graphql
@@ -1,0 +1,3 @@
+query SearchDhcpRawEvents($filter: SearchFilter!){
+    searchDhcpRawEvents(filter: $filter)
+}

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -27,7 +27,7 @@ use crate::{
 
 pub const MAX_CORE_SIZE: u32 = 16; // Number of queues on the collect device's NIC
 const BYTE_TO_BIT: u64 = 8;
-const STATS_ALLOWED_KINDS: [RawEventKind; 16] = [
+const STATS_ALLOWED_KINDS: [RawEventKind; 18] = [
     RawEventKind::Conn,
     RawEventKind::Dns,
     RawEventKind::Rdp,
@@ -43,6 +43,8 @@ const STATS_ALLOWED_KINDS: [RawEventKind; 16] = [
     RawEventKind::Tls,
     RawEventKind::Smb,
     RawEventKind::Nfs,
+    RawEventKind::Bootp,
+    RawEventKind::Dhcp,
     RawEventKind::Statistics,
 ];
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -54,7 +54,7 @@ const CHANNEL_CLOSE_MESSAGE: &[u8; 12] = b"channel done";
 const CHANNEL_CLOSE_TIMESTAMP: i64 = -1;
 const NO_TIMESTAMP: i64 = 0;
 const SOURCE_INTERVAL: u64 = 60 * 60 * 24;
-const INGEST_VERSION_REQ: &str = ">=0.21.0-alpha.1,<0.21.0";
+const INGEST_VERSION_REQ: &str = ">=0.21.0-alpha.2,<0.22.0";
 
 type SourceInfo = (String, DateTime<Utc>, ConnState, bool);
 
@@ -511,6 +511,34 @@ async fn handle_request(
                 Some(NetworkKey::new(&source, "nfs")),
                 source,
                 db.nfs_store()?,
+                stream_direct_channels,
+                shutdown_signal,
+                ack_trans_cnt,
+            )
+            .await?;
+        }
+        RawEventKind::Bootp => {
+            handle_data(
+                send,
+                recv,
+                RawEventKind::Bootp,
+                Some(NetworkKey::new(&source, "bootp")),
+                source,
+                db.bootp_store()?,
+                stream_direct_channels,
+                shutdown_signal,
+                ack_trans_cnt,
+            )
+            .await?;
+        }
+        RawEventKind::Dhcp => {
+            handle_data(
+                send,
+                recv,
+                RawEventKind::Dhcp,
+                Some(NetworkKey::new(&source, "dhcp")),
+                source,
+                db.dhcp_store()?,
                 stream_direct_channels,
                 shutdown_signal,
                 ack_trans_cnt,

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -4,7 +4,8 @@ use giganto_client::ingest::{
     log::{Log, OpLog, OpLogLevel, SecuLog},
     netflow::{Netflow5, Netflow9},
     network::{
-        Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp, Ssh, Tls,
+        Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp,
+        Ssh, Tls,
     },
     statistics::Statistics,
     sysmon::{
@@ -477,6 +478,54 @@ impl EventFilter for Smb {
 impl EventFilter for Nfs {
     fn data_type(&self) -> String {
         "nfs".to_string()
+    }
+    fn orig_addr(&self) -> Option<IpAddr> {
+        Some(self.orig_addr)
+    }
+    fn resp_addr(&self) -> Option<IpAddr> {
+        Some(self.resp_addr)
+    }
+    fn orig_port(&self) -> Option<u16> {
+        Some(self.orig_port)
+    }
+    fn resp_port(&self) -> Option<u16> {
+        Some(self.resp_port)
+    }
+    fn log_level(&self) -> Option<String> {
+        None
+    }
+    fn log_contents(&self) -> Option<String> {
+        None
+    }
+}
+
+impl EventFilter for Bootp {
+    fn data_type(&self) -> String {
+        "bootp".to_string()
+    }
+    fn orig_addr(&self) -> Option<IpAddr> {
+        Some(self.orig_addr)
+    }
+    fn resp_addr(&self) -> Option<IpAddr> {
+        Some(self.resp_addr)
+    }
+    fn orig_port(&self) -> Option<u16> {
+        Some(self.orig_port)
+    }
+    fn resp_port(&self) -> Option<u16> {
+        Some(self.resp_port)
+    }
+    fn log_level(&self) -> Option<String> {
+        None
+    }
+    fn log_contents(&self) -> Option<String> {
+        None
+    }
+}
+
+impl EventFilter for Dhcp {
+    fn data_type(&self) -> String {
+        "dhcp".to_string()
     }
     fn orig_addr(&self) -> Option<IpAddr> {
         Some(self.orig_addr)

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -39,7 +39,7 @@ use crate::{
     IngestSources,
 };
 
-const PEER_VERSION_REQ: &str = ">=0.21.0-alpha.1,<0.22.0";
+const PEER_VERSION_REQ: &str = ">=0.21.0-alpha.2,<0.22.0";
 const PEER_RETRY_INTERVAL: u64 = 5;
 
 pub type Peers = Arc<RwLock<HashMap<String, PeerInfo>>>;
@@ -759,7 +759,7 @@ pub mod tests {
     const ROOT_PATH: &str = "tests/certs/root.pem";
     const HOST: &str = "node1";
     const TEST_PORT: u16 = 60191;
-    const PROTOCOL_VERSION: &str = "0.21.0-alpha.1";
+    const PROTOCOL_VERSION: &str = "0.21.0-alpha.2";
 
     pub struct TestClient {
         send: SendStream,

--- a/src/publish/implement.rs
+++ b/src/publish/implement.rs
@@ -18,7 +18,7 @@ impl RequestStreamMessage for RequestHogStream {
                 .iter()
                 .map(|target_source| {
                     let mut key = String::new();
-                    key.push_str(NodeType::Hog.convert_to_str());
+                    key.push_str(&NodeType::Hog.to_string());
                     key.push('\0');
                     key.push_str(source.as_ref().unwrap());
                     key.push('\0');
@@ -56,7 +56,7 @@ impl RequestStreamMessage for RequestCrusherStream {
     fn channel_key(&self, _source: Option<String>, record_type: &str) -> Result<Vec<String>> {
         if let Some(ref target_source) = self.source {
             let mut crusher_key = String::new();
-            crusher_key.push_str(NodeType::Crusher.convert_to_str());
+            crusher_key.push_str(&NodeType::Crusher.to_string());
             crusher_key.push('\0');
             crusher_key.push_str(&self.id);
             crusher_key.push('\0');

--- a/src/storage/migration/migration_structures.rs
+++ b/src/storage/migration/migration_structures.rs
@@ -64,12 +64,28 @@ pub struct HttpFromV12BeforeV21 {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct ConnBeforeV21 {
+pub struct ConnBeforeV21A1 {
     pub orig_addr: IpAddr,
     pub orig_port: u16,
     pub resp_addr: IpAddr,
     pub resp_port: u16,
     pub proto: u8,
+    pub duration: i64,
+    pub service: String,
+    pub orig_bytes: u64,
+    pub resp_bytes: u64,
+    pub orig_pkts: u64,
+    pub resp_pkts: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct ConnFromV21A1BeforeV21A2 {
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub conn_state: String,
     pub duration: i64,
     pub service: String,
     pub orig_bytes: u64,
@@ -194,8 +210,8 @@ impl From<HttpBeforeV12> for HttpFromV12BeforeV21 {
     }
 }
 
-impl From<ConnBeforeV21> for ConnFromV21 {
-    fn from(input: ConnBeforeV21) -> Self {
+impl From<ConnBeforeV21A1> for ConnFromV21A1BeforeV21A2 {
+    fn from(input: ConnBeforeV21A1) -> Self {
         Self {
             orig_addr: input.orig_addr,
             orig_port: input.orig_port,
@@ -209,6 +225,27 @@ impl From<ConnBeforeV21> for ConnFromV21 {
             resp_bytes: input.resp_bytes,
             orig_pkts: input.orig_pkts,
             resp_pkts: input.resp_pkts,
+        }
+    }
+}
+
+impl From<ConnFromV21A1BeforeV21A2> for ConnFromV21 {
+    fn from(input: ConnFromV21A1BeforeV21A2) -> Self {
+        Self {
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            conn_state: String::new(),
+            duration: input.duration,
+            service: input.service,
+            orig_bytes: input.orig_bytes,
+            resp_bytes: input.resp_bytes,
+            orig_pkts: input.orig_pkts,
+            resp_pkts: input.resp_pkts,
+            resp_l2_bytes: 0,
+            orig_l2_bytes: 0,
         }
     }
 }


### PR DESCRIPTION
- Support bootp, dhcp events.
- Fix code and structures based on changes to the conn protocols field.
- Update the compatibility version of the quic communication modules.
- Update the compatibility version for migration.
- Add migration function `migrate_0_21_0_alpha_1_to_0_21_0_alpha_2`.

Close: #768