### PR TITLE
Apply rustfmt's option `group_imports=StdExternalCrate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/cache-cargo
     - name: Check formatting
-      run: cargo fmt -- --check
+      run: cargo fmt -- --check --config group_imports=StdExternalCrate
     - name: Clippy
       run: cargo clippy -- -D warnings -W clippy::pedantic
     - name: Detect Cargo.lock changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed to append the kind value to the filename when extracting a file for a
   protocol for which a kind value exists.
+- Apply rustfmt's option `group_imports=StdExternalCrate`.
+  - Modify the code with the command `cargo fmt -- --config group_imports=StdExternalCrate`.
+    This command must be applied automatically or manually before all future pull
+    requests are submitted.
+  - Add `--config group_imports=StdExternalCrate` to the CI process like:
+    - `cargo fmt -- --check --config group_imports=StdExternalCrate`
 
 ## [0.20.0+tis.0.2.0] - 2024-05-24
 

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -1,20 +1,16 @@
 #[cfg(test)]
 mod tests;
 
-use super::{
-    check_address, check_agent_id, check_port,
-    netflow::{millis_to_secs, tcp_flags},
-    statistics::MAX_CORE_SIZE,
-    IpRange, NodeName, PortRange, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
+use std::{
+    borrow::Cow,
+    fmt::Display,
+    fs::{self, File},
+    io::Write,
+    iter::Peekable,
+    net::IpAddr,
+    path::{Path, PathBuf},
 };
-use crate::{
-    graphql::{
-        client::derives::{export as exports, Export as Exports},
-        events_in_cluster, impl_from_giganto_range_structs_for_graphql_client,
-    },
-    ingest::implement::EventFilter,
-    storage::{BoundaryIter, Database, Direction, KeyExtractor, RawEventStore, StorageKey},
-};
+
 use anyhow::anyhow;
 use async_graphql::{Context, InputObject, Object, Result};
 use chrono::{DateTime, Local, Utc};
@@ -38,16 +34,22 @@ use giganto_client::{
 };
 use graphql_client::GraphQLQuery;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    borrow::Cow,
-    fmt::Display,
-    fs::{self, File},
-    io::Write,
-    iter::Peekable,
-    net::IpAddr,
-    path::{Path, PathBuf},
-};
 use tracing::{error, info};
+
+use super::{
+    check_address, check_agent_id, check_port,
+    netflow::{millis_to_secs, tcp_flags},
+    statistics::MAX_CORE_SIZE,
+    IpRange, NodeName, PortRange, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
+};
+use crate::{
+    graphql::{
+        client::derives::{export as exports, Export as Exports},
+        events_in_cluster, impl_from_giganto_range_structs_for_graphql_client,
+    },
+    ingest::implement::EventFilter,
+    storage::{BoundaryIter, Database, Direction, KeyExtractor, RawEventStore, StorageKey},
+};
 
 const ADDRESS_PROTOCOL: [&str; 16] = [
     "conn",

--- a/src/graphql/export/tests.rs
+++ b/src/graphql/export/tests.rs
@@ -1,5 +1,6 @@
-use crate::graphql::tests::TestSchema;
-use crate::storage::RawEventStore;
+use std::mem;
+use std::net::IpAddr;
+
 use chrono::{Duration, Utc};
 use giganto_client::ingest::{
     log::{Log, OpLog, OpLogLevel},
@@ -8,8 +9,9 @@ use giganto_client::ingest::{
     },
     timeseries::PeriodicTimeSeries,
 };
-use std::mem;
-use std::net::IpAddr;
+
+use crate::graphql::tests::TestSchema;
+use crate::storage::RawEventStore;
 
 #[tokio::test]
 async fn invalid_query() {

--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -1,6 +1,18 @@
 #[cfg(test)]
 mod tests;
 
+use std::{fmt::Debug, net::IpAddr};
+
+use anyhow::anyhow;
+use async_graphql::{
+    connection::{query, Connection},
+    Context, InputObject, Object, Result, SimpleObject,
+};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::log::{Log, OpLog};
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     base64_engine,
     client::derives::{log_raw_events, LogRawEvents},
@@ -12,16 +24,6 @@ use crate::{
     graphql::{RawEventFilter, TimeRange},
     storage::{Database, KeyExtractor},
 };
-use anyhow::anyhow;
-use async_graphql::{
-    connection::{query, Connection},
-    Context, InputObject, Object, Result, SimpleObject,
-};
-use chrono::{DateTime, Utc};
-use giganto_client::ingest::log::{Log, OpLog};
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::{fmt::Debug, net::IpAddr};
 
 #[derive(Default)]
 pub(super) struct LogQuery;

--- a/src/graphql/log/tests.rs
+++ b/src/graphql/log/tests.rs
@@ -1,10 +1,11 @@
+use chrono::DateTime;
+use giganto_client::ingest::log::{Log, OpLog, OpLogLevel};
+
 use super::{base64_engine, Engine, LogFilter, LogRawEvent, OpLogFilter, OpLogRawEvent};
 use crate::{
     graphql::{tests::TestSchema, TimeRange},
     storage::RawEventStore,
 };
-use chrono::DateTime;
-use giganto_client::ingest::log::{Log, OpLog, OpLogLevel};
 
 #[tokio::test]
 async fn load_time_range() {

--- a/src/graphql/netflow.rs
+++ b/src/graphql/netflow.rs
@@ -1,3 +1,11 @@
+use std::{fmt::Debug, net::IpAddr};
+
+use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::netflow::{Netflow5, Netflow9};
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     check_address, check_contents, check_port, get_timestamp_from_key, handle_paged_events,
     impl_from_giganto_range_structs_for_graphql_client, paged_events_in_cluster, FromKeyValue,
@@ -12,12 +20,6 @@ use crate::{
     },
     storage::{Database, KeyExtractor},
 };
-use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
-use chrono::{DateTime, Utc};
-use giganto_client::ingest::netflow::{Netflow5, Netflow9};
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::{fmt::Debug, net::IpAddr};
 
 static TCP_FLAGS: [(u8, &str); 8] = [
     (0x01, "FIN"),

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -1,6 +1,19 @@
 #[cfg(test)]
 mod tests;
 
+use std::{collections::BTreeSet, fmt::Debug, iter::Peekable, net::IpAddr};
+
+use async_graphql::{
+    connection::{query, Connection, Edge},
+    Context, Object, Result, SimpleObject, Union,
+};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::network::{
+    Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp, Ssh, Tls,
+};
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     base64_engine, check_address, check_agent_id, check_port, collect_exist_timestamp,
     events_vec_in_cluster, get_peekable_iter, get_timestamp_from_key, handle_paged_events,
@@ -27,17 +40,6 @@ use crate::graphql::client::derives::{
     SshRawEvents, TlsRawEvents,
 };
 use crate::storage::{Database, FilteredIter, KeyExtractor};
-use async_graphql::{
-    connection::{query, Connection, Edge},
-    Context, Object, Result, SimpleObject, Union,
-};
-use chrono::{DateTime, Utc};
-use giganto_client::ingest::network::{
-    Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp, Ssh, Tls,
-};
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::{collections::BTreeSet, fmt::Debug, iter::Peekable, net::IpAddr};
 
 #[derive(Default)]
 pub(super) struct NetworkQuery;

--- a/src/graphql/network/tests.rs
+++ b/src/graphql/network/tests.rs
@@ -1,12 +1,14 @@
-use crate::graphql::tests::TestSchema;
-use crate::storage::RawEventStore;
+use std::mem;
+use std::net::{IpAddr, SocketAddr};
+
 use chrono::{Duration, TimeZone, Utc};
 use giganto_client::ingest::network::{
     Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp, Ssh, Tls,
 };
 use mockito;
-use std::mem;
-use std::net::{IpAddr, SocketAddr};
+
+use crate::graphql::tests::TestSchema;
+use crate::storage::RawEventStore;
 
 #[tokio::test]
 async fn conn_empty() {

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -1,3 +1,12 @@
+use std::net::IpAddr;
+
+use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
+use chrono::{DateTime, Utc};
+use data_encoding::BASE64;
+use giganto_client::ingest::Packet as pk;
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     collect_records, get_timestamp_from_key, handle_paged_events, write_run_tcpdump, Direction,
     FromKeyValue, RawEventFilter, TimeRange, TIMESTAMP_SIZE,
@@ -10,13 +19,6 @@ use crate::{
     },
     storage::{Database, KeyExtractor, StorageKey},
 };
-use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
-use chrono::{DateTime, Utc};
-use data_encoding::BASE64;
-use giganto_client::ingest::Packet as pk;
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::net::IpAddr;
 
 #[derive(Default)]
 pub(super) struct PacketQuery;
@@ -212,10 +214,12 @@ impl_from_giganto_packet_filter_for_graphql_client!(packets, pcaps);
 
 #[cfg(test)]
 mod tests {
-    use crate::{graphql::tests::TestSchema, storage::RawEventStore};
+    use std::mem;
+
     use chrono::{NaiveDateTime, TimeZone, Utc};
     use giganto_client::ingest::Packet as pk;
-    use std::mem;
+
+    use crate::{graphql::tests::TestSchema, storage::RawEventStore};
 
     #[tokio::test]
     async fn packets_empty() {

--- a/src/graphql/security.rs
+++ b/src/graphql/security.rs
@@ -1,3 +1,11 @@
+use std::{fmt::Debug, net::IpAddr};
+
+use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::log::SecuLog;
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     check_address, check_contents, check_port, get_timestamp_from_key, handle_paged_events,
     impl_from_giganto_range_structs_for_graphql_client, paged_events_in_cluster, FromKeyValue,
@@ -10,12 +18,6 @@ use crate::{
     },
     storage::{Database, KeyExtractor},
 };
-use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
-use chrono::{DateTime, Utc};
-use giganto_client::ingest::log::SecuLog;
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::{fmt::Debug, net::IpAddr};
 
 #[derive(Default)]
 pub(super) struct SecurityLogQuery;
@@ -175,10 +177,12 @@ impl_from_giganto_secu_log_filter_for_graphql_client!(secu_log_raw_events);
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
+    use giganto_client::ingest::log::SecuLog;
+
     use crate::graphql::tests::TestSchema;
     use crate::storage::RawEventStore;
-    use giganto_client::ingest::log::SecuLog;
-    use std::net::SocketAddr;
 
     #[tokio::test]
     async fn test_secu_log_event() {

--- a/src/graphql/source.rs
+++ b/src/graphql/source.rs
@@ -1,6 +1,8 @@
-use crate::{peer::Peers, IngestSources};
-use async_graphql::{Context, Object, Result};
 use std::collections::HashSet;
+
+use async_graphql::{Context, Object, Result};
+
+use crate::{peer::Peers, IngestSources};
 
 #[derive(Default)]
 pub(super) struct SourceQuery;

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -1,15 +1,17 @@
-use super::{PowerOffNotify, RebootNotify, ReloadNotify, TerminateNotify};
-#[cfg(debug_assertions)]
-use crate::storage::Database;
-use crate::AckTransmissionCount;
-use anyhow::{anyhow, Context as ct};
-use async_graphql::{Context, InputObject, Object, Result, SimpleObject};
 use std::{
     fs::{self, OpenOptions},
     io::Write,
     time::Duration,
 };
+
+use anyhow::{anyhow, Context as ct};
+use async_graphql::{Context, InputObject, Object, Result, SimpleObject};
 use toml_edit::{value, DocumentMut, InlineTable};
+
+use super::{PowerOffNotify, RebootNotify, ReloadNotify, TerminateNotify};
+#[cfg(debug_assertions)]
+use crate::storage::Database;
+use crate::AckTransmissionCount;
 
 const GRAPHQL_REBOOT_DELAY: u64 = 100;
 const CONFIG_INGEST_SRV_ADDR: &str = "ingest_srv_addr";

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -1,3 +1,18 @@
+use std::{collections::BTreeSet, iter::Peekable};
+
+use async_graphql::{
+    connection::{query, Connection, Edge},
+    Context, Object, Result, SimpleObject, Union,
+};
+use chrono::{DateTime, Utc};
+use giganto_client::ingest::sysmon::{
+    DnsEvent, FileCreate, FileCreateStreamHash, FileCreationTimeChanged, FileDelete,
+    FileDeleteDetected, ImageLoaded, NetworkConnection, PipeEvent, ProcessCreate, ProcessTampering,
+    ProcessTerminated, RegistryKeyValueRename, RegistryValueSet,
+};
+use giganto_proc_macro::ConvertGraphQLEdgesNode;
+use graphql_client::GraphQLQuery;
+
 use super::{
     base64_engine, collect_exist_timestamp, events_vec_in_cluster, get_peekable_iter,
     get_timestamp_from_key, handle_paged_events,
@@ -28,19 +43,6 @@ use crate::graphql::client::derives::{
     SysmonEvents as SysmonEventsDerive,
 };
 use crate::storage::{Database, FilteredIter};
-use async_graphql::{
-    connection::{query, Connection, Edge},
-    Context, Object, Result, SimpleObject, Union,
-};
-use chrono::{DateTime, Utc};
-use giganto_client::ingest::sysmon::{
-    DnsEvent, FileCreate, FileCreateStreamHash, FileCreationTimeChanged, FileDelete,
-    FileDeleteDetected, ImageLoaded, NetworkConnection, PipeEvent, ProcessCreate, ProcessTampering,
-    ProcessTerminated, RegistryKeyValueRename, RegistryValueSet,
-};
-use giganto_proc_macro::ConvertGraphQLEdgesNode;
-use graphql_client::GraphQLQuery;
-use std::{collections::BTreeSet, iter::Peekable};
 
 #[derive(Default)]
 pub(super) struct SysmonQuery;

--- a/src/graphql/timeseries.rs
+++ b/src/graphql/timeseries.rs
@@ -1,15 +1,17 @@
-use super::{get_timestamp_from_key, load_connection, FromKeyValue};
-use crate::{
-    graphql::{RawEventFilter, TimeRange},
-    storage::{Database, KeyExtractor},
-};
+use std::{fmt::Debug, net::IpAddr};
+
 use async_graphql::{
     connection::{query, Connection},
     Context, InputObject, Object, Result, SimpleObject,
 };
 use chrono::{DateTime, Utc};
 use giganto_client::ingest::timeseries::PeriodicTimeSeries;
-use std::{fmt::Debug, net::IpAddr};
+
+use super::{get_timestamp_from_key, load_connection, FromKeyValue};
+use crate::{
+    graphql::{RawEventFilter, TimeRange},
+    storage::{Database, KeyExtractor},
+};
 
 #[derive(Default)]
 pub(super) struct TimeSeriesQuery;
@@ -103,8 +105,9 @@ impl TimeSeriesQuery {
 
 #[cfg(test)]
 mod tests {
-    use crate::{graphql::tests::TestSchema, storage::RawEventStore};
     use giganto_client::ingest::timeseries::PeriodicTimeSeries;
+
+    use crate::{graphql::tests::TestSchema, storage::RawEventStore};
 
     #[tokio::test]
     async fn time_series_empty() {

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use giganto_client::ingest::{
     log::{Log, OpLog, OpLogLevel, SecuLog},
     netflow::{Netflow5, Netflow9},
@@ -13,7 +15,6 @@ use giganto_client::ingest::{
     timeseries::PeriodicTimeSeries,
     Packet,
 };
-use std::net::IpAddr;
 
 #[allow(unused)]
 pub trait EventFilter {

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -1,9 +1,10 @@
-use super::Server;
-use crate::{
-    new_ingest_sources, new_pcap_sources, new_runtime_ingest_sources, new_stream_direct_channels,
-    storage::{Database, DbOptions},
-    to_cert_chain, to_private_key, to_root_cert, Certs,
+use std::{
+    fs,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    path::Path,
+    sync::{Arc, OnceLock},
 };
+
 use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use chrono::{Duration, Utc};
 use giganto_client::{
@@ -23,16 +24,17 @@ use giganto_client::{
 };
 use quinn::{Connection, Endpoint};
 use serde::Serialize;
-use std::{
-    fs,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
-    path::Path,
-    sync::{Arc, OnceLock},
-};
 use tempfile::TempDir;
 use tokio::{
     sync::{Mutex, Notify, RwLock},
     task::JoinHandle,
+};
+
+use super::Server;
+use crate::{
+    new_ingest_sources, new_pcap_sources, new_runtime_ingest_sources, new_stream_direct_channels,
+    storage::{Database, DbOptions},
+    to_cert_chain, to_private_key, to_root_cert, Certs,
 };
 
 fn get_token() -> &'static Mutex<u32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,18 +7,6 @@ mod settings;
 mod storage;
 mod web;
 
-use crate::{
-    graphql::{status::TEMP_TOML_POST_FIX, NodeName},
-    server::{certificate_info, Certs, SERVER_REBOOT_DELAY},
-    storage::migrate_data_dir,
-};
-use anyhow::{anyhow, bail, Context, Result};
-use chrono::{DateTime, Utc};
-use peer::{PeerIdentity, PeerIdents, PeerInfo, Peers};
-use quinn::Connection;
-use rocksdb::DB;
-use rustls::{Certificate, PrivateKey};
-use settings::Settings;
 use std::{
     collections::{HashMap, HashSet},
     env, fs,
@@ -27,6 +15,14 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Utc};
+use peer::{PeerIdentity, PeerIdents, PeerInfo, Peers};
+use quinn::Connection;
+use rocksdb::DB;
+use rustls::{Certificate, PrivateKey};
+use settings::Settings;
 use storage::Database;
 use tokio::{
     runtime, select,
@@ -38,6 +34,12 @@ use tracing::{error, info, metadata::LevelFilter, warn};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     fmt, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+};
+
+use crate::{
+    graphql::{status::TEMP_TOML_POST_FIX, NodeName},
+    server::{certificate_info, Certs, SERVER_REBOOT_DELAY},
+    storage::migrate_data_dir,
 };
 
 const ONE_DAY: u64 = 60 * 60 * 24;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,3 +1,32 @@
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+    net::{SocketAddr, ToSocketAddrs},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use giganto_client::{
+    connection::{client_handshake, server_handshake},
+    frame::{self, recv_bytes, recv_raw, send_bytes},
+};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use quinn::{
+    ClientConfig, Connection, ConnectionError, Endpoint, RecvStream, SendStream, ServerConfig,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::{
+    select,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Notify, RwLock,
+    },
+    time::sleep,
+};
+use toml_edit::DocumentMut;
+use tracing::{error, info, warn};
+
 use crate::{
     graphql::status::{
         insert_toml_peers, parse_toml_element_to_string, read_toml_file, write_toml_file,
@@ -9,33 +38,6 @@ use crate::{
     },
     IngestSources,
 };
-use anyhow::{anyhow, bail, Context, Result};
-use giganto_client::{
-    connection::{client_handshake, server_handshake},
-    frame::{self, recv_bytes, recv_raw, send_bytes},
-};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
-use quinn::{
-    ClientConfig, Connection, ConnectionError, Endpoint, RecvStream, SendStream, ServerConfig,
-};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    mem,
-    net::{SocketAddr, ToSocketAddrs},
-    sync::Arc,
-    time::Duration,
-};
-use tokio::{
-    select,
-    sync::{
-        mpsc::{channel, Receiver, Sender},
-        Notify, RwLock,
-    },
-    time::sleep,
-};
-use toml_edit::DocumentMut;
-use tracing::{error, info, warn};
 
 const PEER_VERSION_REQ: &str = ">=0.19.0,<0.21.0";
 const PEER_RETRY_INTERVAL: u64 = 5;
@@ -725,14 +727,6 @@ async fn update_to_new_source_list(
 
 #[cfg(test)]
 pub mod tests {
-    use super::Peer;
-    use crate::{
-        peer::{receive_peer_data, request_init_info, PeerCode, PeerIdentity},
-        server::Certs,
-        to_cert_chain, to_private_key, to_root_cert, PeerInfo,
-    };
-    use giganto_client::connection::client_handshake;
-    use quinn::{Connection, Endpoint, RecvStream, SendStream};
     use std::{
         collections::{HashMap, HashSet},
         fs::{self, File},
@@ -740,8 +734,18 @@ pub mod tests {
         path::Path,
         sync::{Arc, OnceLock},
     };
+
+    use giganto_client::connection::client_handshake;
+    use quinn::{Connection, Endpoint, RecvStream, SendStream};
     use tempfile::TempDir;
     use tokio::sync::{Mutex, Notify, RwLock};
+
+    use super::Peer;
+    use crate::{
+        peer::{receive_peer_data, request_init_info, PeerCode, PeerIdentity},
+        server::Certs,
+        to_cert_chain, to_private_key, to_root_cert, PeerInfo,
+    };
 
     fn get_token() -> &'static Mutex<u32> {
         static TOKEN: OnceLock<Mutex<u32>> = OnceLock::new();

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -2,16 +2,11 @@ pub mod implement;
 #[cfg(test)]
 mod tests;
 
-use self::implement::RequestStreamMessage;
-use crate::graphql::TIMESTAMP_SIZE;
-use crate::ingest::{implement::EventFilter, NetworkKey};
-use crate::peer::{PeerIdents, Peers};
-use crate::server::{
-    certificate_info, config_client, config_server, extract_cert_from_conn, Certs,
-    SERVER_CONNNECTION_DELAY, SERVER_ENDPOINT_DELAY,
-};
-use crate::storage::{Database, Direction, RawEventStore, StorageKey};
-use crate::{IngestSources, PcapSources, StreamDirectChannels};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{TimeZone, Utc};
 use giganto_client::connection::client_handshake;
@@ -49,16 +44,23 @@ use giganto_client::{
 };
 use quinn::{Connection, Endpoint, RecvStream, SendStream, ServerConfig};
 use serde::{de::DeserializeOwned, Serialize};
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
-use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
     select,
     sync::{mpsc::unbounded_channel, Notify},
     time::sleep,
 };
 use tracing::{debug, error, info, warn};
+
+use self::implement::RequestStreamMessage;
+use crate::graphql::TIMESTAMP_SIZE;
+use crate::ingest::{implement::EventFilter, NetworkKey};
+use crate::peer::{PeerIdents, Peers};
+use crate::server::{
+    certificate_info, config_client, config_server, extract_cert_from_conn, Certs,
+    SERVER_CONNNECTION_DELAY, SERVER_ENDPOINT_DELAY,
+};
+use crate::storage::{Database, Direction, RawEventStore, StorageKey};
+use crate::{IngestSources, PcapSources, StreamDirectChannels};
 
 const PUBLISH_VERSION_REQ: &str = ">=0.17.0,<0.21.0";
 

--- a/src/publish/implement.rs
+++ b/src/publish/implement.rs
@@ -1,8 +1,9 @@
+use std::{net::IpAddr, vec};
+
 use anyhow::{bail, Result};
 use giganto_client::publish::stream::{
     NodeType, RequestCrusherStream, RequestHogStream, RequestUrlCollectorStream,
 };
-use std::{net::IpAddr, vec};
 
 pub trait RequestStreamMessage {
     fn channel_key(&self, source: Option<String>, record_type: &str) -> Result<Vec<String>>;

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -1,11 +1,12 @@
-use super::Server;
-use crate::{
-    new_pcap_sources, new_peers_data, new_stream_direct_channels,
-    peer::{PeerIdentity, PeerInfo},
-    server::Certs,
-    storage::{Database, DbOptions, RawEventStore},
-    to_cert_chain, to_private_key, to_root_cert,
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    fs,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    path::Path,
+    sync::{Arc, OnceLock},
 };
+
 use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use giganto_client::{
@@ -30,15 +31,16 @@ use giganto_client::{
 };
 use quinn::{Connection, Endpoint, SendStream};
 use serial_test::serial;
-use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet},
-    fs,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
-    path::Path,
-    sync::{Arc, OnceLock},
-};
 use tokio::sync::{Mutex, Notify, RwLock};
+
+use super::Server;
+use crate::{
+    new_pcap_sources, new_peers_data, new_stream_direct_channels,
+    peer::{PeerIdentity, PeerInfo},
+    server::Certs,
+    storage::{Database, DbOptions, RawEventStore},
+    to_cert_chain, to_private_key, to_root_cert,
+};
 
 fn get_token() -> &'static Mutex<u32> {
     static TOKEN: OnceLock<Mutex<u32>> = OnceLock::new();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
+use std::{sync::Arc, time::Duration};
+
 use anyhow::{bail, Context, Result};
 use quinn::{ClientConfig, Connection, ServerConfig, TransportConfig};
 use rustls::{Certificate, PrivateKey, RootCertStore};
-use std::{sync::Arc, time::Duration};
 use tracing::info;
 use x509_parser::nom::Parser;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,10 @@
 //! Configurations for the application.
-use crate::peer::PeerIdentity;
+use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
+
 use config::{builder::DefaultState, Config, ConfigBuilder, ConfigError, File};
 use serde::{de::Error, Deserialize, Deserializer};
-use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
+
+use crate::peer::PeerIdentity;
 
 const DEFAULT_INGEST_SRV_ADDR: &str = "[::]:38370";
 const DEFAULT_PUBLISH_SRV_ADDR: &str = "[::]:38371";

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1,21 +1,23 @@
 //! Routines to check the database format version and migrate it if necessary.
-use super::Database;
-use crate::{
-    graphql::TIMESTAMP_SIZE,
-    ingest::implement::EventFilter,
-    storage::{RawEventStore, StorageKey},
-};
-use anyhow::{anyhow, Context, Result};
-use giganto_client::ingest::log::SecuLog;
-use semver::{Version, VersionReq};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     fs::{create_dir_all, File},
     io::{Read, Write},
     net::IpAddr,
     path::Path,
 };
+
+use anyhow::{anyhow, Context, Result};
+use giganto_client::ingest::log::SecuLog;
+use semver::{Version, VersionReq};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::info;
+
+use super::Database;
+use crate::{
+    graphql::TIMESTAMP_SIZE,
+    ingest::implement::EventFilter,
+    storage::{RawEventStore, StorageKey},
+};
 
 const COMPATIBLE_VERSION_REQ: &str = ">=0.19.0,<0.21.0";
 
@@ -285,8 +287,8 @@ fn get_timestamp_from_key(key: &[u8]) -> Result<i64, anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::COMPATIBLE_VERSION_REQ;
-    use crate::storage::{Database, DbOptions, StorageKey};
+    use std::net::IpAddr;
+
     use chrono::Utc;
     use giganto_client::ingest::{
         log::SecuLog,
@@ -295,7 +297,9 @@ mod tests {
     };
     use semver::{Version, VersionReq};
     use serde::{Deserialize, Serialize};
-    use std::net::IpAddr;
+
+    use super::COMPATIBLE_VERSION_REQ;
+    use crate::storage::{Database, DbOptions, StorageKey};
 
     #[test]
     fn version() {

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,9 +1,11 @@
-use crate::graphql::Schema;
-use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use tokio::{sync::Notify, task};
 use tracing::info;
 use warp::{http::Response as HttpResponse, Filter};
+
+use crate::graphql::Schema;
 
 /// Runs the GraphQL server.
 ///


### PR DESCRIPTION
- Apply `group_imports=StdExternalCrate` format.
- Fix clippy error.

Related issue: #760