### PR TITLE
Support for all sources in network protocol search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     requests are submitted.
   - Add `--config group_imports=StdExternalCrate` to the CI process like:
     - `cargo fmt -- --check --config group_imports=StdExternalCrate`
+- Modified network event search queries. The modifications are as follows.
+  - Changed the type of filter from `NetworkFilter` to `Option<NetworkOptFilter>`.
+  - Added `request_from_peer` as a parameter to the queries.
+  - Added `request_all_peers_if_source_is_one`,`request_from_peer` to the
+    `paged_events_in_cluster` macro so that requests for all sources can also
+    be processed.
+  - Added the `source` field to the network event search result structure to
+    know which source the event is from.
+- Changed the sorting of event search results for the all source from `cursor`,
+  `source` to `timestamp`, `source`.
+
+### Added
+
+- Added a `NetworkOptFilter` structure to allow network event search queries
+  to request all sources.
+- Added `handle_paged_events_for_all_source`, `get_peekable_iter_for_all_source`,
+  `load_connection_for_all_source` functions for all source search.
 
 ## [0.20.0+tis.0.2.0] - 2024-05-24
 

--- a/docs/guide-giganto-cluster-graphql.md
+++ b/docs/guide-giganto-cluster-graphql.md
@@ -124,6 +124,7 @@ impl NetworkQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -279,6 +280,8 @@ impl StatisticsQuery {
 - Giganto Cluster 사용법
   - 다음과 같이 `request_all_peers_if_source_is_none` 으로 시작하는 macro
     variant를 호출하면 됩니다.
+  - 쿼리의 Filter 구조체가 Option으로 변경됨에 따라 변환을 위한 표현식도 또한
+    `filter.map(std::convert::Into::into)` 로 변경해 주면 됩니다.
 
 ```rust
 pub struct NetflowFilter {
@@ -297,20 +300,20 @@ impl NetflowQuery {
     async fn netflow5_raw_events<'ctx>(
         &self,
         ctx: &Context<'ctx>,
-        mut filter: NetflowFilter,
+        filter: Option<NetflowFilter>, // check!
         after: Option<String>,
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
         request_from_peer: Option<bool>,
     ) -> Result<Connection<String, Netflow5RawEvent>> {
-        filter.kind = Some("netflow5".to_string());
         let handler = handle_netflow5_raw_events;
 
         paged_events_in_cluster!(
             request_all_peers_if_source_is_none  // here!
             ctx,
             filter,
+            filter.map(std::convert::Into::into), // here!
             after,
             before,
             first,

--- a/src/graphql/client/schema/conn_raw_events.graphql
+++ b/src/graphql/client/schema/conn_raw_events.graphql
@@ -1,5 +1,5 @@
-query ConnRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    connRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query ConnRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    connRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query ConnRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/dce_rpc_raw_events.graphql
+++ b/src/graphql/client/schema/dce_rpc_raw_events.graphql
@@ -1,5 +1,5 @@
-query DceRpcRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    dceRpcRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query DceRpcRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    dceRpcRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query DceRpcRawEvents($filter: NetworkFilter!, $after: String, $before: String, 
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/dns_raw_events.graphql
+++ b/src/graphql/client/schema/dns_raw_events.graphql
@@ -1,5 +1,5 @@
-query DnsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    dnsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query DnsRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    dnsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query DnsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/ftp_raw_events.graphql
+++ b/src/graphql/client/schema/ftp_raw_events.graphql
@@ -1,5 +1,5 @@
-query FtpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    ftpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query FtpRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    ftpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query FtpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/http_raw_events.graphql
+++ b/src/graphql/client/schema/http_raw_events.graphql
@@ -1,5 +1,5 @@
-query HttpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    httpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query HttpRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    httpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query HttpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/kerberos_raw_events.graphql
+++ b/src/graphql/client/schema/kerberos_raw_events.graphql
@@ -1,5 +1,5 @@
-query KerberosRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    kerberosRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query KerberosRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    kerberosRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query KerberosRawEvents($filter: NetworkFilter!, $after: String, $before: String
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/ldap_raw_events.graphql
+++ b/src/graphql/client/schema/ldap_raw_events.graphql
@@ -1,5 +1,5 @@
-query LdapRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    ldapRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query LdapRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    ldapRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query LdapRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/mqtt_raw_events.graphql
+++ b/src/graphql/client/schema/mqtt_raw_events.graphql
@@ -1,5 +1,5 @@
-query MqttRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    mqttRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query MqttRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    mqttRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query MqttRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/network_raw_events.graphql
+++ b/src/graphql/client/schema/network_raw_events.graphql
@@ -12,6 +12,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 __typename
                 ... on ConnRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -26,6 +27,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on DnsRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -47,6 +49,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on HttpRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -76,6 +79,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on RdpRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -86,6 +90,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on NtlmRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -102,6 +107,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on KerberosRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -120,6 +126,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on SshRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -141,6 +148,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on DceRpcRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -154,6 +162,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on FtpRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -175,6 +184,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on MqttRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -190,6 +200,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on LdapRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -206,6 +217,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on TlsRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -233,6 +245,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on SmbRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -253,6 +266,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on NfsRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort
@@ -264,6 +278,7 @@ query NetworkRawEvents($filter: NetworkFilter!, $after: String, $before: String,
                 }
                 ... on SmtpRawEvent {
                     timestamp
+                    source
                     origAddr
                     respAddr
                     origPort

--- a/src/graphql/client/schema/nfs_raw_events.graphql
+++ b/src/graphql/client/schema/nfs_raw_events.graphql
@@ -1,5 +1,5 @@
-query NfsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    nfsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query NfsRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    nfsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query NfsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/ntlm_raw_events.graphql
+++ b/src/graphql/client/schema/ntlm_raw_events.graphql
@@ -1,5 +1,5 @@
-query NtlmRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    ntlmRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query NtlmRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    ntlmRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query NtlmRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/rdp_raw_events.graphql
+++ b/src/graphql/client/schema/rdp_raw_events.graphql
@@ -1,5 +1,5 @@
-query RdpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    rdpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query RdpRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    rdpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query RdpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -1,5 +1,6 @@
 type ConnRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -40,6 +41,7 @@ scalar DateTime
 
 type DceRpcRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -107,6 +109,7 @@ type DnsEventEventEdge {
 
 type DnsRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -328,6 +331,7 @@ type FileDeleteEventEdge {
 
 type FtpRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -391,6 +395,7 @@ type GigantoStatus {
 
 type HttpRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -491,6 +496,7 @@ input IpRange {
 
 type KerberosRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -530,6 +536,7 @@ type KerberosRawEventEdge {
 
 type LdapRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -598,6 +605,7 @@ type LogRawEventEdge {
 
 type MqttRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -784,6 +792,15 @@ input NetworkFilter {
   agentId: String
 }
 
+input NetworkOptFilter {
+  time: TimeRange
+  source: String
+  origAddr: IpRange
+  respAddr: IpRange
+  origPort: PortRange
+  respPort: PortRange
+}
+
 union NetworkRawEvents =
     ConnRawEvent
   | DnsRawEvent
@@ -823,6 +840,7 @@ type NetworkRawEventsEdge {
 
 type NfsRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -855,6 +873,7 @@ type NfsRawEventEdge {
 
 type NtlmRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -1151,109 +1170,124 @@ type Query {
     last: Int
   ): OpLogRawEventConnection!
   connRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): ConnRawEventConnection!
   dnsRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): DnsRawEventConnection!
   httpRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): HttpRawEventConnection!
   rdpRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): RdpRawEventConnection!
   smtpRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): SmtpRawEventConnection!
   ntlmRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): NtlmRawEventConnection!
   kerberosRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): KerberosRawEventConnection!
   sshRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): SshRawEventConnection!
   dceRpcRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): DceRpcRawEventConnection!
   ftpRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): FtpRawEventConnection!
   mqttRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): MqttRawEventConnection!
   ldapRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): LdapRawEventConnection!
   tlsRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): TlsRawEventConnection!
   smbRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): SmbRawEventConnection!
   nfsRawEvents(
-    filter: NetworkFilter!
+    filter: NetworkOptFilter
     after: String
     before: String
     first: Int
     last: Int
+    requestFromPeer: Boolean
   ): NfsRawEventConnection!
   networkRawEvents(
     filter: NetworkFilter!
@@ -1448,6 +1482,7 @@ type Query {
 
 type RdpRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -1602,6 +1637,7 @@ type SecuLogRawEventEdge {
 
 type SmbRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -1643,6 +1679,7 @@ type SmbRawEventEdge {
 
 type SmtpRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -1679,6 +1716,7 @@ type SmtpRawEventEdge {
 
 type SshRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!
@@ -1810,6 +1848,7 @@ input TimeSeriesFilter {
 
 type TlsRawEvent {
   timestamp: DateTime!
+  source: String!
   origAddr: String!
   origPort: Int!
   respAddr: String!

--- a/src/graphql/client/schema/smb_raw_events.graphql
+++ b/src/graphql/client/schema/smb_raw_events.graphql
@@ -1,5 +1,5 @@
-query SmbRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    smbRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query SmbRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    smbRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query SmbRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/smtp_raw_events.graphql
+++ b/src/graphql/client/schema/smtp_raw_events.graphql
@@ -1,5 +1,5 @@
-query SmtpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    smtpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query SmtpRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    smtpRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query SmtpRawEvents($filter: NetworkFilter!, $after: String, $before: String, $f
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/ssh_raw_events.graphql
+++ b/src/graphql/client/schema/ssh_raw_events.graphql
@@ -1,5 +1,5 @@
-query SshRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    sshRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query SshRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    sshRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query SshRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/client/schema/tls_raw_events.graphql
+++ b/src/graphql/client/schema/tls_raw_events.graphql
@@ -1,5 +1,5 @@
-query TlsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $first: Int, $last: Int ){
-    tlsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last){
+query TlsRawEvents($filter: NetworkOptFilter, $after: String, $before: String, $first: Int, $last: Int, $requestFromPeer: Boolean){
+    tlsRawEvents(filter: $filter, after: $after, before: $before, first: $first, last: $last, requestFromPeer: $requestFromPeer){
         pageInfo {
             hasPreviousPage
             hasNextPage
@@ -10,6 +10,7 @@ query TlsRawEvents($filter: NetworkFilter!, $after: String, $before: String, $fi
             cursor
             node {
                 timestamp
+                source
                 origAddr
                 respAddr
                 origPort

--- a/src/graphql/log.rs
+++ b/src/graphql/log.rs
@@ -202,6 +202,7 @@ impl LogQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,

--- a/src/graphql/netflow.rs
+++ b/src/graphql/netflow.rs
@@ -251,6 +251,7 @@ impl NetflowQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -279,6 +280,7 @@ impl NetflowQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,

--- a/src/graphql/network/tests.rs
+++ b/src/graphql/network/tests.rs
@@ -204,6 +204,7 @@ async fn conn_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "ingest src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 46378,
@@ -457,6 +458,7 @@ async fn dns_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "31.3.245.133",
                             "origPort": 46378,
@@ -718,6 +720,7 @@ async fn http_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 46378,
@@ -974,6 +977,7 @@ async fn rdp_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 46378,
@@ -1102,6 +1106,7 @@ async fn smtp_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 25,
@@ -1236,6 +1241,7 @@ async fn ntlm_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.1.200",
                             "origPort": 12345,
@@ -1373,6 +1379,7 @@ async fn kerberos_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.1.200",
                             "origPort": 12345,
@@ -1520,6 +1527,7 @@ async fn ssh_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 22,
@@ -1657,6 +1665,7 @@ async fn dce_rpc_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 135,
@@ -1793,6 +1802,7 @@ async fn ftp_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 21,
@@ -1933,6 +1943,7 @@ async fn mqtt_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 1883,
@@ -2071,6 +2082,7 @@ async fn ldap_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 389,
@@ -2232,6 +2244,7 @@ async fn tls_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 443,
@@ -2381,6 +2394,7 @@ async fn smb_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.77",
                             "origPort": 445,
@@ -2514,6 +2528,7 @@ async fn nfs_with_data_giganto_cluster() {
                         "cursor": "cGl0YTIwMjNNQlAAF5gitjR0HIM=",
                         "node": {
                             "timestamp": "2023-11-16T15:03:45.291779203+00:00",
+                            "source": "src 2",
                             "origAddr": "192.168.4.76",
                             "respAddr": "192.168.4.76",
                             "origPort": 2049,

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -163,6 +163,7 @@ impl PacketQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,

--- a/src/graphql/security.rs
+++ b/src/graphql/security.rs
@@ -138,6 +138,7 @@ impl SecurityLogQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -721,6 +721,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -748,6 +749,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -775,6 +777,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -802,6 +805,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -829,6 +833,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -856,6 +861,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -883,6 +889,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -910,6 +917,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -937,6 +945,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -964,6 +973,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -990,6 +1000,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -1016,6 +1027,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -1042,6 +1054,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -1068,6 +1081,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -1490,6 +1504,7 @@ impl SysmonQuery {
         paged_events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             after,
             before,
@@ -1676,20 +1691,20 @@ async fn handle_sysmon_events<'ctx>(
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn sysmon_connection(
-    mut process_create_iter: Peekable<FilteredIter<ProcessCreate>>,
-    mut file_create_time_iter: Peekable<FilteredIter<FileCreationTimeChanged>>,
-    mut network_connect_iter: Peekable<FilteredIter<NetworkConnection>>,
-    mut process_terminate_iter: Peekable<FilteredIter<ProcessTerminated>>,
-    mut image_load_iter: Peekable<FilteredIter<ImageLoaded>>,
-    mut file_create_iter: Peekable<FilteredIter<FileCreate>>,
-    mut registry_value_set_iter: Peekable<FilteredIter<RegistryValueSet>>,
-    mut registry_key_rename_iter: Peekable<FilteredIter<RegistryKeyValueRename>>,
-    mut file_create_stream_hash_iter: Peekable<FilteredIter<FileCreateStreamHash>>,
-    mut pipe_event_iter: Peekable<FilteredIter<PipeEvent>>,
-    mut dns_query_iter: Peekable<FilteredIter<DnsEvent>>,
-    mut file_delete_iter: Peekable<FilteredIter<FileDelete>>,
-    mut process_tamper_iter: Peekable<FilteredIter<ProcessTampering>>,
-    mut file_delete_detected_iter: Peekable<FilteredIter<FileDeleteDetected>>,
+    mut process_create_iter: Peekable<FilteredIter<ProcessCreate, NetworkFilter>>,
+    mut file_create_time_iter: Peekable<FilteredIter<FileCreationTimeChanged, NetworkFilter>>,
+    mut network_connect_iter: Peekable<FilteredIter<NetworkConnection, NetworkFilter>>,
+    mut process_terminate_iter: Peekable<FilteredIter<ProcessTerminated, NetworkFilter>>,
+    mut image_load_iter: Peekable<FilteredIter<ImageLoaded, NetworkFilter>>,
+    mut file_create_iter: Peekable<FilteredIter<FileCreate, NetworkFilter>>,
+    mut registry_value_set_iter: Peekable<FilteredIter<RegistryValueSet, NetworkFilter>>,
+    mut registry_key_rename_iter: Peekable<FilteredIter<RegistryKeyValueRename, NetworkFilter>>,
+    mut file_create_stream_hash_iter: Peekable<FilteredIter<FileCreateStreamHash, NetworkFilter>>,
+    mut pipe_event_iter: Peekable<FilteredIter<PipeEvent, NetworkFilter>>,
+    mut dns_query_iter: Peekable<FilteredIter<DnsEvent, NetworkFilter>>,
+    mut file_delete_iter: Peekable<FilteredIter<FileDelete, NetworkFilter>>,
+    mut process_tamper_iter: Peekable<FilteredIter<ProcessTampering, NetworkFilter>>,
+    mut file_delete_detected_iter: Peekable<FilteredIter<FileDeleteDetected, NetworkFilter>>,
     size: usize,
     is_forward: bool,
 ) -> Result<Connection<String, SysmonEvents>> {

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -16,7 +16,6 @@ use giganto_client::ingest::{
     Packet,
 };
 
-#[allow(unused)]
 pub trait EventFilter {
     fn data_type(&self) -> String;
     fn orig_addr(&self) -> Option<IpAddr>;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -40,7 +40,7 @@ use tokio::{select, sync::Notify, time};
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    graphql::{NetworkFilter, RawEventFilter, TIMESTAMP_SIZE},
+    graphql::{RawEventFilter, TIMESTAMP_SIZE},
     ingest::implement::EventFilter,
 };
 
@@ -762,20 +762,24 @@ where
     }
 }
 
-pub struct FilteredIter<'d, T> {
+pub struct FilteredIter<'d, T, F> {
     inner: BoundaryIter<'d, T>,
-    filter: &'d NetworkFilter,
+    filter: &'d F,
 }
 
-impl<'d, T> FilteredIter<'d, T> {
-    pub fn new(inner: BoundaryIter<'d, T>, filter: &'d NetworkFilter) -> Self {
+impl<'d, T, F> FilteredIter<'d, T, F>
+where
+    F: RawEventFilter,
+{
+    pub fn new(inner: BoundaryIter<'d, T>, filter: &'d F) -> Self {
         Self { inner, filter }
     }
 }
 
-impl<'d, T> Iterator for FilteredIter<'d, T>
+impl<'d, T, F> Iterator for FilteredIter<'d, T, F>
 where
     T: DeserializeOwned + EventFilter,
+    F: RawEventFilter,
 {
     type Item = KeyValue<T>;
 


### PR DESCRIPTION
- Add `NetworkOptFilter` struct to allow network event search queries to request all sources.
- Add functions for all source search.
- Change the sorting of event search results for all sources to timestamp, source.
- Modify network event search queries.
  - Change the type of filter from `NetworkFilter` to `Option<NetworkOptFilter>`.
  - Add `request_from_peer` as a parameter to the queries.
  - Change the `paged_events_in_cluster` macro argument to handle all source requests.
  - Add the source field to the network event search result structure.

Close: #770