### PR TITLE
Rename giganto cluster related configs & Remove `unsafe` block in `write_run_tcpdump`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
       in version `0.21.0-alpha.2`.
 - Rename `chwaddr` to `chaddr` because the field names within the `Bootp` structure
   of the giganto-client have changed.
+- Changed cluster realted configuration field names.
+  - `peer_address` to `addr_to_peers`
+  - `address` in `peers` to `addr` and `host_name` in `peers` to `hostname`
 
 ## [0.20.0] - 2024-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed cluster realted configuration field names.
   - `peer_address` to `addr_to_peers`
   - `address` in `peers` to `addr` and `host_name` in `peers` to `hostname`
+- Removed `unsafe` block in `write_run_tcpdump` while creating a temorary file.
 
 ## [0.20.0] - 2024-05-17
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ max_mb_of_level_base = 512                 # db options max MB of rocksDB Level 
 num_of_thread = 8                          # db options for background thread.
 max_sub_compactions = 2                    # db options for sub-compaction.
 ack_transmission = 1024                    # ack count for ingestion data.
-peer_address = "10.10.11.1:38383"          # address to listen for peers QUIC.
-peers=[{address = "10.10.12.1:38383", host_name = "ai"}]     # list of peer info.
+addr_to_peers = "10.10.11.1:38383"          # address to listen for peers QUIC.
+peers = [ { addr = "10.10.12.1:38383", hostname = "ai" } ]     # list of peer info.
 ```
 
 By default, giganto reads the config file from the following directories:
@@ -64,7 +64,7 @@ These values assume you've used all the way up to level 6, so the actual values 
 change if you want to grow your data further at the level base.
 So if it's less than `512`MB, it's recommended to set default value of `512`MB.
 
-If there is no `peer_address` option in the configuration file, it runs in
+If there is no `addr_to_peers` option in the configuration file, it runs in
 standalone mode, and if there is, it runs in cluster mode for P2P.
 
 ## Test

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -11,10 +11,6 @@ pub mod status;
 mod sysmon;
 mod timeseries;
 
-#[cfg(target_os = "macos")]
-use std::os::fd::AsRawFd;
-#[cfg(target_os = "linux")]
-use std::os::unix::io::AsRawFd;
 use std::{
     collections::{BTreeSet, HashSet},
     io::{Read, Seek, SeekFrom, Write},
@@ -39,7 +35,7 @@ use num_traits::AsPrimitive;
 use pcap::{Capture, Linktype, Packet, PacketHeader};
 use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
-use tempfile::tempfile;
+use tempfile::NamedTempFile;
 use tokio::sync::Notify;
 use tracing::error;
 
@@ -573,10 +569,10 @@ where
 }
 
 fn write_run_tcpdump(packets: &Vec<pk>) -> Result<String, anyhow::Error> {
-    let mut temp_file = tempfile()?;
-    let fd = temp_file.as_raw_fd();
+    let mut temp_file = NamedTempFile::new()?;
+    let file_path = temp_file.path();
     let new_pcap = Capture::dead_with_precision(Linktype::ETHERNET, pcap::Precision::Nano)?;
-    let mut file = unsafe { new_pcap.savefile_raw_fd(fd)? };
+    let mut file = new_pcap.savefile(file_path)?;
 
     for packet in packets {
         let len = u32::try_from(packet.packet.len()).unwrap_or_default();

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1206,13 +1206,13 @@ async fn peer_in_charge_graphql_addr<'ctx>(
                 .read()
                 .await
                 .iter()
-                .find_map(|(peer_address, peer_info)| {
+                .find_map(|(addr_to_peers, peer_info)| {
                     peer_info
                         .ingest_sources
                         .contains(source_filter)
                         .then(|| {
                             SocketAddr::new(
-                                peer_address.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
+                                addr_to_peers.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
                                 peer_info.graphql_port.expect("Peer's graphql port must be valid, because it is validated when peer giganto started."),
                             )
                         })
@@ -1250,15 +1250,15 @@ async fn find_who_are_in_charge(
             .read()
             .await
             .iter()
-            .filter(|&(_peer_address, peer_info)| {
+            .filter(|&(_addr_to_peers, peer_info)| {
                 peer_info
                     .ingest_sources
                     .iter()
                     .any(|ingest_source| sources.contains(&ingest_source.as_str()))
             })
-            .map(|(peer_address, peer_info)| {
+            .map(|(addr_to_peers, peer_info)| {
                 SocketAddr::new(
-                    peer_address
+                    addr_to_peers
                         .parse::<IpAddr>()
                         .expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
                     peer_info
@@ -1333,9 +1333,9 @@ macro_rules! request_all_peers_for_paged_events_fut {
                     .read()
                     .await
                     .iter()
-                    .map(|(peer_address, peer_info)| {
+                    .map(|(addr_to_peers, peer_info)| {
                         std::net::SocketAddr::new(
-                            peer_address.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
+                            addr_to_peers.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
                             peer_info.graphql_port.expect("Peer's graphql port must be valid, because it is validated when peer giganto started."),
                         )
                     }).collect()

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -574,8 +574,8 @@ type ImageLoadedEventEdge {
 }
 
 input InputPeerList {
-  address: String!
-  hostName: String!
+  addr: String!
+  hostname: String!
 }
 
 input IpRange {
@@ -1070,8 +1070,8 @@ type Pcap {
 }
 
 type PeerList {
-  address: String!
-  hostName: String!
+  addr: String!
+  hostname: String!
 }
 
 type PipeEventEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,8 +205,8 @@ async fn main() -> Result<()> {
                 });
         });
 
-        if let Some(peer_address) = settings.peer_address {
-            let peer_server = peer::Peer::new(peer_address, &certs.clone())?;
+        if let Some(addr_to_peers) = settings.addr_to_peers {
+            let peer_server = peer::Peer::new(addr_to_peers, &certs.clone())?;
             let notify_source = Arc::new(Notify::new());
             task::spawn(peer_server.run(
                 ingest_sources.clone(),

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -349,10 +349,10 @@ async fn process_pcap_extract(
                     let peer_idents_guard = peer_idents.read().await;
                     let peer_ident = peer_idents_guard
                         .iter()
-                        .find(|idents| idents.address.eq(&peer_addr));
+                        .find(|idents| idents.addr.eq(&peer_addr));
 
                     if let Some(peer_ident) = peer_ident {
-                        peer_ident.host_name.clone()
+                        peer_ident.hostname.clone()
                     } else {
                         error!("Peer giganto's server name cannot be identitified. addr: {peer_addr}, source: {}", filter.source);
                         continue;
@@ -1946,13 +1946,13 @@ async fn is_current_giganto_in_charge(ingest_sources: IngestSources, source: &St
 }
 
 async fn peer_in_charge_publish_addr(peers: Peers, source: &String) -> Option<SocketAddr> {
-    peers.read().await.iter().find_map(|(peer_address, peer_info)| {
+    peers.read().await.iter().find_map(|(addr_to_peers, peer_info)| {
         peer_info
             .ingest_sources
             .contains(source)
             .then(|| {
                 SocketAddr::new(
-                    peer_address.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
+                    addr_to_peers.parse::<IpAddr>().expect("Peer's IP address must be valid, because it is validated when peer giganto started."),
                     peer_info.publish_port.expect("Peer's publish port must be valid, because it is validated when peer giganto started."),
                 )
             })
@@ -2221,10 +2221,10 @@ async fn peer_name(peer_idents: PeerIdents, peer_addr: &SocketAddr) -> Result<St
     let peer_idents_guard = peer_idents.read().await;
     let peer_ident = peer_idents_guard
         .iter()
-        .find(|idents| idents.address.eq(peer_addr));
+        .find(|idents| idents.addr.eq(peer_addr));
 
     match peer_ident {
-        Some(peer_ident) => Ok(peer_ident.host_name.clone()),
+        Some(peer_ident) => Ok(peer_ident.hostname.clone()),
         None => bail!("Peer giganto's server name cannot be identitified"),
     }
 }

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -4158,8 +4158,8 @@ async fn request_range_data_with_protocol_giganto_cluster() {
 
         let mut peer_identities = HashSet::new();
         peer_identities.insert(PeerIdentity {
-            address: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            host_name: NODE1_HOST.to_string(),
+            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
+            hostname: NODE1_HOST.to_string(),
         });
         let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4222,10 +4222,10 @@ async fn request_range_data_with_protocol_giganto_cluster() {
         },
     )])));
     let mut peer_identities = HashSet::new();
-    let peer_address = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
+    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
     peer_identities.insert(PeerIdentity {
-        address: peer_address.clone(),
-        host_name: NODE2_HOST.to_string(),
+        addr: addr_to_peers.clone(),
+        hostname: NODE2_HOST.to_string(),
     });
     let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4365,8 +4365,8 @@ async fn request_range_data_with_log_giganto_cluster() {
 
         let mut peer_identities = HashSet::new();
         peer_identities.insert(PeerIdentity {
-            address: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            host_name: NODE1_HOST.to_string(),
+            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
+            hostname: NODE1_HOST.to_string(),
         });
         let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4429,10 +4429,10 @@ async fn request_range_data_with_log_giganto_cluster() {
         },
     )])));
     let mut peer_identities = HashSet::new();
-    let peer_address = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
+    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
     peer_identities.insert(PeerIdentity {
-        address: peer_address.clone(),
-        host_name: NODE2_HOST.to_string(),
+        addr: addr_to_peers.clone(),
+        hostname: NODE2_HOST.to_string(),
     });
     let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4570,8 +4570,8 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
 
         let mut peer_identities = HashSet::new();
         peer_identities.insert(PeerIdentity {
-            address: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            host_name: NODE1_HOST.to_string(),
+            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
+            hostname: NODE1_HOST.to_string(),
         });
         let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4639,10 +4639,10 @@ async fn request_range_data_with_period_time_series_giganto_cluster() {
     )])));
 
     let mut peer_identities = HashSet::new();
-    let peer_address = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
+    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
     peer_identities.insert(PeerIdentity {
-        address: peer_address.clone(),
-        host_name: NODE2_HOST.to_string(),
+        addr: addr_to_peers.clone(),
+        hostname: NODE2_HOST.to_string(),
     });
     let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4780,8 +4780,8 @@ async fn request_raw_events_giganto_cluster() {
 
         let mut peer_identities = HashSet::new();
         peer_identities.insert(PeerIdentity {
-            address: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            host_name: NODE1_HOST.to_string(),
+            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
+            hostname: NODE1_HOST.to_string(),
         });
         let peer_idents = Arc::new(RwLock::new(peer_identities));
 
@@ -4841,10 +4841,10 @@ async fn request_raw_events_giganto_cluster() {
     )])));
 
     let mut peer_identities = HashSet::new();
-    let peer_address = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
+    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
     peer_identities.insert(PeerIdentity {
-        address: peer_address.clone(),
-        host_name: NODE2_HOST.to_string(),
+        addr: addr_to_peers.clone(),
+        hostname: NODE2_HOST.to_string(),
     });
     let peer_idents = Arc::new(RwLock::new(peer_identities));
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ use crate::peer::PeerIdentity;
 const DEFAULT_INGEST_SRV_ADDR: &str = "[::]:38370";
 const DEFAULT_PUBLISH_SRV_ADDR: &str = "[::]:38371";
 const DEFAULT_GRAPHQL_SRV_ADDR: &str = "[::]:8442";
-const DEFAULT_INVALID_PEER_ADDRESS: &str = "254.254.254.254:38383";
+const DEFAULT_INVALID_ADDR_TO_PEERS: &str = "254.254.254.254:38383";
 const DEFAULT_ACK_TRANSMISSION: u16 = 1024;
 const DEFAULT_RETENTION: &str = "100d";
 const DEFAULT_MAX_OPEN_FILES: i32 = 8000;
@@ -46,7 +46,7 @@ pub struct Settings {
 
     // peers
     #[serde(deserialize_with = "deserialize_peer_addr")]
-    pub peer_address: Option<SocketAddr>, // IP address & port for peer connection
+    pub addr_to_peers: Option<SocketAddr>, // IP address & port for peer connection
     pub peers: Option<HashSet<PeerIdentity>>,
 
     // ack transmission interval
@@ -134,7 +134,7 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .expect("default max subcompactions")
         .set_default("cfg_path", config_path.to_str().expect("path to string"))
         .expect("default config dir")
-        .set_default("peer_address", DEFAULT_INVALID_PEER_ADDRESS)
+        .set_default("addr_to_peers", DEFAULT_INVALID_ADDR_TO_PEERS)
         .expect("default ack transmission")
         .set_default("ack_transmission", DEFAULT_ACK_TRANSMISSION)
         .expect("ack_transmission")
@@ -156,7 +156,7 @@ where
 
 /// Deserializes a giganto's peer socket address.
 ///
-/// `Ok(None)` is returned if the address is an empty string or there is no `peer_address`
+/// `Ok(None)` is returned if the address is an empty string or there is no `addr_to_peers`
 ///  option in the configuration file.
 ///
 /// # Errors
@@ -168,7 +168,7 @@ where
 {
     (Option::<String>::deserialize(deserializer)?).map_or(Ok(None), |addr| {
         // Cluster mode is only available if there is a value for 'Peer Address' in the configuration file.
-        if addr == DEFAULT_INVALID_PEER_ADDRESS || addr.is_empty() {
+        if addr == DEFAULT_INVALID_ADDR_TO_PEERS || addr.is_empty() {
             Ok(None)
         } else {
             Ok(Some(addr.parse::<SocketAddr>().map_err(|e| {

--- a/tests/certs/node1/config.toml
+++ b/tests/certs/node1/config.toml
@@ -13,5 +13,5 @@ max_open_files = 8000
 max_mb_of_level_base = 512
 num_of_thread = 8
 max_sub_compactions = 2
-peer_address = "127.0.0.1:48383"
-peers = [{ address = "127.0.0.1:60192", host_name = "node2" }]
+addr_to_peers = "127.0.0.1:48383"
+peers = [{ addr = "127.0.0.1:60192", hostname = "node2" }]


### PR DESCRIPTION
close: #786 
close: #787 

#786 을 작업하고 test 를 돌려보는 도중 #787 이슈를 만났고, 이에 대한 fix도 함께 넣었습니다. 두가지 작업은 별개의 commit으로 작성하였습니다.

---

#787 이슈의 발생 원인으로는 모종의 원인(아마도 rust 1.80 업데이트와 관련이 있을 것으로 추측합니다)에 의하여 함수 scope를 벗어날 때 raw fd를 인자로 하는 `unsafe` 함수로 생성된 `file` 이 먼저 drop 되고, 그 다음 `temp_file` 이 drop 되는 순서가 발생하는 것으로 생각하고 있습니다. 우리가 `write_run_tcpdump`에서 `savefile_raw_fd` 함수로 달성하고자 하는 바는 safe 함수로도 충분히 가능하므로 아래와 같은 변경을 반영하고자 합니다.


