### PR TITLE
Add `total_count` GraphQL query & Remove unsafe block in `write_run_tcpdump`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the sorting of event search results for the all source from `cursor`,
   `source` to `timestamp`, `source`.
 - Removed `unsafe` block in `write_run_tcpdump` while creating a temorary file.
+- Modified `events_in_cluster` macro.
+  - Added `filter_into` expression to also support `total_count` query.
+  - Added macro pattern to return the sum of all source request results.
 
 ### Added
 
@@ -35,6 +38,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   to request all sources.
 - Added `handle_paged_events_for_all_source`, `get_peekable_iter_for_all_source`,
   `load_connection_for_all_source` functions for all source search.
+- Added `total_count` GraphQL query to return the number of events for a specific
+  filter condition.
 
 ## [0.20.0+tis.0.2.0] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     know which source the event is from.
 - Changed the sorting of event search results for the all source from `cursor`,
   `source` to `timestamp`, `source`.
+- Removed `unsafe` block in `write_run_tcpdump` while creating a temorary file.
 
 ### Added
 

--- a/src/graphql/client/derives.rs
+++ b/src/graphql/client/derives.rs
@@ -556,3 +556,11 @@ pub struct Export;
     response_derives = "Clone, Default, PartialEq"
 )]
 pub struct Statistics;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/client/schema/schema.graphql",
+    query_path = "src/graphql/client/schema/total_count.graphql",
+    response_derives = "Clone, Default, PartialEq"
+)]
+pub struct TotalCount;

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -34,6 +34,10 @@ type ConnRawEventEdge {
   cursor: String!
 }
 
+type TotalCount {
+  totalCount: Int!
+}
+
 # Implement the DateTime<Utc> scalar
 #
 # The input/output is a string in RFC3339 format.
@@ -1169,6 +1173,11 @@ type Query {
     first: Int
     last: Int
   ): OpLogRawEventConnection!
+  totalCount(
+    protocol: String!
+    filter: NetworkOptFilter
+    requestFromPeer: Boolean
+  ): TotalCount!
   connRawEvents(
     filter: NetworkOptFilter
     after: String

--- a/src/graphql/client/schema/total_count.graphql
+++ b/src/graphql/client/schema/total_count.graphql
@@ -1,0 +1,5 @@
+query TotalCount($protocol:String!, $filter: NetworkOptFilter, $requestFromPeer: Boolean) {
+    totalCount(protocol: $protocol, filter: $filter, requestFromPeer: $requestFromPeer) {
+        totalCount
+    }
+}

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -1591,6 +1591,7 @@ impl ExportQuery {
         events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source_id,
             handler,
             Exports,

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -183,6 +183,7 @@ impl PacketQuery {
         events_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             Pcaps,

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -1115,6 +1115,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchProcessCreateEvents,
@@ -1145,6 +1146,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchFileCreateTimeEvents,
@@ -1174,6 +1176,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchNetworkConnectEvents,
@@ -1203,6 +1206,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchProcessTerminateEvents,
@@ -1229,6 +1233,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchImageLoadEvents,
@@ -1256,6 +1261,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchFileCreateEvents,
@@ -1285,6 +1291,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchRegistryValueSetEvents,
@@ -1314,6 +1321,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchRegistryKeyRenameEvents,
@@ -1344,6 +1352,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchFileCreateStreamHashEvents,
@@ -1370,6 +1379,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchPipeEventEvents,
@@ -1396,6 +1406,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchDnsQueryEvents,
@@ -1423,6 +1434,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchFileDeleteEvents,
@@ -1452,6 +1464,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchProcessTamperEvents,
@@ -1481,6 +1494,7 @@ impl SysmonQuery {
         events_vec_in_cluster!(
             ctx,
             filter,
+            filter.into(),
             filter.source,
             handler,
             SearchFileDeleteDetectedEvents,


### PR DESCRIPTION
Add `total_count` GraphQL query & Remove unsafe block in `write_run_tcpdump`
  
- Add `total_count` GraphQL query to return the number of events for a specific filter condition.
- Fix `events_in_cluster` macro.
  - Add `into` expression to also support `total_count` query.
  - Add macro pattern to return the sum of all source request results.
- Removed `unsafe` block in `write_run_tcpdump` while creating a temorary file.

Related issue: #787
Close: #790