### PR TITLE
Supports exporting files for all sources of network protocol events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Added macro pattern to return the sum of all source request results.
 - Changed `MAXIMUM_PAGE_SIZE` to 300. This change is for pagination of network
   traffic events.
+- Supports exporting files for all sources of network protocol events.
+  - Changed `sourceId` in `ExportFilter` to `Option<String>`.
+  - Modified network protocol's RawEvent struct to extract json and csv format.
+    - Added `Serialize` and use the `#[serde(serialize_with)]` attribute.
+    - Implement `Display` trait.
+  - Added `process_export_for_all_source` to handle extraction for all sources.
 
 ### Added
 

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -156,7 +156,7 @@ type DnsRawEventEdge {
 
 input ExportFilter {
   protocol: String!
-  sourceId: String!
+  sourceId: String
   agentName: String
   agentId: String
   kind: String

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -471,6 +471,7 @@ impl Database {
     }
 }
 
+#[derive(Clone)]
 pub struct RawEventStore<'db, T> {
     db: &'db DB,
     cf: &'db ColumnFamily,


### PR DESCRIPTION
- Changed `sourceId` in `ExportFilter` to `Option<String>`.
- Modified network protocol's RawEvent struct to extract json and csv formats.
  - Added `Serialize` and use the `#[serde(serialize_with)]` attribute.
  - Implement `Display` trait.
- Added `process_export_for_all_source` to handle extraction for all sources.

Close: #778