### PR TITLE
Use `StringNumber` for integers beyond `i32` in a GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `address` in `peers` to `addr` and `host_name` in `peers` to `hostname`
 - Removed `unsafe` block in `write_run_tcpdump` while creating a temorary file.
 - Remove migration code less than `0.15.3`
+- In `BootpRawEvent`, `ConnRawEvent`, `DceRpcRawEvent`, `DhcpRawEvent`,
+  `DnsEventEvent`, `DnsRawEvent`, `FileCreateEvent`,
+  `FileCreateStreamHashEvent`, `FileCreationTimeChangedEvent`,
+  `FileDeleteDetectedEvent`, `FileDeleteEvent`, `FtpRawEvent`,
+  `HttpRawEvent`, `ImageLoadedEvent`, `KerberosRawEvent`, `LdapRawEvent`,
+  `MqttRawEvent`, `Netflow5RawEvent`, `Netflow9RawEvent`,
+  `NetworkConnectionEvent`, `NfsRawEvent`, `NtlmRawEvent`, `PipeEventEvent`,
+  `ProcessCreateEvent`, `ProcessTamperingEvent`, `ProcessTerminatedEvent`,
+  `RdpRawEvent`, `RegistryKeyValueRenameEvent`, `RegistryValueSetEvent`,
+  `SmbRawEvent`, `SmtpRawEvent`, `SshRawEvent`, `StatisticsInfo`, and
+  `TlsRawEvent` changed GraphQL APIs to return `StringNumber` instead of
+  integers beyond `i32`.
+- Changed the `from_key_value` macro to additionally receive `str_num_field`
+  for `StringNumber` conversion.
 
 ## [0.20.0] - 2024-05-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "giganto"
 
 [dependencies]
 anyhow = "1.0"
-async-graphql = { version = "7.0", features = ["chrono"] }
+async-graphql = { version = "7.0", features = ["chrono", "string_number"] }
 async-graphql-warp = "7.0"
 base64 = "0.22"
 bincode = "1.3"

--- a/src/graphql/client/derives.rs
+++ b/src/graphql/client/derives.rs
@@ -1,9 +1,15 @@
 #![allow(clippy::enum_variant_names)]
 
+use async_graphql::StringNumber;
 use chrono::{DateTime as ChronoDateTime, Utc};
 use graphql_client::GraphQLQuery;
 
 type DateTime = ChronoDateTime<Utc>;
+
+type StringNumberU32 = StringNumber<u32>;
+type StringNumberI64 = StringNumber<i64>;
+type StringNumberU64 = StringNumber<u64>;
+type StringNumberUSize = StringNumber<usize>;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -1,3 +1,8 @@
+scalar StringNumberU32
+scalar StringNumberU64
+scalar StringNumberI64
+scalar StringNumberUSize
+
 type BootpRawEvent {
   timestamp: DateTime!
   origAddr: String!
@@ -5,11 +10,11 @@ type BootpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   op: Int!
   htype: Int!
   hops: Int!
-  xid: Int!
+  xid: StringNumberU32!
   ciaddr: String!
   yiaddr: String!
   siaddr: String!
@@ -47,14 +52,14 @@ type ConnRawEvent {
   respPort: Int!
   proto: Int!
   connState: String!
-  duration: Int!
+  duration: StringNumberI64!
   service: String!
-  origBytes: Int!
-  respBytes: Int!
-  origPkts: Int!
-  respPkts: Int!
-  origL2Bytes: Int!
-  respL2Bytes: Int!
+  origBytes: StringNumberU64!
+  respBytes: StringNumberU64!
+  origPkts: StringNumberU64!
+  respPkts: StringNumberU64!
+  origL2Bytes: StringNumberU64!
+  respL2Bytes: StringNumberU64!
 }
 
 type ConnRawEventConnection {
@@ -89,8 +94,8 @@ type DceRpcRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
-  rtt: Int!
+  lastTime: StringNumberI64!
+  rtt: StringNumberI64!
   namedPipe: String!
   endpoint: String!
   operation: String!
@@ -123,7 +128,7 @@ type DhcpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   msgType: Int!
   ciaddr: String!
   yiaddr: String!
@@ -133,12 +138,12 @@ type DhcpRawEvent {
   router: [String!]!
   domainNameServer: [String!]!
   reqIpAddr: String!
-  leaseTime: Int!
+  leaseTime: StringNumberU32!
   serverId: String!
   paramReqList: [Int!]!
   message: String!
-  renewalTime: Int!
-  rebindingTime: Int!
+  renewalTime: StringNumberU32!
+  rebindingTime: StringNumberU32!
   classId: [Int!]!
   clientIdType: Int!
   clientId: [Int!]!
@@ -169,9 +174,9 @@ type DnsEventEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   queryName: String!
-  queryStatus: Int!
+  queryStatus: StringNumberU32!
   queryResults: [String!]!
   image: String!
   user: String!
@@ -204,11 +209,11 @@ type DnsRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   query: String!
   answer: [String!]!
   transId: Int!
-  rtt: Int!
+  rtt: StringNumberI64!
   qclass: Int!
   qtype: Int!
   rcode: Int!
@@ -257,10 +262,10 @@ type FileCreateEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   targetFilename: String!
-  creationUtcTime: Int!
+  creationUtcTime: StringNumberI64!
   user: String!
 }
 
@@ -289,10 +294,10 @@ type FileCreateStreamHashEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   targetFilename: String!
-  creationUtcTime: Int!
+  creationUtcTime: StringNumberI64!
   hash: [String!]!
   contents: String!
   user: String!
@@ -323,11 +328,11 @@ type FileCreationTimeChangedEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   targetFilename: String!
-  creationUtcTime: Int!
-  previousCreationUtcTime: Int!
+  creationUtcTime: StringNumberI64!
+  previousCreationUtcTime: StringNumberI64!
   user: String!
 }
 
@@ -356,7 +361,7 @@ type FileDeleteDetectedEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   user: String!
   image: String!
   targetFilename: String!
@@ -389,7 +394,7 @@ type FileDeleteEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   user: String!
   image: String!
   targetFilename: String!
@@ -425,7 +430,7 @@ type FtpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   user: String!
   password: String!
   command: String!
@@ -436,7 +441,7 @@ type FtpRawEvent {
   dataRespAddr: String!
   dataRespPort: Int!
   file: String!
-  fileSize: Int!
+  fileSize: StringNumberU64!
   fileId: String!
 }
 
@@ -488,15 +493,15 @@ type HttpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   method: String!
   host: String!
   uri: String!
   referrer: String!
   version: String!
   userAgent: String!
-  requestLen: Int!
-  responseLen: Int!
+  requestLen: StringNumberUSize!
+  responseLen: StringNumberUSize!
   statusCode: Int!
   statusMsg: String!
   username: String!
@@ -538,7 +543,7 @@ type ImageLoadedEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   imageLoaded: String!
   fileVersion: String!
@@ -590,10 +595,10 @@ type KerberosRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
-  clientTime: Int!
-  serverTime: Int!
-  errorCode: Int!
+  lastTime: StringNumberI64!
+  clientTime: StringNumberI64!
+  serverTime: StringNumberI64!
+  errorCode: StringNumberU32!
   clientRealm: String!
   cnameType: Int!
   clientName: [String!]!
@@ -629,8 +634,8 @@ type LdapRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
-  messageId: Int!
+  lastTime: StringNumberI64!
+  messageId: StringNumberU32!
   version: Int!
   opcode: [String!]!
   result: [String!]!
@@ -697,7 +702,7 @@ type MqttRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   protocol: String!
   version: Int!
   clientId: String!
@@ -741,8 +746,8 @@ type Netflow5RawEvent {
   nextHop: String!
   input: Int!
   output: Int!
-  dPkts: Int!
-  dOctets: Int!
+  dPkts: StringNumberU32!
+  dOctets: StringNumberU32!
   first: String!
   last: String!
   srcPort: Int!
@@ -754,7 +759,7 @@ type Netflow5RawEvent {
   dstAs: Int!
   srcMask: Int!
   dstMask: Int!
-  sequence: Int!
+  sequence: StringNumberU32!
   engineType: Int!
   engineId: Int!
   samplingMode: String!
@@ -783,8 +788,8 @@ type Netflow5RawEventEdge {
 
 type Netflow9RawEvent {
   timestamp: DateTime!
-  sequence: Int!
-  sourceId: Int!
+  sequence: StringNumberU32!
+  sourceId: StringNumberU32!
   templateId: Int!
   origAddr: String!
   origPort: Int!
@@ -829,7 +834,7 @@ type NetworkConnectionEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   user: String!
   protocol: String!
@@ -924,7 +929,7 @@ type NfsRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   readFiles: [String!]!
   writeFiles: [String!]!
 }
@@ -956,7 +961,7 @@ type NtlmRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   username: String!
   hostname: String!
   domainname: String!
@@ -1080,7 +1085,7 @@ type PipeEventEvent {
   agentId: String!
   eventType: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   pipeName: String!
   image: String!
   user: String!
@@ -1116,7 +1121,7 @@ type ProcessCreateEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   fileVersion: String!
   description: String!
@@ -1127,12 +1132,12 @@ type ProcessCreateEvent {
   currentDirectory: String!
   user: String!
   logonGuid: String!
-  logonId: Int!
-  terminalSessionId: Int!
+  logonId: StringNumberU32!
+  terminalSessionId: StringNumberU32!
   integrityLevel: String!
   hashes: [String!]!
   parentProcessGuid: String!
-  parentProcessId: Int!
+  parentProcessId: StringNumberU32!
   parentImage: String!
   parentCommandLine: String!
   parentUser: String!
@@ -1163,7 +1168,7 @@ type ProcessTamperingEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   tamperType: String!
   user: String!
@@ -1194,7 +1199,7 @@ type ProcessTerminatedEvent {
   agentName: String!
   agentId: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   user: String!
 }
@@ -1563,7 +1568,7 @@ type RdpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   cookie: String!
 }
 
@@ -1593,7 +1598,7 @@ type RegistryKeyValueRenameEvent {
   agentId: String!
   eventType: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   targetObject: String!
   newName: String!
@@ -1626,7 +1631,7 @@ type RegistryValueSetEvent {
   agentId: String!
   eventType: String!
   processGuid: String!
-  processId: Int!
+  processId: StringNumberU32!
   image: String!
   targetObject: String!
   details: String!
@@ -1717,18 +1722,18 @@ type SmbRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   command: Int!
   path: String!
   service: String!
   fileName: String!
-  fileSize: Int!
+  fileSize: StringNumberU64!
   resourceType: Int!
   fid: Int!
-  createTime: Int!
-  accessTime: Int!
-  writeTime: Int!
-  changeTime: Int!
+  createTime: StringNumberI64!
+  accessTime: StringNumberI64!
+  writeTime: StringNumberI64!
+  changeTime: StringNumberI64!
 }
 
 type SmbRawEventConnection {
@@ -1758,7 +1763,7 @@ type SmtpRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   mailfrom: String!
   date: String!
   from: String!
@@ -1795,7 +1800,7 @@ type SshRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   client: String!
   server: String!
   cipherAlg: String!
@@ -1839,7 +1844,7 @@ type StatisticsDetail {
 }
 
 type StatisticsInfo {
-  timestamp: Int!
+  timestamp: StringNumberI64!
   detail: [StatisticsDetail!]!
 }
 
@@ -1927,7 +1932,7 @@ type TlsRawEvent {
   respAddr: String!
   respPort: Int!
   proto: Int!
-  lastTime: Int!
+  lastTime: StringNumberI64!
   serverName: String!
   alpnProtocol: String!
   ja3: String!
@@ -1941,8 +1946,8 @@ type TlsRawEvent {
   subjectCountry: String!
   subjectOrgName: String!
   subjectCommonName: String!
-  validityNotBefore: Int!
-  validityNotAfter: Int!
+  validityNotBefore: StringNumberI64!
+  validityNotAfter: StringNumberI64!
   subjectAltName: String!
   issuerCountry: String!
   issuerOrgName: String!

--- a/src/graphql/netflow.rs
+++ b/src/graphql/netflow.rs
@@ -1,6 +1,8 @@
 use std::{fmt::Debug, net::IpAddr};
 
-use async_graphql::{connection::Connection, Context, InputObject, Object, Result, SimpleObject};
+use async_graphql::{
+    connection::Connection, Context, InputObject, Object, Result, SimpleObject, StringNumber,
+};
 use chrono::{DateTime, Utc};
 use giganto_client::ingest::netflow::{Netflow5, Netflow9};
 use giganto_proc_macro::ConvertGraphQLEdgesNode;
@@ -100,8 +102,8 @@ pub struct Netflow5RawEvent {
     next_hop: String,
     input: u16,
     output: u16,
-    d_pkts: u32,
-    d_octets: u32,
+    d_pkts: StringNumber<u32>,
+    d_octets: StringNumber<u32>,
     first: String, // milliseconds
     last: String,  // milliseconds
     src_port: u16,
@@ -113,7 +115,7 @@ pub struct Netflow5RawEvent {
     dst_as: u16,
     src_mask: u8,
     dst_mask: u8,
-    sequence: u32,
+    sequence: StringNumber<u32>,
     engine_type: u8,
     engine_id: u8,
     sampling_mode: String,
@@ -129,8 +131,8 @@ impl FromKeyValue<Netflow5> for Netflow5RawEvent {
             next_hop: val.next_hop.to_string(),
             input: val.input,
             output: val.output,
-            d_pkts: val.d_pkts,
-            d_octets: val.d_octets,
+            d_pkts: StringNumber(val.d_pkts),
+            d_octets: StringNumber(val.d_octets),
             first: millis_to_secs(val.first),
             last: millis_to_secs(val.last),
             src_port: val.src_port,
@@ -142,7 +144,7 @@ impl FromKeyValue<Netflow5> for Netflow5RawEvent {
             dst_as: val.dst_as,
             src_mask: val.src_mask,
             dst_mask: val.dst_mask,
-            sequence: val.sequence,
+            sequence: StringNumber(val.sequence),
             engine_type: val.engine_type,
             engine_id: val.engine_id,
             sampling_mode: format!("{:x}", val.sampling_mode),
@@ -156,8 +158,8 @@ impl FromKeyValue<Netflow5> for Netflow5RawEvent {
 #[allow(clippy::module_name_repetitions)]
 pub struct Netflow9RawEvent {
     timestamp: DateTime<Utc>,
-    sequence: u32,
-    source_id: u32,
+    sequence: StringNumber<u32>,
+    source_id: StringNumber<u32>,
     template_id: u16,
     orig_addr: String,
     orig_port: u16,
@@ -171,8 +173,8 @@ impl FromKeyValue<Netflow9> for Netflow9RawEvent {
     fn from_key_value(key: &[u8], val: Netflow9) -> Result<Self> {
         Ok(Netflow9RawEvent {
             timestamp: get_timestamp_from_key(key)?,
-            sequence: val.sequence,
-            source_id: val.source_id,
+            sequence: StringNumber(val.sequence),
+            source_id: StringNumber(val.source_id),
             template_id: val.template_id,
             orig_addr: val.orig_addr.to_string(),
             orig_port: val.orig_port,

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, fmt::Debug, iter::Peekable, net::IpAddr};
 
 use async_graphql::{
     connection::{query, Connection, Edge},
-    Context, Object, Result, SimpleObject, Union,
+    Context, Object, Result, SimpleObject, StringNumber, Union,
 };
 use chrono::{DateTime, Utc};
 use giganto_client::ingest::network::{
@@ -135,14 +135,14 @@ struct ConnRawEvent {
     resp_port: u16,
     proto: u8,
     conn_state: String,
-    duration: i64,
+    duration: StringNumber<i64>,
     service: String,
-    orig_bytes: u64,
-    resp_bytes: u64,
-    orig_pkts: u64,
-    resp_pkts: u64,
-    orig_l2_bytes: u64,
-    resp_l2_bytes: u64,
+    orig_bytes: StringNumber<u64>,
+    resp_bytes: StringNumber<u64>,
+    orig_pkts: StringNumber<u64>,
+    resp_pkts: StringNumber<u64>,
+    orig_l2_bytes: StringNumber<u64>,
+    resp_l2_bytes: StringNumber<u64>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -155,11 +155,11 @@ struct DnsRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     query: String,
     answer: Vec<String>,
     trans_id: u16,
-    rtt: i64,
+    rtt: StringNumber<i64>,
     qclass: u16,
     qtype: u16,
     rcode: u16,
@@ -179,15 +179,15 @@ struct HttpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     method: String,
     host: String,
     uri: String,
     referrer: String,
     version: String,
     user_agent: String,
-    request_len: usize,
-    response_len: usize,
+    request_len: StringNumber<usize>,
+    response_len: StringNumber<usize>,
     status_code: u16,
     status_msg: String,
     username: String,
@@ -213,7 +213,7 @@ struct RdpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     cookie: String,
 }
 
@@ -226,7 +226,7 @@ struct SmtpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     mailfrom: String,
     date: String,
     from: String,
@@ -245,7 +245,7 @@ struct NtlmRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     username: String,
     hostname: String,
     domainname: String,
@@ -262,10 +262,10 @@ struct KerberosRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
-    client_time: i64,
-    server_time: i64,
-    error_code: u32,
+    last_time: StringNumber<i64>,
+    client_time: StringNumber<i64>,
+    server_time: StringNumber<i64>,
+    error_code: StringNumber<u32>,
     client_realm: String,
     cname_type: u8,
     client_name: Vec<String>,
@@ -283,7 +283,7 @@ struct SshRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     client: String,
     server: String,
     cipher_alg: String,
@@ -308,8 +308,8 @@ struct DceRpcRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
-    rtt: i64,
+    last_time: StringNumber<i64>,
+    rtt: StringNumber<i64>,
     named_pipe: String,
     endpoint: String,
     operation: String,
@@ -324,7 +324,7 @@ struct FtpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     user: String,
     password: String,
     command: String,
@@ -335,7 +335,7 @@ struct FtpRawEvent {
     data_resp_addr: String,
     data_resp_port: u16,
     file: String,
-    file_size: u64,
+    file_size: StringNumber<u64>,
     file_id: String,
 }
 
@@ -348,7 +348,7 @@ struct MqttRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     protocol: String,
     version: u8,
     client_id: String,
@@ -366,8 +366,8 @@ struct LdapRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
-    message_id: u32,
+    last_time: StringNumber<i64>,
+    message_id: StringNumber<u32>,
     version: u8,
     opcode: Vec<String>,
     result: Vec<String>,
@@ -385,7 +385,7 @@ struct TlsRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     server_name: String,
     alpn_protocol: String,
     ja3: String,
@@ -400,8 +400,8 @@ struct TlsRawEvent {
     subject_country: String,
     subject_org_name: String,
     subject_common_name: String,
-    validity_not_before: i64,
-    validity_not_after: i64,
+    validity_not_before: StringNumber<i64>,
+    validity_not_after: StringNumber<i64>,
     subject_alt_name: String,
     issuer_country: String,
     issuer_org_name: String,
@@ -419,18 +419,18 @@ struct SmbRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     command: u8,
     path: String,
     service: String,
     file_name: String,
-    file_size: u64,
+    file_size: StringNumber<u64>,
     resource_type: u16,
     fid: u16,
-    create_time: i64,
-    access_time: i64,
-    write_time: i64,
-    change_time: i64,
+    create_time: StringNumber<i64>,
+    access_time: StringNumber<i64>,
+    write_time: StringNumber<i64>,
+    change_time: StringNumber<i64>,
 }
 
 #[derive(SimpleObject, Debug, ConvertGraphQLEdgesNode)]
@@ -442,7 +442,7 @@ struct NfsRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     read_files: Vec<String>,
     write_files: Vec<String>,
 }
@@ -456,11 +456,11 @@ struct BootpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     op: u8,
     htype: u8,
     hops: u8,
-    xid: u32,
+    xid: StringNumber<u32>,
     ciaddr: String,
     yiaddr: String,
     siaddr: String,
@@ -479,7 +479,7 @@ struct DhcpRawEvent {
     resp_addr: String,
     resp_port: u16,
     proto: u8,
-    last_time: i64,
+    last_time: StringNumber<i64>,
     msg_type: u8,
     ciaddr: String,
     yiaddr: String,
@@ -489,12 +489,12 @@ struct DhcpRawEvent {
     router: Vec<String>,
     domain_name_server: Vec<String>,
     req_ip_addr: String,
-    lease_time: u32,
+    lease_time: StringNumber<u32>,
     server_id: String,
     param_req_list: Vec<u8>,
     message: String,
-    renewal_time: u32,
-    rebinding_time: u32,
+    renewal_time: StringNumber<u32>,
+    rebinding_time: StringNumber<u32>,
     class_id: Vec<u8>,
     client_id_type: u8,
     client_id: Vec<u8>,
@@ -581,7 +581,7 @@ impl From<network_raw_events::NetworkRawEventsNetworkRawEventsEdgesNode> for Net
 }
 
 macro_rules! from_key_value {
-    ($to:ty, $from:ty, $($fields:ident),*) => {
+    ($to:ty, $from:ty,$( $plain_field:ident ),* ; $( $str_num_field:ident ),* ) => {
         impl FromKeyValue<$from> for $to {
             fn from_key_value(key: &[u8], val: $from) -> Result<Self> {
                 let timestamp = get_timestamp_from_key(key)?;
@@ -592,9 +592,13 @@ macro_rules! from_key_value {
                     orig_port: val.orig_port,
                     resp_port: val.resp_port,
                     proto: val.proto,
-                    last_time: val.last_time,
                     $(
-                        $fields: val.$fields,
+                        $plain_field: val.$plain_field,
+                    )*
+                    $(
+                        $str_num_field: {
+                            StringNumber(val.$str_num_field)
+                        },
                     )*
                 })
             }
@@ -612,14 +616,14 @@ impl FromKeyValue<Conn> for ConnRawEvent {
             resp_port: val.resp_port,
             proto: val.proto,
             conn_state: val.conn_state,
-            duration: val.duration,
+            duration: StringNumber(val.duration),
             service: val.service,
-            orig_bytes: val.orig_bytes,
-            resp_bytes: val.resp_bytes,
-            orig_pkts: val.orig_pkts,
-            resp_pkts: val.resp_pkts,
-            orig_l2_bytes: val.orig_l2_bytes,
-            resp_l2_bytes: val.resp_l2_bytes,
+            orig_bytes: StringNumber(val.orig_bytes),
+            resp_bytes: StringNumber(val.resp_bytes),
+            orig_pkts: StringNumber(val.orig_pkts),
+            resp_pkts: StringNumber(val.resp_pkts),
+            orig_l2_bytes: StringNumber(val.orig_l2_bytes),
+            resp_l2_bytes: StringNumber(val.resp_l2_bytes),
         })
     }
 }
@@ -633,7 +637,7 @@ impl FromKeyValue<Ftp> for FtpRawEvent {
             orig_port: val.orig_port,
             resp_port: val.resp_port,
             proto: val.proto,
-            last_time: val.last_time,
+            last_time: StringNumber(val.last_time),
             user: val.user,
             password: val.password,
             command: val.command,
@@ -644,7 +648,7 @@ impl FromKeyValue<Ftp> for FtpRawEvent {
             data_resp_addr: val.data_resp_addr.to_string(),
             data_resp_port: val.data_resp_port,
             file: val.file,
-            file_size: val.file_size,
+            file_size: StringNumber(val.file_size),
             file_id: val.file_id,
         })
     }
@@ -659,11 +663,11 @@ impl FromKeyValue<Bootp> for BootpRawEvent {
             resp_addr: val.resp_addr.to_string(),
             resp_port: val.resp_port,
             proto: val.proto,
-            last_time: val.last_time,
+            last_time: StringNumber(val.last_time),
             op: val.op,
             htype: val.htype,
             hops: val.hops,
-            xid: val.xid,
+            xid: StringNumber(val.xid),
             ciaddr: val.ciaddr.to_string(),
             yiaddr: val.yiaddr.to_string(),
             siaddr: val.siaddr.to_string(),
@@ -684,7 +688,7 @@ impl FromKeyValue<Dhcp> for DhcpRawEvent {
             resp_addr: val.resp_addr.to_string(),
             resp_port: val.resp_port,
             proto: val.proto,
-            last_time: val.last_time,
+            last_time: StringNumber(val.last_time),
             msg_type: val.msg_type,
             ciaddr: val.ciaddr.to_string(),
             yiaddr: val.yiaddr.to_string(),
@@ -698,12 +702,12 @@ impl FromKeyValue<Dhcp> for DhcpRawEvent {
                 .map(ToString::to_string)
                 .collect(),
             req_ip_addr: val.req_ip_addr.to_string(),
-            lease_time: val.lease_time,
+            lease_time: StringNumber(val.lease_time),
             server_id: val.server_id.to_string(),
             param_req_list: val.param_req_list.clone(),
             message: val.message.clone(),
-            renewal_time: val.renewal_time,
-            rebinding_time: val.rebinding_time,
+            renewal_time: StringNumber(val.renewal_time),
+            rebinding_time: StringNumber(val.rebinding_time),
             class_id: val.class_id.clone(),
             client_id_type: val.client_id_type,
             client_id: val.client_id.clone(),
@@ -720,8 +724,6 @@ from_key_value!(
     referrer,
     version,
     user_agent,
-    request_len,
-    response_len,
     status_code,
     status_msg,
     username,
@@ -735,9 +737,12 @@ from_key_value!(
     resp_filenames,
     resp_mime_types,
     post_body,
-    state
+    state;
+    last_time,
+    request_len,
+    response_len
 );
-from_key_value!(RdpRawEvent, Rdp, cookie);
+from_key_value!(RdpRawEvent, Rdp, cookie; last_time);
 
 from_key_value!(
     DnsRawEvent,
@@ -745,7 +750,6 @@ from_key_value!(
     query,
     answer,
     trans_id,
-    rtt,
     qclass,
     qtype,
     rcode,
@@ -753,7 +757,9 @@ from_key_value!(
     tc_flag,
     rd_flag,
     ra_flag,
-    ttl
+    ttl;
+    last_time,
+    rtt
 );
 
 from_key_value!(
@@ -765,7 +771,8 @@ from_key_value!(
     to,
     subject,
     agent,
-    state
+    state;
+    last_time
 );
 
 from_key_value!(
@@ -775,21 +782,23 @@ from_key_value!(
     hostname,
     domainname,
     success,
-    protocol
+    protocol;
+    last_time
 );
 
 from_key_value!(
     KerberosRawEvent,
     Kerberos,
-    client_time,
-    server_time,
-    error_code,
     client_realm,
     cname_type,
     client_name,
     realm,
     sname_type,
-    service_name
+    service_name;
+    last_time,
+    client_time,
+    server_time,
+    error_code
 );
 
 from_key_value!(
@@ -807,10 +816,19 @@ from_key_value!(
     hassh_server_algorithms,
     hassh_server,
     client_shka,
-    server_shka
+    server_shka;
+    last_time
 );
 
-from_key_value!(DceRpcRawEvent, DceRpc, rtt, named_pipe, endpoint, operation);
+from_key_value!(
+    DceRpcRawEvent,
+    DceRpc,
+    named_pipe,
+    endpoint,
+    operation;
+    last_time,
+    rtt
+);
 
 from_key_value!(
     MqttRawEvent,
@@ -820,19 +838,21 @@ from_key_value!(
     client_id,
     connack_reason,
     subscribe,
-    suback_reason
+    suback_reason;
+    last_time
 );
 
 from_key_value!(
     LdapRawEvent,
     Ldap,
-    message_id,
     version,
     opcode,
     result,
     diagnostic_message,
     object,
-    argument
+    argument;
+    last_time,
+    message_id
 );
 
 from_key_value!(
@@ -851,14 +871,15 @@ from_key_value!(
     subject_country,
     subject_org_name,
     subject_common_name,
-    validity_not_before,
-    validity_not_after,
     subject_alt_name,
     issuer_country,
     issuer_org_name,
     issuer_org_unit_name,
     issuer_common_name,
-    last_alert
+    last_alert;
+    last_time,
+    validity_not_before,
+    validity_not_after
 );
 
 from_key_value!(
@@ -868,16 +889,17 @@ from_key_value!(
     path,
     service,
     file_name,
-    file_size,
     resource_type,
-    fid,
+    fid;
+    last_time,
+    file_size,
     create_time,
     access_time,
     write_time,
     change_time
 );
 
-from_key_value!(NfsRawEvent, Nfs, read_files, write_files);
+from_key_value!(NfsRawEvent, Nfs, read_files, write_files; last_time);
 
 async fn handle_paged_conn_raw_events<'ctx>(
     ctx: &Context<'ctx>,

--- a/src/graphql/network/tests.rs
+++ b/src/graphql/network/tests.rs
@@ -129,6 +129,13 @@ async fn conn_with_data() {
                     origAddr,
                     respAddr,
                     origPort,
+                    duration,
+                    origBytes,
+                    respBytes,
+                    origPkts,
+                    respPkts,
+                    origL2Bytes,
+                    respL2Bytes,
                 }
             }
         }
@@ -136,7 +143,9 @@ async fn conn_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{connRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", origPort: 46378}}]}}"
+        "{connRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", \
+         origPort: 46378, duration: \"12345\", origBytes: \"77\", respBytes: \"295\", origPkts: \
+         \"397\", respPkts: \"511\", origL2Bytes: \"21515\", respL2Bytes: \"27889\"}}]}}"
     );
 }
 
@@ -189,6 +198,13 @@ async fn conn_with_data_giganto_cluster() {
                     origAddr,
                     respAddr,
                     origPort,
+                    duration,
+                    origBytes,
+                    respBytes,
+                    origPkts,
+                    respPkts,
+                    origL2Bytes,
+                    respL2Bytes,
                 }
             }
         }
@@ -248,7 +264,9 @@ async fn conn_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{connRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", origPort: 46378}}]}}"
+        "{connRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", \
+         origPort: 46378, duration: \"324234\", origBytes: \"0\", respBytes: \"0\", origPkts: \
+         \"6\", respPkts: \"0\", origL2Bytes: \"0\", respL2Bytes: \"0\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -382,6 +400,7 @@ async fn dns_with_data() {
                     origAddr,
                     respAddr,
                     origPort,
+                    rtt,
                 }
             }
         }
@@ -389,7 +408,8 @@ async fn dns_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{dnsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"31.3.245.133\", origPort: 46378}}]}}"
+        "{dnsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"31.3.245.133\", \
+        origPort: 46378, rtt: \"1\"}}]}}"
     );
 }
 
@@ -444,6 +464,7 @@ async fn dns_with_data_giganto_cluster() {
                     origAddr,
                     respAddr,
                     origPort,
+                    rtt,
                 }
             }
         }
@@ -513,7 +534,8 @@ async fn dns_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{dnsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"31.3.245.133\", origPort: 46378}}]}}"
+        "{dnsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"31.3.245.133\", \
+        origPort: 46378, rtt: \"567\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -634,6 +656,8 @@ async fn http_with_data() {
                     origAddr,
                     respAddr,
                     origPort,
+                    requestLen,
+                    responseLen,
                 }
             }
         }
@@ -641,7 +665,8 @@ async fn http_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{httpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", origPort: 46378}}]}}"
+        "{httpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", \
+         origPort: 46378, requestLen: \"0\", responseLen: \"0\"}}]}}"
     );
 }
 
@@ -706,6 +731,8 @@ async fn http_with_data_giganto_cluster() {
                     origAddr,
                     respAddr,
                     origPort,
+                    requestLen,
+                    responseLen,
                 }
             }
         }
@@ -796,7 +823,8 @@ async fn http_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{httpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", origPort: 46378}}]}}"
+        "{httpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", respAddr: \"192.168.4.76\", \
+         origPort: 46378, requestLen: \"1024\", responseLen: \"2048\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -1365,6 +1393,9 @@ async fn kerberos_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    clientTime,
+                    serverTime,
+                    errorCode,
                 }
             }
         }
@@ -1431,7 +1462,8 @@ async fn kerberos_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{kerberosRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{kerberosRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", clientTime: \
+        \"123456789\", serverTime: \"987654321\", errorCode: \"0\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -1651,6 +1683,7 @@ async fn dce_rpc_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    rtt,
                 }
             }
         }
@@ -1707,7 +1740,7 @@ async fn dce_rpc_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{dceRpcRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{dceRpcRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", rtt: \"123456\"}}]}}"
     );
     mock.assert_async().await;
 }
@@ -1787,6 +1820,7 @@ async fn ftp_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    fileSize,
                 }
             }
         }
@@ -1851,7 +1885,7 @@ async fn ftp_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{ftpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{ftpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", fileSize: \"1024\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -2065,6 +2099,7 @@ async fn ldap_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    messageId,
                 }
             }
         }
@@ -2139,7 +2174,7 @@ async fn ldap_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{ldapRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{ldapRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", messageId: \"123\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -2229,6 +2264,8 @@ async fn tls_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    validityNotBefore,
+                    validityNotAfter,
                 }
             }
         }
@@ -2313,7 +2350,8 @@ async fn tls_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{tlsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{tlsRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", validityNotBefore: \
+        \"1637076000\", validityNotAfter: \"1668612000\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -2338,6 +2376,11 @@ async fn smb_with_data() {
             edges {
                 node {
                     origAddr,
+                    fileSize,
+                    createTime,
+                    accessTime,
+                    writeTime,
+                    changeTime,
                 }
             }
         }
@@ -2345,7 +2388,9 @@ async fn smb_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{smbRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{smbRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", fileSize: \"10\", \
+        createTime: \"10000000\", accessTime: \"20000000\", writeTime: \"10000000\", \
+        changeTime: \"20000000\"}}]}}"
     );
 }
 
@@ -2393,6 +2438,11 @@ async fn smb_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    fileSize,
+                    createTime,
+                    accessTime,
+                    writeTime,
+                    changeTime,
                 }
             }
         }
@@ -2455,7 +2505,9 @@ async fn smb_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{smbRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{smbRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", fileSize: \"1024\", \
+        createTime: \"1609459200\", accessTime: \"1637076000\", writeTime: \"1668612000\", \
+        changeTime: \"1700148000\"}}]}}"
     );
 
     mock.assert_async().await;
@@ -2609,6 +2661,7 @@ async fn bootp_with_data() {
             edges {
                 node {
                     origAddr,
+                    xid,
                 }
             }
         }
@@ -2616,7 +2669,7 @@ async fn bootp_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{bootpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{bootpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", xid: \"0\"}}]}}"
     );
 }
 
@@ -2664,6 +2717,7 @@ async fn bootp_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    xid
                 }
             }
         }
@@ -2726,7 +2780,7 @@ async fn bootp_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{bootpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{bootpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", xid: \"0\"}}]}}"
     );
     mock.assert_async().await;
 }
@@ -2750,6 +2804,9 @@ async fn dhcp_with_data() {
             edges {
                 node {
                     origAddr,
+                    leaseTime,
+                    renewalTime,
+                    rebindingTime,
                 }
             }
         }
@@ -2757,7 +2814,8 @@ async fn dhcp_with_data() {
     let res = schema.execute(query).await;
     assert_eq!(
         res.data.to_string(),
-        "{dhcpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{dhcpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", leaseTime: \"1\", \
+        renewalTime: \"1\", rebindingTime: \"1\"}}]}}"
     );
 }
 
@@ -2818,6 +2876,9 @@ async fn dhcp_with_data_giganto_cluster() {
             edges {
                 node {
                     origAddr,
+                    leaseTime,
+                    renewalTime,
+                    rebindingTime,
                 }
             }
         }
@@ -2887,7 +2948,8 @@ async fn dhcp_with_data_giganto_cluster() {
     // then
     assert_eq!(
         res.data.to_string(),
-        "{dhcpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\"}}]}}"
+        "{dhcpRawEvents: {edges: [{node: {origAddr: \"192.168.4.76\", leaseTime: \"1\", \
+        renewalTime: \"1\", rebindingTime: \"1\"}}]}}"
     );
     mock.assert_async().await;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,17 +96,11 @@ extern crate proc_macro;
 ///     fn from(node: conn_raw_events::ConnRawEventsConnRawEventsEdgesNode) -> Self {
 ///         Self {
 ///             timestamp: node.timestamp,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             orig_port: node.orig_port.map(|x| x as _),
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             proto: node.proto as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             duration: node.duration as __,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             service: node.service as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             resp_pkts: node.resp_pkts as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             ttl: node.ttl.into_iter().map(|x| x as _).collect(),
 ///             orig_filenames: node.orig_filenames,
 ///             ja3s: node.ja3_s,
@@ -119,17 +113,11 @@ extern crate proc_macro;
 ///     fn from(node: network_raw_events::NetworkRawEventsNetworkRawEventsEdgesNodeOnConnRawEvent) -> Self {
 ///         Self {
 ///             timestamp: node.timestamp,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             orig_port: node.orig_port.map(|x| x as _),
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             proto: node.proto as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             duration: node.duration as __,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             service: node.service as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             resp_pkts: node.resp_pkts as _,
-///             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 ///             ttl: node.ttl.into_iter().map(|x| x as _).collect(),
 ///             orig_filenames: node.orig_filenames,
 ///             ja3s: node.ja3_s,
@@ -230,19 +218,16 @@ fn derive_from_graphql_client_autogen_2(
                         },
                         (SegmentType::Vec, CastStyle::As) => {
                             quote! {
-                                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 #to_field_name: node.#from_field_name.into_iter().map(|x| x as _).collect(),
                             }
                         },
                         (SegmentType::Option, CastStyle::As) => {
                             quote! {
-                                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 #to_field_name: node.#from_field_name.map(|x| x as _),
                             }
                         },
                         (SegmentType::Other, CastStyle::As) => {
                             quote! {
-                                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 #to_field_name: node.#from_field_name as _,
                             }
                         },
@@ -360,7 +345,7 @@ fn segment_type_and_cast_style(ty: &Type, recursive_into: bool) -> (SegmentType,
 }
 
 fn cast_style(field_type: &Type, recursive_into: bool) -> CastStyle {
-    if is_target_of_force_cast(field_type) {
+    if is_target_of_safe_to_i64_cast(field_type) {
         assert!(!recursive_into, "inappropriate use of `recursive_into`. Please remove `recursive_into` attribute on a field with `{}`", field_type.to_token_stream());
         CastStyle::As
     } else if recursive_into {
@@ -370,9 +355,9 @@ fn cast_style(field_type: &Type, recursive_into: bool) -> CastStyle {
     }
 }
 
-static TARGET_OF_FORCE_CAST: [&str; 8] = ["u8", "u16", "i8", "i16", "i32", "u32", "u64", "usize"];
+static SAFE_TO_I64_TYPES: [&str; 5] = ["u8", "u16", "i8", "i16", "i32"];
 
-fn is_target_of_force_cast(ty: &Type) -> bool {
+fn is_target_of_safe_to_i64_cast(ty: &Type) -> bool {
     let type_token = ty.to_token_stream().to_string();
-    TARGET_OF_FORCE_CAST.contains(&type_token.as_str())
+    SAFE_TO_I64_TYPES.contains(&type_token.as_str())
 }


### PR DESCRIPTION
Close #619

Add macro `from_key_value_with_str_num_fields`.
- `plain_field`: A field that remains unchanged without any type conversion.
- `str_num_field`: A field that is converted to the `StringNumber` type.