### PR TITLE
Change `OpLogFilter::agent_id` to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,28 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `sensor` field to `OpLog`.
+  - Added the `load_connection_by_prefix_timestamp_key` function and
+    `TimestampKeyExtractor` trait to enable querying of keys prefixed with
+    `timestamp`.
+  - The `opLogRawEvents` GraphQL API no longer requires `agentId` and now
+    accepts it as an optional parameter. Additionally, the API response now
+    includes logs from all agents displayed in chronological order, rather than
+    being limited to the logs of a single agent.
+
 ### Changed
 
 - Rename the `csvFormattedRawEvents` GraphQL API to `tsvFormattedRawEvents`.
+- Update the compatibility version of the quic communication modules.
+  - Changed `PEER_VERSION_REQ` to ">=0.24.0-alpha.1,<0.25.0".
+  - Changed `INGEST_VERSION_REQ` to ">=0.24.0-alpha.1,<0.25.0".
+  - Changed `PUBLISH_VERSION_REQ` to ">=0.24.0-alpha.1,<0.25.0".
+- Modify the code related to migration.
+  - Changed `COMPATIBLE_VERSION_REQ` to ">=0.24.0-alpha.1,<0.25.0
+  - Added migration function in `migrate_0_23_0_to_0_24_0_op_log`. This function
+    performs a migration to change the `key`, `value` of `Oplog`.
 
 ## [0.23.0] - 2024-11-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.23.0"
+version = "0.24.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.23.0"
+version = "0.24.0-alpha.1"
 edition = "2021"
 
 [lib]

--- a/src/graphql/client/schema/op_log_raw_events.graphql
+++ b/src/graphql/client/schema/op_log_raw_events.graphql
@@ -12,6 +12,8 @@ query OpLogRawEvents($filter: OpLogFilter!, $after: String, $before: String, $fi
                 timestamp
                 level
                 contents
+                agentName
+                sensor
             }
         }
     }

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -980,7 +980,8 @@ type NtlmRawEventEdge {
 
 input OpLogFilter {
   time: TimeRange
-  agentId: String!
+  sensor: String
+  agentId: String
   logLevel: String
   contents: String
 }
@@ -989,6 +990,8 @@ type OpLogRawEvent {
   timestamp: DateTime!
   level: String!
   contents: String!
+  agentName: String!
+  sensor: String!
 }
 
 type OpLogRawEventConnection {

--- a/src/ingest/generation.rs
+++ b/src/ingest/generation.rs
@@ -1,0 +1,42 @@
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use chrono::{Datelike, Utc};
+
+pub struct SequenceGenerator {
+    counter: AtomicUsize,
+    last_reset_date: AtomicU32,
+}
+
+impl SequenceGenerator {
+    pub(crate) fn new() -> Self {
+        Self {
+            counter: AtomicUsize::new(0),
+            last_reset_date: AtomicU32::new(SequenceGenerator::get_current_date_time()),
+        }
+    }
+
+    pub(crate) fn generate_sequence_number(&self) -> usize {
+        let current_date_time = SequenceGenerator::get_current_date_time();
+        let last_reset_day = self.last_reset_date.load(Ordering::Acquire);
+
+        if last_reset_day == current_date_time {
+            return self.counter.fetch_add(1, Ordering::Relaxed);
+        }
+
+        self.last_reset_date
+            .store(current_date_time, Ordering::Release);
+        self.counter.store(1, Ordering::Release);
+        1
+    }
+
+    pub(crate) fn init_generator() -> Arc<SequenceGenerator> {
+        let generator = SequenceGenerator::new();
+        Arc::new(generator)
+    }
+
+    pub(crate) fn get_current_date_time() -> u32 {
+        let utc_now = Utc::now();
+        utc_now.day()
+    }
+}

--- a/src/ingest/implement.rs
+++ b/src/ingest/implement.rs
@@ -305,6 +305,13 @@ impl EventFilter for OpLog {
     fn log_contents(&self) -> Option<String> {
         Some(self.contents.clone())
     }
+    fn agent_id(&self) -> Option<String> {
+        Some(self.agent_name.clone())
+    }
+
+    fn sensor(&self) -> Option<String> {
+        Some(self.sensor.clone())
+    }
 }
 
 impl EventFilter for PeriodicTimeSeries {

--- a/src/ingest/tests.rs
+++ b/src/ingest/tests.rs
@@ -50,7 +50,7 @@ const KEY_PATH: &str = "tests/certs/node1/key.pem";
 const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
 const HOST: &str = "node1";
 const TEST_PORT: u16 = 60190;
-const PROTOCOL_VERSION: &str = "0.23.0";
+const PROTOCOL_VERSION: &str = "0.24.0-alpha.1";
 
 struct TestClient {
     conn: Connection,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -40,7 +40,7 @@ use crate::{
     IngestSensors,
 };
 
-const PEER_VERSION_REQ: &str = ">=0.23.0,<0.24.0";
+const PEER_VERSION_REQ: &str = ">=0.24.0-alpha.1,<0.25.0";
 const PEER_RETRY_INTERVAL: u64 = 5;
 
 pub type Peers = Arc<RwLock<HashMap<String, PeerInfo>>>;
@@ -761,7 +761,7 @@ pub mod tests {
     const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
     const HOST: &str = "node1";
     const TEST_PORT: u16 = 60191;
-    const PROTOCOL_VERSION: &str = "0.23.0";
+    const PROTOCOL_VERSION: &str = "0.24.0-alpha.1";
 
     pub struct TestClient {
         send: SendStream,

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -60,7 +60,7 @@ use crate::server::{
 use crate::storage::{Database, Direction, RawEventStore, StorageKey};
 use crate::{IngestSensors, PcapSensors, StreamDirectChannels};
 
-const PUBLISH_VERSION_REQ: &str = ">=0.23.0,<0.24.0";
+const PUBLISH_VERSION_REQ: &str = ">=0.24.0-alpha.1,<0.25.0";
 
 pub struct Server {
     server_config: ServerConfig,

--- a/src/publish/tests.rs
+++ b/src/publish/tests.rs
@@ -48,7 +48,7 @@ fn get_token() -> &'static Mutex<u32> {
 }
 
 const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
-const PROTOCOL_VERSION: &str = "0.23.0";
+const PROTOCOL_VERSION: &str = "0.24.0-alpha.1";
 
 const NODE1_CERT_PATH: &str = "tests/certs/node1/cert.pem";
 const NODE1_KEY_PATH: &str = "tests/certs/node1/key.pem";

--- a/src/storage/migration/migration_structures.rs
+++ b/src/storage/migration/migration_structures.rs
@@ -1,13 +1,14 @@
 use std::net::IpAddr;
 
+use giganto_client::ingest::log::OpLogLevel;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     ingest::implement::EventFilter,
     storage::{
         Conn as ConnFromV21, Http as HttpFromV21, Netflow5 as Netflow5FromV23,
-        Netflow9 as Netflow9FromV23, Ntlm as NtlmFromV21, SecuLog as SecuLogFromV23,
-        Smtp as SmtpFromV21, Ssh as SshFromV21, Tls as TlsFromV21,
+        Netflow9 as Netflow9FromV23, Ntlm as NtlmFromV21, OpLog as OpLogFromV24,
+        SecuLog as SecuLogFromV23, Smtp as SmtpFromV21, Ssh as SshFromV21, Tls as TlsFromV21,
     },
 };
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -483,6 +484,24 @@ impl From<SecuLogBeforeV23> for SecuLogFromV23 {
             resp_addr: input.resp_addr,
             resp_port: input.resp_port,
             proto: input.proto,
+            contents: input.contents,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct OpLogBeforeV24 {
+    pub agent_name: String,
+    pub log_level: OpLogLevel,
+    pub contents: String,
+}
+
+impl From<OpLogBeforeV24> for OpLogFromV24 {
+    fn from(input: OpLogBeforeV24) -> Self {
+        Self {
+            sensor: String::new(),
+            agent_name: input.agent_name,
+            log_level: input.log_level,
             contents: input.contents,
         }
     }


### PR DESCRIPTION
Close #724

The RocksDB keys in the `oplog` are currently in the form agent_id-0-timestamp. This change modifies the keys to the form timestamp-sequence.
