### PR TITLE
Fix `Connection` of type `PcapSources` to `Vec<Connection>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `Connection` of type `PcapSources` to `Vec<Connection>`. This change
+  will allow giganto to find the latest `Connection` and extract pcap even if it
+  detects a late disconnect from ingest.
+
 ## [0.22.0] - 2024-10-04
 
 ### Added
@@ -569,6 +577,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.22.0...main
 [0.22.0]: https://github.com/aicers/giganto/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/aicers/giganto/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/aicers/giganto/compare/0.19.0...0.20.0

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -410,7 +410,7 @@ where
         let item = item.expect("not error value");
         let data_type = item.1.data_type();
 
-        match filter.check(
+        if let Ok(true) = filter.check(
             item.1.orig_addr(),
             item.1.resp_addr(),
             item.1.orig_port(),
@@ -421,8 +421,7 @@ where
             item.1.source(),
             item.1.agent_id(),
         ) {
-            Ok(true) => records.push(item),
-            Ok(false) | Err(_) => {}
+            records.push(item);
         }
         if records.len() == size {
             if invalid_data_cnt > 1 {

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -2709,7 +2709,7 @@ where
     T: Display + EventFilter + JsonOutput<N> + Serialize,
     N: Serialize,
 {
-    match filter.check(
+    if let Ok(true) = filter.check(
         value.orig_addr(),
         value.resp_addr(),
         value.orig_port(),
@@ -2720,25 +2720,22 @@ where
         value.source(),
         value.agent_id(),
     ) {
-        Ok(true) => {
-            let (source, timestamp) = parse_key(key)?;
-            let timestamp = DateTime::from_timestamp_nanos(timestamp)
-                .format("%s%.9f")
-                .to_string();
+        let (source, timestamp) = parse_key(key)?;
+        let timestamp = DateTime::from_timestamp_nanos(timestamp)
+            .format("%s%.9f")
+            .to_string();
 
-            match export_type {
-                "csv" => {
-                    writeln!(writer, "{timestamp}\t{source}\t{value}")?;
-                }
-                "json" => {
-                    let json_data = value.convert_json_output(timestamp, source.to_string())?;
-                    let json_data = serde_json::to_string(&json_data)?;
-                    writeln!(writer, "{json_data}")?;
-                }
-                _ => {}
+        match export_type {
+            "csv" => {
+                writeln!(writer, "{timestamp}\t{source}\t{value}")?;
             }
+            "json" => {
+                let json_data = value.convert_json_output(timestamp, source.to_string())?;
+                let json_data = serde_json::to_string(&json_data)?;
+                writeln!(writer, "{json_data}")?;
+            }
+            _ => {}
         }
-        Ok(false) | Err(_) => {}
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ use crate::{
 const ONE_DAY: u64 = 60 * 60 * 24;
 const WAIT_SHUTDOWN: u64 = 15;
 
-pub type PcapSources = Arc<RwLock<HashMap<String, Connection>>>;
+pub type PcapSources = Arc<RwLock<HashMap<String, Vec<Connection>>>>;
 pub type IngestSources = Arc<RwLock<HashSet<String>>>;
 pub type RunTimeIngestSources = Arc<RwLock<HashMap<String, DateTime<Utc>>>>;
 pub type StreamDirectChannels = Arc<RwLock<HashMap<String, UnboundedSender<Vec<u8>>>>>;
@@ -348,7 +348,7 @@ fn to_hms(dur: Duration) -> String {
 }
 
 fn new_pcap_sources() -> PcapSources {
-    Arc::new(RwLock::new(HashMap::<String, Connection>::new()))
+    Arc::new(RwLock::new(HashMap::<String, Vec<Connection>>::new()))
 }
 
 fn new_ingest_sources(db: &Database) -> IngestSources {
@@ -394,7 +394,11 @@ fn init_tracing(path: &Path) -> Result<WorkerGuard> {
         .with_ansi(false)
         .with_target(false)
         .with_writer(file_writer)
-        .with_filter(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()));
+        .with_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        );
 
     let layered_subscriber = tracing_subscriber::registry().with(layer_file);
     #[cfg(debug_assertions)]

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -389,7 +389,11 @@ async fn get_pcap_conn_if_current_giganto_in_charge(
     pcap_sources: PcapSources,
     source: &String,
 ) -> Option<Connection> {
-    pcap_sources.read().await.get(source).cloned()
+    pcap_sources
+        .read()
+        .await
+        .get(source)
+        .and_then(|connections| connections.last().cloned())
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]


### PR DESCRIPTION
- Fix `Connection` of type `PcapSources` to `Vec<Connection>`. This change will allow giganto to find the latest `Connection` and extract pcap even if it detects a late disconnect from ingest.
- Apply the log level based on the RUST_LOG.
- Fix clippy error.

Close: #859
Close: #860