### PR TITLE
Adjust logging behavior by revised logging policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed `config` GraphQL API to respond `retention` field in "{days}d" format
   to align with the format of the configuration field in the API request.
 - `log_dir` is not a required configuration item.
+- Adjust logging behavior by revised logging policy.
+  - If `log_dir` is not present in the local/remote config, logs are written
+    to stdout/stderr.
+  - If `log_dir` in the local/remote config is writable, logs are written to
+    the specified `log_dir`.
+  - If `log_dir` in the local config is not writable, the program terminates.
+  - If `log_dir` in the remote config is not writable, the program enters idle
+    mode.
+  - Logging in idle mode: logs are written to stdout/stderr until the remote
+    config is retrieved.
 
 ### Removed
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -152,6 +152,7 @@ pub struct NodeName(pub String);
 pub struct RebootNotify(Arc<Notify>); // reboot
 pub struct PowerOffNotify(Arc<Notify>); // shutdown
 pub struct TerminateNotify(Arc<Notify>); // stop
+pub struct TracingEnabled(bool);
 
 #[allow(clippy::too_many_arguments)]
 pub fn schema(
@@ -169,6 +170,7 @@ pub fn schema(
     ack_transmission_cnt: AckTransmissionCount,
     is_local_config: bool,
     settings: Option<Settings>,
+    tracing_enabled: bool,
 ) -> Schema {
     Schema::build(Query::default(), Mutation::default(), EmptySubscription)
         .data(node_name)
@@ -185,6 +187,7 @@ pub fn schema(
         .data(PowerOffNotify(notify_power_off))
         .data(is_local_config)
         .data(settings)
+        .data(TracingEnabled(tracing_enabled))
         .finish()
 }
 
@@ -195,6 +198,7 @@ pub fn minimal_schema(
     notify_terminate: Arc<Notify>,
     is_local_config: bool,
     settings: Option<Settings>,
+    tracing_enabled: bool,
 ) -> MinimalSchema {
     MinimalSchema::build(
         MinimalQuery::default(),
@@ -207,6 +211,7 @@ pub fn minimal_schema(
     .data(PowerOffNotify(notify_power_off))
     .data(is_local_config)
     .data(settings)
+    .data(TracingEnabled(tracing_enabled))
     .finish()
 }
 
@@ -1818,6 +1823,7 @@ mod tests {
                 Arc::new(RwLock::new(1024)),
                 is_local_config,
                 Some(settings),
+                true,
             );
 
             Self {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1117,12 +1117,12 @@ pub fn repair_db(
     );
     let start = Instant::now();
     let (db_opts, _) = rocksdb_options(&db_options);
-    info!("repair db start.");
+    println!("repair db start.");
     match DB::repair(&db_opts, db_path) {
-        Ok(()) => info!("repair ok"),
-        Err(e) => error!("repair error: {e}"),
+        Ok(()) => println!("repair ok"),
+        Err(e) => eprintln!("repair error: {e}"),
     }
     let dur = start.elapsed();
-    info!("{}", to_hms(dur));
+    println!("{}", to_hms(dur));
     exit(0);
 }


### PR DESCRIPTION
- If `log_dir` is not present in the local/remote config, logs are written to stdout/stderr.
- If `log_dir` in the local/remote config is writable, logs are written to the specified `log_dir`.
- If `log_dir` in the local config is not writable, the program terminates.
- If `log_dir` in the remote config is not writable, the program enters idle mode.
- Logging in idle mode: logs are written to stdout/stderr until the remote config is retrieved.

Close: #878