### PR TITLE
Add documentation for `DceRpcRawEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `sshRawEvents`
   - `dhcpRawEvents`
   - `bootpRawEvents`
+  - `dceRpcRawEvents`
 - Changed `config` GraphQL API to respond `retention` field in "{days}d" format
   to align with the format of the configuration field in the API request.
 - `log_dir` is not a required configuration item.

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -197,17 +197,43 @@ type ConnRawEventEdge {
 # The input/output is a string in RFC3339 format.
 scalar DateTime
 
+# Represents an event extracted from the DCE-RPC protocol.
 type DceRpcRawEvent {
+  # Start Time
   time: DateTime!
+
+  # Source IP Address
   origAddr: String!
+
+  # Source Port Number
   origPort: Int!
+
+  # Destination IP Address
   respAddr: String!
+
+  # Destination Port Number
   respPort: Int!
+
+  # Protocol Number
+  #
+  # TCP is 6, UDP is 17.
   proto: Int!
+
+  # End Time
+  #
+  # It is measured in nanoseconds.
   lastTime: StringNumberI64!
+
+  # Round-Trip Time
   rtt: StringNumberI64!
+
+  # Named Pipe
   namedPipe: String!
+
+  # Endpoint
   endpoint: String!
+
+  # Operation
   operation: String!
 }
 

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -439,19 +439,35 @@ struct SshRawEvent {
     server_shka: String,
 }
 
+/// Represents and event extracted from the DCE-RPC protocol.
 #[derive(SimpleObject, Debug, ConvertGraphQLEdgesNode)]
 #[graphql_client_type(names = [dce_rpc_raw_events::DceRpcRawEventsDceRpcRawEventsEdgesNode, network_raw_events::NetworkRawEventsNetworkRawEventsEdgesNodeOnDceRpcRawEvent])]
 struct DceRpcRawEvent {
+    /// Start Time
     time: DateTime<Utc>,
+    /// Source IP Address
     orig_addr: String,
+    /// Source Port Number
     orig_port: u16,
+    /// Destination IP Address
     resp_addr: String,
+    /// Destination Port Number
     resp_port: u16,
+    /// Protocol Number
+    ///
+    /// TCP is 6, UDP is 17.
     proto: u8,
+    /// End Time
+    ///
+    /// It is measured in nanoseconds.
     last_time: StringNumberI64,
+    /// Round-Trip Time
     rtt: StringNumberI64,
+    /// Named Pipe
     named_pipe: String,
+    /// Endpoint
     endpoint: String,
+    /// Operation
     operation: String,
 }
 


### PR DESCRIPTION
Closes: #979 ;

Adds documentation for `DceRpcRawEvent` in schema and other related files.