### PR TITLE
Correct the format of `--ca-certs` CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can run Giganto by invoking the following command:
 
 ```sh
 giganto -c <CONFIG_PATH> --cert <CERT_PATH> --key <KEY_PATH> --ca-certs \
-<CA_CERT_PATH>[,<CA_CERT_PATH>...] [--log-dir <LOG_DIR>]
+<CA_CERT_PATH>[,<CA_CERT_PATH>,...] [--log-dir <LOG_DIR>]
 ```
 
 ### Arguments

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -815,9 +815,9 @@ fn check_port(filter_port: Option<&PortRange>, target_port: Option<u16>) -> bool
 }
 
 fn check_contents(filter_str: Option<&str>, target_str: Option<String>) -> bool {
-    filter_str.as_ref().map_or(true, |filter_str| {
-        target_str.is_some_and(|contents| contents.contains(*filter_str))
-    })
+    filter_str
+        .as_ref()
+        .is_none_or(|filter_str| target_str.is_some_and(|contents| contents.contains(*filter_str)))
 }
 
 fn check_agent_id(filter_agent_id: Option<&str>, target_agent_id: Option<&str>) -> bool {
@@ -825,7 +825,7 @@ fn check_agent_id(filter_agent_id: Option<&str>, target_agent_id: Option<&str>) 
 }
 
 fn filter_by_str(filter_str: Option<&str>, target_str: Option<&str>) -> bool {
-    filter_str.as_ref().map_or(true, |filter_id| {
+    filter_str.as_ref().is_none_or(|filter_id| {
         target_str
             .as_ref()
             .is_some_and(|agent_id| agent_id == filter_id)


### PR DESCRIPTION
Added a missing comma in the README.md file.

Closes #1033