### PR TITLE
Rename the log file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+LOG_FILE_NAME = "data_store.log"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.cargo/
 /target
 
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Documentation of the following GraphQL APIs is updated:
   - `dnsRawEvents`
 - Changed default GraphQL API port to 8443.
+- Renamed the log file from giganto.log to data_store.log.
 
 ## [0.24.0] - 2025-02-19
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ giganto -c <CONFIG_PATH> --cert <CERT_PATH> --key <KEY_PATH> --ca-certs \
   - If `<LOG_DIR>` is not provided, logs are written to stdout using the tracing
     library.
   - If `<LOG_DIR>` is provided and writable, logs are written to the specified
-    directory using the tracing library.
+    directory using the tracing library, with the log file named data_store.log.
   - If `<LOG_DIR>` is provided but not writable, Giganto will terminate.
   - Any logs generated before the tracing functionality is initialized will be
     written directly to stdout or stderr using `println`, `eprintln`, or

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,8 +391,7 @@ fn init_tracing(log_dir: Option<&Path>) -> Result<Vec<WorkerGuard>> {
     let mut guards = vec![];
 
     let file_layer = if let Some(log_dir) = log_dir {
-        let file_name = format!("{}.log", env!("CARGO_PKG_NAME"));
-        let file_path = log_dir.join(&file_name);
+        let file_path = log_dir.join(env!("LOG_FILE_NAME"));
         let file = OpenOptions::new()
             .create(true)
             .append(true)


### PR DESCRIPTION
Renamed the log file from giganto.log to data_store.log.
Added the env variable `LOG_FILE_NAME` to the Cargo config file.

Closes #1047