### PR TITLE
Limit PCAP dump to first 10 packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Modified `pcap` GraphQL API to process only the first 10 packets instead of
-  the full pcap, reducing resource usage and improving performance when handling
-  large HTTP sessions, since 10 packets are generally enough for clients to
-  inspect the packet.
+- Adjusted the `pcap` GraphQL API with the following improvements:
+  - Reduced the number of processed packets from up to 1,000 to up to 10,
+    lowering resource usage and improving performance when handling large HTTP
+    sessions. Ten packets are generally sufficient for client-side inspection.
+  - Simplified PCAP generation by removing the intermediate step of reading a
+    temporary file into memory and piping it into `tcpdump` via stdin. Now,
+    `tcpdump` reads directly from the temporary file, reducing overhead and
+    improving efficiency.
 
 ## [0.24.1] - 2025-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified `pcap` GraphQL API to process only the first 10 packets instead of
+  the full pcap, reducing resource usage and improving performance when handling
+  large HTTP sessions, since 10 packets are generally enough for clients to
+  inspect the packet.
+
 ## [0.24.1] - 2025-03-14
 
 ### Changed
@@ -716,6 +725,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
+[Unreleased]: https://github.com/aicers/giganto/compare/0.24.0...main
 [0.24.1]: https://github.com/aicers/giganto/compare/0.24.0...0.24.1
 [0.24.0]: https://github.com/aicers/giganto/compare/0.23.0...0.24.0
 [0.23.0]: https://github.com/aicers/giganto/compare/0.22.1...0.23.0

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -755,7 +755,7 @@ fn write_run_tcpdump(packets: &Vec<pk>) -> Result<String, anyhow::Error> {
     temp_file.read_to_end(&mut buf)?;
 
     let cmd = "tcpdump";
-    let args = ["-n", "-X", "-tttt", "-v", "-r", "-"];
+    let args = ["-n", "-X", "-tttt", "-v", "-c", "10", "-r", "-"];
 
     let mut child = Command::new(cmd)
         .env("PATH", "/usr/sbin:/usr/bin")

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -1570,7 +1570,7 @@ impl KeyExtractor for ExportFilter {
         if let Some(kind) = &self.kind {
             mid_key.extend_from_slice(kind.as_bytes());
             return Some(mid_key);
-        };
+        }
         if let Some(agent_name) = &self.agent_name {
             mid_key.extend_from_slice(agent_name.as_bytes());
             if let Some(agent_id) = &self.agent_id {
@@ -1578,7 +1578,7 @@ impl KeyExtractor for ExportFilter {
                 mid_key.extend_from_slice(agent_id.as_bytes());
             }
             return Some(mid_key);
-        };
+        }
         None
     }
 
@@ -2714,7 +2714,7 @@ fn parse_key(key: &[u8]) -> anyhow::Result<(Cow<str>, i64)> {
             if let Some(t) = key.get(key.len() - 8..) {
                 let timestamp = i64::from_be_bytes(t.try_into()?);
                 return Ok((sensor, timestamp));
-            };
+            }
         }
     }
     Err(anyhow!("Invalid key"))

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -2894,7 +2894,7 @@ fn network_connection(
                         NetworkRawEvents::ConnRawEvent(ConnRawEvent::from_key_value(&key, value)?),
                     ));
                     conn_data = conn_iter.next();
-                };
+                }
             }
             _ if selected == dns_ts => {
                 if let Some((key, value)) = dns_data {
@@ -2903,7 +2903,7 @@ fn network_connection(
                         NetworkRawEvents::DnsRawEvent(DnsRawEvent::from_key_value(&key, value)?),
                     ));
                     dns_data = dns_iter.next();
-                };
+                }
             }
             _ if selected == http_ts => {
                 if let Some((key, value)) = http_data {
@@ -2912,7 +2912,7 @@ fn network_connection(
                         NetworkRawEvents::HttpRawEvent(HttpRawEvent::from_key_value(&key, value)?),
                     ));
                     http_data = http_iter.next();
-                };
+                }
             }
             _ if selected == rdp_ts => {
                 if let Some((key, value)) = rdp_data {
@@ -2921,7 +2921,7 @@ fn network_connection(
                         NetworkRawEvents::RdpRawEvent(RdpRawEvent::from_key_value(&key, value)?),
                     ));
                     rdp_data = rdp_iter.next();
-                };
+                }
             }
             _ if selected == ntlm_ts => {
                 if let Some((key, value)) = ntlm_data {
@@ -2930,7 +2930,7 @@ fn network_connection(
                         NetworkRawEvents::NtlmRawEvent(NtlmRawEvent::from_key_value(&key, value)?),
                     ));
                     ntlm_data = ntlm_iter.next();
-                };
+                }
             }
             _ if selected == kerberos_ts => {
                 if let Some((key, value)) = kerberos_data {
@@ -2941,7 +2941,7 @@ fn network_connection(
                         )?),
                     ));
                     kerberos_data = kerberos_iter.next();
-                };
+                }
             }
             _ if selected == ssh_ts => {
                 if let Some((key, value)) = ssh_data {
@@ -2950,7 +2950,7 @@ fn network_connection(
                         NetworkRawEvents::SshRawEvent(SshRawEvent::from_key_value(&key, value)?),
                     ));
                     ssh_data = ssh_iter.next();
-                };
+                }
             }
             _ if selected == dce_rpc_ts => {
                 if let Some((key, value)) = dce_rpc_data {
@@ -2961,7 +2961,7 @@ fn network_connection(
                         )?),
                     ));
                     dce_rpc_data = dce_rpc_iter.next();
-                };
+                }
             }
             _ if selected == ftp_ts => {
                 if let Some((key, value)) = ftp_data {
@@ -2970,7 +2970,7 @@ fn network_connection(
                         NetworkRawEvents::FtpRawEvent(FtpRawEvent::from_key_value(&key, value)?),
                     ));
                     ftp_data = ftp_iter.next();
-                };
+                }
             }
             _ if selected == mqtt_ts => {
                 if let Some((key, value)) = mqtt_data {
@@ -2979,7 +2979,7 @@ fn network_connection(
                         NetworkRawEvents::MqttRawEvent(MqttRawEvent::from_key_value(&key, value)?),
                     ));
                     mqtt_data = mqtt_iter.next();
-                };
+                }
             }
             _ if selected == ldap_ts => {
                 if let Some((key, value)) = ldap_data {
@@ -2988,7 +2988,7 @@ fn network_connection(
                         NetworkRawEvents::LdapRawEvent(LdapRawEvent::from_key_value(&key, value)?),
                     ));
                     ldap_data = ldap_iter.next();
-                };
+                }
             }
             _ if selected == tls_ts => {
                 if let Some((key, value)) = tls_data {
@@ -2997,7 +2997,7 @@ fn network_connection(
                         NetworkRawEvents::TlsRawEvent(TlsRawEvent::from_key_value(&key, value)?),
                     ));
                     tls_data = tls_iter.next();
-                };
+                }
             }
             _ if selected == smb_ts => {
                 if let Some((key, value)) = smb_data {
@@ -3006,7 +3006,7 @@ fn network_connection(
                         NetworkRawEvents::SmbRawEvent(SmbRawEvent::from_key_value(&key, value)?),
                     ));
                     smb_data = smb_iter.next();
-                };
+                }
             }
             _ if selected == nfs_ts => {
                 if let Some((key, value)) = nfs_data {
@@ -3015,7 +3015,7 @@ fn network_connection(
                         NetworkRawEvents::NfsRawEvent(NfsRawEvent::from_key_value(&key, value)?),
                     ));
                     nfs_data = nfs_iter.next();
-                };
+                }
             }
             _ if selected == smtp_ts => {
                 if let Some((key, value)) = smtp_data {
@@ -3024,7 +3024,7 @@ fn network_connection(
                         NetworkRawEvents::SmtpRawEvent(SmtpRawEvent::from_key_value(&key, value)?),
                     ));
                     smtp_data = smtp_iter.next();
-                };
+                }
             }
             _ if selected == bootp_ts => {
                 if let Some((key, value)) = bootp_data {
@@ -3035,7 +3035,7 @@ fn network_connection(
                         )?),
                     ));
                     bootp_data = bootp_iter.next();
-                };
+                }
             }
             _ if selected == dhcp_ts => {
                 if let Some((key, value)) = dhcp_data {
@@ -3044,7 +3044,7 @@ fn network_connection(
                         NetworkRawEvents::DhcpRawEvent(DhcpRawEvent::from_key_value(&key, value)?),
                     ));
                     dhcp_data = dhcp_iter.next();
-                };
+                }
             }
             _ => {}
         }

--- a/src/graphql/packet.rs
+++ b/src/graphql/packet.rs
@@ -135,7 +135,7 @@ fn handle_pcap(ctx: &Context<'_>, filter: &PacketFilter) -> Result<Pcap> {
         .build();
 
     let iter = store.boundary_iter(&from_key.key(), &to_key.key(), Direction::Forward);
-    let (records, _) = collect_records(iter, 1000, filter);
+    let (records, _) = collect_records(iter, 10, filter);
 
     let packet_vector = records.into_iter().map(|(_, packet)| packet).collect();
 

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -1843,7 +1843,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     process_create_data = process_create_iter.next();
-                };
+                }
             }
             _ if selected == file_create_time_ts => {
                 if let Some((key, value)) = file_create_time_data {
@@ -1854,7 +1854,7 @@ fn sysmon_connection(
                         ),
                     ));
                     file_create_time_data = file_create_time_iter.next();
-                };
+                }
             }
             _ if selected == network_connect_ts => {
                 if let Some((key, value)) = network_connect_data {
@@ -1865,7 +1865,7 @@ fn sysmon_connection(
                         ),
                     ));
                     network_connect_data = network_connect_iter.next();
-                };
+                }
             }
             _ if selected == process_terminate_ts => {
                 if let Some((key, value)) = process_terminate_data {
@@ -1876,7 +1876,7 @@ fn sysmon_connection(
                         ),
                     ));
                     process_terminate_data = process_terminate_iter.next();
-                };
+                }
             }
             _ if selected == image_load_ts => {
                 if let Some((key, value)) = image_load_data {
@@ -1887,7 +1887,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     image_load_data = image_load_iter.next();
-                };
+                }
             }
             _ if selected == file_create_ts => {
                 if let Some((key, value)) = file_create_data {
@@ -1898,7 +1898,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     file_create_data = file_create_iter.next();
-                };
+                }
             }
             _ if selected == registry_value_set_ts => {
                 if let Some((key, value)) = registry_value_set_data {
@@ -1909,7 +1909,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     registry_value_set_data = registry_value_set_iter.next();
-                };
+                }
             }
             _ if selected == registry_key_rename_ts => {
                 if let Some((key, value)) = registry_key_rename_data {
@@ -1920,7 +1920,7 @@ fn sysmon_connection(
                         ),
                     ));
                     registry_key_rename_data = registry_key_rename_iter.next();
-                };
+                }
             }
             _ if selected == file_create_stream_hash_ts => {
                 if let Some((key, value)) = file_create_stream_hash_data {
@@ -1931,7 +1931,7 @@ fn sysmon_connection(
                         ),
                     ));
                     file_create_stream_hash_data = file_create_stream_hash_iter.next();
-                };
+                }
             }
             _ if selected == pipe_event_ts => {
                 if let Some((key, value)) = pipe_event_data {
@@ -1940,7 +1940,7 @@ fn sysmon_connection(
                         SysmonEvents::PipeEventEvent(PipeEventEvent::from_key_value(&key, value)?),
                     ));
                     pipe_event_data = pipe_event_iter.next();
-                };
+                }
             }
             _ if selected == dns_query_ts => {
                 if let Some((key, value)) = dns_query_data {
@@ -1949,7 +1949,7 @@ fn sysmon_connection(
                         SysmonEvents::DnsEventEvent(DnsEventEvent::from_key_value(&key, value)?),
                     ));
                     dns_query_data = dns_query_iter.next();
-                };
+                }
             }
             _ if selected == file_delete_ts => {
                 if let Some((key, value)) = file_delete_data {
@@ -1960,7 +1960,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     file_delete_data = file_delete_iter.next();
-                };
+                }
             }
             _ if selected == process_tamper_ts => {
                 if let Some((key, value)) = process_tamper_data {
@@ -1971,7 +1971,7 @@ fn sysmon_connection(
                         )?),
                     ));
                     process_tamper_data = process_tamper_iter.next();
-                };
+                }
             }
             _ if selected == file_delete_detected_ts => {
                 if let Some((key, value)) = file_delete_detected_data {
@@ -1982,7 +1982,7 @@ fn sysmon_connection(
                         ),
                     ));
                     file_delete_detected_data = file_delete_detected_iter.next();
-                };
+                }
             }
             _ => {}
         }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -166,7 +166,7 @@ async fn handle_connection(
             connection.close(quinn::VarInt::from_u32(0), e.to_string().as_bytes());
             bail!("{e}")
         }
-    };
+    }
 
     let (agent, sensor) = subject_from_cert_verbose(&extract_cert_from_conn(&connection)?)?;
     let rep = agent.contains("reproduce");
@@ -790,7 +790,7 @@ async fn handle_request(
         _ => {
             error!("The record type message could not be processed.");
         }
-    };
+    }
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,22 +331,16 @@ fn segment_type_and_cast_style(ty: &Type, recursive_into: bool) -> (SegmentType,
             if segment.ident == "Vec" {
                 if let PathArguments::AngleBracketed(vec_element_type_arg) = &segment.arguments {
                     for arg in &vec_element_type_arg.args {
-                        match arg {
-                            GenericArgument::Type(el_type) => {
-                                return (SegmentType::Vec, cast_style(el_type, recursive_into));
-                            }
-                            _ => continue,
+                        if let GenericArgument::Type(el_type) = arg {
+                            return (SegmentType::Vec, cast_style(el_type, recursive_into));
                         }
                     }
                 }
             } else if segment.ident == "Option" {
                 if let PathArguments::AngleBracketed(option_element_type_arg) = &segment.arguments {
                     for arg in &option_element_type_arg.args {
-                        match arg {
-                            GenericArgument::Type(el_type) => {
-                                return (SegmentType::Option, cast_style(el_type, recursive_into));
-                            }
-                            _ => continue,
+                        if let GenericArgument::Type(el_type) = arg {
+                            return (SegmentType::Option, cast_style(el_type, recursive_into));
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,6 @@ async fn main() -> Result<()> {
                         Err(e) => {
                             error!("Failed to update configuration: {e:#}");
                             warn!("Run giganto with the previous config");
-                            continue;
                         }
                     }
                 },

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -423,7 +423,6 @@ async fn client_connection(
                                 peer_info.addr,
                             );
                             sleep(Duration::from_secs(PEER_RETRY_INTERVAL)).await;
-                            continue 'connection;
                         }
                         _ => {}
                     }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -478,7 +478,7 @@ where
         RequestStreamRecord::FileCreate => handle_store!(file_create_store, "file_create"),
         RequestStreamRecord::FileDelete => handle_store!(file_delete_store, "file_delete"),
         RequestStreamRecord::Pcap => {}
-    };
+    }
     Ok(())
 }
 


### PR DESCRIPTION
~This draft PR has been opened to document the code used for pcap extraction, which we plan to verify with this commit. It is not yet ready for review, as it is intended solely to share the exact extraction method used.~

Related: #888 
Closes: #1065 

Based on commit e96e4ad in this PR, testing was conducted on the test server, and I have confirmed that PCAP data is successfully served via the GraphQL API. The testing was conducted in both single-queue and multi-queue packet parsing modes. The CI failure with e96e4ad is lint failure from Clippy, which was updated to 1.86.0 very recently. The Clippy fix is addressed in the last commit of this PR. The lint check is now passing. So I convert this draft PR to a regular pull request.

---

Note: Since this PR might not be sufficient to fully resolve the broad issue demonstrated in #888, I only used the Github keyword "Related" for the issue #888.