### PR TITLE
Change logging behavior to depend on log_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Logging behavior no longer considers the debug mode. Previously, logging
+  behavior depended on both `log_path` and the build type(debug/release). Now,
+  whether logs are written to stdout or to a file is determined solely by the
+  presence of `log_path`.
 - Giganto now creates a backup before overwriting the config via the
   `updateConfig` GraphQL API. If reading the config fails, it automatically
   restores from the backup, both during `updateConfig` calls and at startup.


### PR DESCRIPTION
## Related Issue
- close #1075

## PR Description
- Previously, logging behavior depended on both `log_path` and the build type(debug/release).
- Removed the dependency on the build type.
- Logging is now controlled solely by `log_path`.