### PR TITLE
Flatten deeply-nested expressions

### DIFF
--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -2869,21 +2869,41 @@ fn network_connection(
         };
 
         let selected = if is_forward {
-            time.min(dns_ts.min(conn_ts.min(http_ts.min(rdp_ts.min(ntlm_ts.min(
-                kerberos_ts.min(
-                    ssh_ts.min(dce_rpc_ts.min(ftp_ts.min(mqtt_ts.min(ldap_ts.min(
-                        tls_ts.min(smb_ts.min(nfs_ts.min(smtp_ts.min(bootp_ts.min(dhcp_ts))))),
-                    ))))),
-                ),
-            ))))))
+            time.min(dns_ts)
+                .min(conn_ts)
+                .min(http_ts)
+                .min(rdp_ts)
+                .min(ntlm_ts)
+                .min(kerberos_ts)
+                .min(ssh_ts)
+                .min(dce_rpc_ts)
+                .min(ftp_ts)
+                .min(mqtt_ts)
+                .min(ldap_ts)
+                .min(tls_ts)
+                .min(smb_ts)
+                .min(nfs_ts)
+                .min(smtp_ts)
+                .min(bootp_ts)
+                .min(dhcp_ts)
         } else {
-            time.max(dns_ts.max(conn_ts.max(http_ts.max(rdp_ts.max(ntlm_ts.max(
-                kerberos_ts.max(
-                    ssh_ts.max(dce_rpc_ts.max(ftp_ts.max(mqtt_ts.max(ldap_ts.max(
-                        tls_ts.max(smb_ts.max(nfs_ts.max(smtp_ts.max(bootp_ts.max(dhcp_ts))))),
-                    ))))),
-                ),
-            ))))))
+            time.max(dns_ts)
+                .max(conn_ts)
+                .max(http_ts)
+                .max(rdp_ts)
+                .max(ntlm_ts)
+                .max(kerberos_ts)
+                .max(ssh_ts)
+                .max(dce_rpc_ts)
+                .max(ftp_ts)
+                .max(mqtt_ts)
+                .max(ldap_ts)
+                .max(tls_ts)
+                .max(smb_ts)
+                .max(nfs_ts)
+                .max(smtp_ts)
+                .max(bootp_ts)
+                .max(dhcp_ts)
         };
 
         match selected {

--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -1807,29 +1807,35 @@ fn sysmon_connection(
         };
 
         let selected = if is_forward {
-            time.min(
-                file_create_time_ts.min(process_create_ts.min(network_connect_ts.min(
-                    process_terminate_ts.min(image_load_ts.min(file_create_ts.min(
-                        registry_value_set_ts.min(registry_key_rename_ts.min(
-                            file_create_stream_hash_ts.min(pipe_event_ts.min(dns_query_ts.min(
-                                file_delete_ts.min(process_tamper_ts.min(file_delete_detected_ts)),
-                            ))),
-                        )),
-                    ))),
-                ))),
-            )
+            time.min(file_create_time_ts)
+                .min(process_create_ts)
+                .min(network_connect_ts)
+                .min(process_terminate_ts)
+                .min(image_load_ts)
+                .min(file_create_ts)
+                .min(registry_value_set_ts)
+                .min(registry_key_rename_ts)
+                .min(file_create_stream_hash_ts)
+                .min(pipe_event_ts)
+                .min(dns_query_ts)
+                .min(file_delete_ts)
+                .min(process_tamper_ts)
+                .min(file_delete_detected_ts)
         } else {
-            time.max(
-                file_create_time_ts.max(process_create_ts.max(network_connect_ts.max(
-                    process_terminate_ts.max(image_load_ts.max(file_create_ts.max(
-                        registry_value_set_ts.max(registry_key_rename_ts.max(
-                            file_create_stream_hash_ts.max(pipe_event_ts.max(dns_query_ts.max(
-                                file_delete_ts.max(process_tamper_ts.max(file_delete_detected_ts)),
-                            ))),
-                        )),
-                    ))),
-                ))),
-            )
+            time.max(file_create_time_ts)
+                .max(process_create_ts)
+                .max(network_connect_ts)
+                .max(process_terminate_ts)
+                .max(image_load_ts)
+                .max(file_create_ts)
+                .max(registry_value_set_ts)
+                .max(registry_key_rename_ts)
+                .max(file_create_stream_hash_ts)
+                .max(pipe_event_ts)
+                .max(dns_query_ts)
+                .max(file_delete_ts)
+                .max(process_tamper_ts)
+                .max(file_delete_detected_ts)
         };
 
         match selected {


### PR DESCRIPTION
This reduces the processing time of `cargo fmt` from minutes to sub-second.

Fixes #1122.