### PR TITLE
Refactor FTP event structure to store commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Modified FTP event structure to store multiple commands as `Vec<FtpCommand>`
+  instead of single command fields. This change preserves the complete command
+  history of FTP sessions, enabling better threat analysis and session tracking.
+  The FTP GraphQL API now returns a `commands` array containing all commands
+  and their responses from a session.
 - Refactored Publish API to use request type-driven processing. The Publish
   API now processes requests based on their specific request type rather than
   the client's `NodeType`. This change decouples request handling from client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "giganto"
-version = "0.26.0-alpha.3"
+version = "0.26.0-alpha.4"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "giganto-client"
 version = "0.23.0"
-source = "git+https://github.com/aicers/giganto-client.git?rev=3e4939c#3e4939c7261dfcde1b6c5ea765a510eb8e4f4438"
+source = "git+https://github.com/aicers/giganto-client.git?rev=f52f942#f52f9427bc5b26a60c6cd49b534350d3551f2ada"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto"
-version = "0.26.0-alpha.3"
+version = "0.26.0-alpha.4"
 edition = "2024"
 default-run = "giganto"
 
@@ -27,7 +27,7 @@ ctrlc = { version = "3", features = ["termination"] }
 data-encoding = "2"
 deluxe = "0.5"
 futures-util = "0.3"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "3e4939c" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "f52f942" }
 graphql_client = "0.14"
 humantime = "2"
 humantime-serde = "1"

--- a/src/comm/ingest.rs
+++ b/src/comm/ingest.rs
@@ -55,7 +55,7 @@ const CHANNEL_CLOSE_MESSAGE: &[u8; 12] = b"channel done";
 const CHANNEL_CLOSE_TIMESTAMP: i64 = -1;
 const NO_TIMESTAMP: i64 = 0;
 const SENSOR_INTERVAL: u64 = 60 * 60 * 24;
-const INGEST_VERSION_REQ: &str = ">=0.26.0-alpha.3,<0.26.0-alpha.4";
+const INGEST_VERSION_REQ: &str = ">=0.26.0-alpha.4,<0.26.0-alpha.5";
 
 type SensorInfo = (String, DateTime<Utc>, ConnState, bool);
 

--- a/src/comm/ingest/tests.rs
+++ b/src/comm/ingest/tests.rs
@@ -17,8 +17,8 @@ use giganto_client::{
         Packet,
         log::{Log, OpLog, OpLogLevel},
         network::{
-            Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb,
-            Smtp, Ssh, Tls,
+            Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, FtpCommand, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm,
+            Rdp, Smb, Smtp, Ssh, Tls,
         },
         receive_ack_timestamp, send_record_header,
         statistics::Statistics,
@@ -63,7 +63,7 @@ const KEY_PATH: &str = "tests/certs/node1/key.pem";
 const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
 const HOST: &str = "node1";
 const TEST_PORT: u16 = 60190;
-const PROTOCOL_VERSION: &str = "0.26.0-alpha.3";
+const PROTOCOL_VERSION: &str = "0.26.0-alpha.4";
 
 struct TestClient {
     conn: Connection,
@@ -742,16 +742,18 @@ async fn ftp() {
         end_time: 1,
         user: "cluml".to_string(),
         password: "aice".to_string(),
-        command: "command".to_string(),
-        reply_code: "500".to_string(),
-        reply_msg: "reply_message".to_string(),
-        data_passive: false,
-        data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
-        data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
-        data_resp_port: 80,
-        file: "ftp_file".to_string(),
-        file_size: 100,
-        file_id: "1".to_string(),
+        commands: vec![FtpCommand {
+            command: "command".to_string(),
+            reply_code: "500".to_string(),
+            reply_msg: "reply_message".to_string(),
+            data_passive: false,
+            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+            data_resp_port: 80,
+            file: "ftp_file".to_string(),
+            file_size: 100,
+            file_id: "1".to_string(),
+        }],
     };
 
     send_record_header(&mut send_ftp, RAW_EVENT_KIND_FTP)

--- a/src/comm/peer.rs
+++ b/src/comm/peer.rs
@@ -46,7 +46,7 @@ use crate::{
 //   within the cluster.
 // - Updates of event protocol structures: Any changes to giganto-client's event protocols require
 //   all Gigantos in the cluster to use the same protocol version for compatibility.
-const PEER_VERSION_REQ: &str = ">=0.26.0-alpha.3,<0.26.0-alpha.4";
+const PEER_VERSION_REQ: &str = ">=0.26.0-alpha.4,<0.26.0-alpha.5";
 const PEER_RETRY_INTERVAL: u64 = 5;
 
 pub type Peers = Arc<RwLock<HashMap<String, PeerInfo>>>;
@@ -777,7 +777,7 @@ pub mod tests {
     const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
     const HOST: &str = "node1";
     const TEST_PORT: u16 = 60191;
-    const PROTOCOL_VERSION: &str = "0.26.0-alpha.3";
+    const PROTOCOL_VERSION: &str = "0.26.0-alpha.4";
 
     pub struct TestClient {
         send: SendStream,

--- a/src/comm/publish.rs
+++ b/src/comm/publish.rs
@@ -59,7 +59,7 @@ use crate::server::{
 };
 use crate::storage::{Database, Direction, RawEventStore, StorageKey};
 
-const PUBLISH_VERSION_REQ: &str = ">=0.26.0-alpha.3,<0.26.0-alpha.4";
+const PUBLISH_VERSION_REQ: &str = ">=0.26.0-alpha.4,<0.26.0-alpha.5";
 
 pub struct Server {
     server_config: ServerConfig,

--- a/src/comm/publish/tests.rs
+++ b/src/comm/publish/tests.rs
@@ -15,8 +15,8 @@ use giganto_client::{
     ingest::{
         log::Log,
         network::{
-            Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb,
-            Smtp, Ssh, Tls,
+            Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, FtpCommand, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm,
+            Rdp, Smb, Smtp, Ssh, Tls,
         },
         timeseries::PeriodicTimeSeries,
     },
@@ -63,7 +63,7 @@ fn get_token() -> &'static Mutex<u32> {
 }
 
 const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
-const PROTOCOL_VERSION: &str = "0.26.0-alpha.3";
+const PROTOCOL_VERSION: &str = "0.26.0-alpha.4";
 
 const NODE1_CERT_PATH: &str = "tests/certs/node1/cert.pem";
 const NODE1_KEY_PATH: &str = "tests/certs/node1/key.pem";
@@ -426,16 +426,18 @@ fn gen_ftp_raw_event() -> Vec<u8> {
         end_time: 1,
         user: "cluml".to_string(),
         password: "aice".to_string(),
-        command: "command".to_string(),
-        reply_code: "500".to_string(),
-        reply_msg: "reply_message".to_string(),
-        data_passive: false,
-        data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
-        data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
-        data_resp_port: 80,
-        file: "ftp_file".to_string(),
-        file_size: 100,
-        file_id: "1".to_string(),
+        commands: vec![FtpCommand {
+            command: "command".to_string(),
+            reply_code: "500".to_string(),
+            reply_msg: "reply_message".to_string(),
+            data_passive: false,
+            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+            data_resp_port: 80,
+            file: "ftp_file".to_string(),
+            file_size: 100,
+            file_id: "1".to_string(),
+        }],
     };
 
     bincode::serialize(&ftp_body).unwrap()

--- a/src/graphql/client/schema/ftp_raw_events.graphql
+++ b/src/graphql/client/schema/ftp_raw_events.graphql
@@ -31,16 +31,18 @@ query FtpRawEvents(
         endTime
         user
         password
-        command
-        replyCode
-        replyMsg
-        dataPassive
-        dataOrigAddr
-        dataRespAddr
-        dataRespPort
-        file
-        fileSize
-        fileId
+        commands {
+          command
+          replyCode
+          replyMsg
+          dataPassive
+          dataOrigAddr
+          dataRespAddr
+          dataRespPort
+          file
+          fileSize
+          fileId
+        }
       }
     }
   }

--- a/src/graphql/client/schema/network_raw_events.graphql
+++ b/src/graphql/client/schema/network_raw_events.graphql
@@ -185,16 +185,18 @@ query NetworkRawEvents(
           endTime
           user
           password
-          command
-          replyCode
-          replyMsg
-          dataPassive
-          dataOrigAddr
-          dataRespAddr
-          dataRespPort
-          file
-          fileSize
-          fileId
+          commands {
+            command
+            replyCode
+            replyMsg
+            dataPassive
+            dataOrigAddr
+            dataRespAddr
+            dataRespPort
+            file
+            fileSize
+            fileId
+          }
         }
         ... on MqttRawEvent {
           time

--- a/src/graphql/client/schema/schema.graphql
+++ b/src/graphql/client/schema/schema.graphql
@@ -883,6 +883,52 @@ type FileDeleteEventEdge {
 }
 
 """
+Represents an individual FTP command with its response and associated data.
+"""
+type FtpCommandRawEvent {
+	"""
+	Command
+	"""
+	command: String!
+	"""
+	Reply Code
+	"""
+	replyCode: String!
+	"""
+	Reply Message
+	"""
+	replyMsg: String!
+	"""
+	Passive Mode Flag
+	"""
+	dataPassive: Boolean!
+	"""
+	Data Channel Source IP Address
+	"""
+	dataOrigAddr: String!
+	"""
+	Data Channel Destination IP Address
+	"""
+	dataRespAddr: String!
+	"""
+	Data Channel Destination Port Number
+	"""
+	dataRespPort: Int!
+	"""
+	Filename
+	"""
+	file: String!
+	"""
+	File Size
+	"""
+	fileSize: StringNumberU64!
+	"""
+	File ID
+	"""
+	fileId: String!
+}
+
+"""
 Represents an event extracted from the FTP protocol.
 """
 type FtpRawEvent {
@@ -933,45 +979,9 @@ type FtpRawEvent {
 	"""
 	password: String!
 	"""
-	Command
+	Commands and their responses
 	"""
-	command: String!
-	"""
-	Reply Code
-	"""
-	replyCode: String!
-	"""
-	Reply Message
-	"""
-	replyMsg: String!
-	"""
-	Passive Mode Flag
-	"""
-	dataPassive: Boolean!
-	"""
-	Data Channel Source IP Address
-	"""
-	dataOrigAddr: String!
-	"""
-	Data Channel Destination IP Address
-	"""
-	dataRespAddr: String!
-	"""
-	Data Channel Destination Port Number
-	"""
-	dataRespPort: Int!
-	"""
-	Filename
-	"""
-	file: String!
-	"""
-	File Size
-	"""
-	fileSize: StringNumberU64!
-	"""
-	File ID
-	"""
-	fileId: String!
+	commands: [FtpCommandRawEvent!]!
 }
 
 type FtpRawEventConnection {

--- a/src/graphql/export.rs
+++ b/src/graphql/export.rs
@@ -293,6 +293,20 @@ struct DceRpcJsonOutput {
 }
 
 #[derive(Serialize, Debug)]
+struct FtpCommandJsonOutput {
+    command: String,
+    reply_code: String,
+    reply_msg: String,
+    data_passive: bool,
+    data_orig_addr: String,
+    data_resp_addr: String,
+    data_resp_port: u16,
+    file: String,
+    file_size: u64,
+    file_id: String,
+}
+
+#[derive(Serialize, Debug)]
 struct FtpJsonOutput {
     time: String,
     sensor: String,
@@ -305,16 +319,7 @@ struct FtpJsonOutput {
     end_time: i64,
     user: String,
     password: String,
-    command: String,
-    reply_code: String,
-    reply_msg: String,
-    data_passive: bool,
-    data_orig_addr: String,
-    data_resp_addr: String,
-    data_resp_port: u16,
-    file: String,
-    file_size: u64,
-    file_id: String,
+    commands: Vec<FtpCommandJsonOutput>,
 }
 
 #[derive(Serialize, Debug)]
@@ -1082,6 +1087,23 @@ impl JsonOutput<SecuLogJsonOutput> for SecuLog {
 
 impl JsonOutput<FtpJsonOutput> for Ftp {
     fn convert_json_output(&self, time: String, sensor: String) -> Result<FtpJsonOutput> {
+        let commands = self
+            .commands
+            .iter()
+            .map(|cmd| FtpCommandJsonOutput {
+                command: cmd.command.clone(),
+                reply_code: cmd.reply_code.clone(),
+                reply_msg: cmd.reply_msg.clone(),
+                data_passive: cmd.data_passive,
+                data_orig_addr: cmd.data_orig_addr.to_string(),
+                data_resp_addr: cmd.data_resp_addr.to_string(),
+                data_resp_port: cmd.data_resp_port,
+                file: cmd.file.clone(),
+                file_size: cmd.file_size,
+                file_id: cmd.file_id.clone(),
+            })
+            .collect();
+
         Ok(FtpJsonOutput {
             time,
             sensor,
@@ -1094,16 +1116,7 @@ impl JsonOutput<FtpJsonOutput> for Ftp {
             end_time: self.end_time,
             user: self.user.clone(),
             password: self.password.clone(),
-            command: self.command.clone(),
-            reply_code: self.reply_code.clone(),
-            reply_msg: self.reply_msg.clone(),
-            data_passive: self.data_passive,
-            data_orig_addr: self.data_orig_addr.to_string(),
-            data_resp_addr: self.data_resp_addr.to_string(),
-            data_resp_port: self.data_resp_port,
-            file: self.file.clone(),
-            file_size: self.file_size,
-            file_id: self.file_id.clone(),
+            commands,
         })
     }
 }

--- a/src/graphql/export/tests.rs
+++ b/src/graphql/export/tests.rs
@@ -6,8 +6,8 @@ use chrono::{Duration, Utc};
 use giganto_client::ingest::{
     log::{Log, OpLog, OpLogLevel},
     network::{
-        Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm, Rdp, Smb, Smtp,
-        Ssh, Tls,
+        Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, FtpCommand, Http, Kerberos, Ldap, Mqtt, Nfs, Ntlm,
+        Rdp, Smb, Smtp, Ssh, Tls,
     },
     timeseries::PeriodicTimeSeries,
 };
@@ -1039,16 +1039,18 @@ fn insert_ftp_raw_event(store: &RawEventStore<Ftp>, sensor: &str, timestamp: i64
         end_time: 1,
         user: "cluml".to_string(),
         password: "aice".to_string(),
-        command: "command".to_string(),
-        reply_code: "500".to_string(),
-        reply_msg: "reply_message".to_string(),
-        data_passive: false,
-        data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
-        data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
-        data_resp_port: 80,
-        file: "ftp_file".to_string(),
-        file_size: 100,
-        file_id: "1".to_string(),
+        commands: vec![FtpCommand {
+            command: "command".to_string(),
+            reply_code: "500".to_string(),
+            reply_msg: "reply_message".to_string(),
+            data_passive: false,
+            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+            data_resp_port: 80,
+            file: "ftp_file".to_string(),
+            file_size: 100,
+            file_id: "1".to_string(),
+        }],
     };
     let ser_ftp_body = bincode::serialize(&ftp_body).unwrap();
 

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -35,7 +35,7 @@ use crate::{
     },
 };
 
-const COMPATIBLE_VERSION_REQ: &str = ">=0.26.0-alpha.3,<0.26.0-alpha.4";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.26.0-alpha.4,<0.26.0-alpha.5";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -63,8 +63,8 @@ pub fn migrate_data_dir(data_dir: &Path, db_opts: &DbOptions) -> Result<()> {
             migrate_0_23_to_0_24,
         ),
         (
-            VersionReq::parse(">=0.24.0,<0.26.0-alpha.3").expect("valid version requirement"),
-            Version::parse("0.26.0-alpha.3").expect("valid version"),
+            VersionReq::parse(">=0.24.0,<0.26.0-alpha.4").expect("valid version requirement"),
+            Version::parse("0.26.0-alpha.4").expect("valid version"),
             migrate_0_24_to_0_26,
         ),
     ];
@@ -424,7 +424,7 @@ mod tests {
     use std::{fs, fs::File, io::Write, net::IpAddr, path::Path, path::PathBuf};
 
     use chrono::Utc;
-    use giganto_client::ingest::log::OpLogLevel;
+    use giganto_client::ingest::{log::OpLogLevel, network::FtpCommand};
     use rocksdb::{ColumnFamilyDescriptor, DB, Options, WriteBatch};
     use semver::{Version, VersionReq};
     use tempfile::TempDir;
@@ -1281,16 +1281,18 @@ mod tests {
             end_time: 1,
             user: "cluml".to_string(),
             password: "aice".to_string(),
-            command: "command".to_string(),
-            reply_code: "500".to_string(),
-            reply_msg: "reply_message".to_string(),
-            data_passive: false,
-            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
-            data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
-            data_resp_port: 80,
-            file: "ftp_file".to_string(),
-            file_size: 100,
-            file_id: "1".to_string(),
+            commands: vec![FtpCommand {
+                command: "command".to_string(),
+                reply_code: "500".to_string(),
+                reply_msg: "reply_message".to_string(),
+                data_passive: false,
+                data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+                data_resp_addr: "31.3.245.133".parse::<IpAddr>().unwrap(),
+                data_resp_port: 80,
+                file: "ftp_file".to_string(),
+                file_size: 100,
+                file_id: "1".to_string(),
+            }],
         };
         assert_eq!(store_ftp, new_ftp);
 

--- a/src/storage/migration/migration_structures.rs
+++ b/src/storage/migration/migration_structures.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use giganto_client::ingest::log::OpLogLevel;
+use giganto_client::ingest::{log::OpLogLevel, network::FtpCommand};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -735,16 +735,18 @@ impl MigrationNew<FtpBeforeV26> for FtpFromV26 {
             end_time: old_data.end_time,
             user: old_data.user,
             password: old_data.password,
-            command: old_data.command,
-            reply_code: old_data.reply_code,
-            reply_msg: old_data.reply_msg,
-            data_passive: old_data.data_passive,
-            data_orig_addr: old_data.data_orig_addr,
-            data_resp_addr: old_data.data_resp_addr,
-            data_resp_port: old_data.data_resp_port,
-            file: old_data.file,
-            file_size: old_data.file_size,
-            file_id: old_data.file_id,
+            commands: vec![FtpCommand {
+                command: old_data.command,
+                reply_code: old_data.reply_code,
+                reply_msg: old_data.reply_msg,
+                data_passive: old_data.data_passive,
+                data_orig_addr: old_data.data_orig_addr,
+                data_resp_addr: old_data.data_resp_addr,
+                data_resp_port: old_data.data_resp_port,
+                file: old_data.file,
+                file_size: old_data.file_size,
+                file_id: old_data.file_id,
+            }],
         }
     }
 }


### PR DESCRIPTION
## Related Issues

Closes #1156

## PR Description

- Modify FTP event structure to store all commands as `Vec<FtpCommand>` instead of single command fields
- Implement manual From trait conversions for `FtpCommandRawEvent` to handle GraphQL client type conversions
- Update cluster mode tests to query commands array structure (`commands { fileSize }` instead of direct `fileSize`)
- Ensure compatibility with giganto-client's updated FTP structure (rev=f52f942)

### Changed

- Modified FTP event structure to store multiple commands as `Vec<FtpCommand>`
  instead of single command fields. This change preserves the complete command
  history of FTP sessions, enabling better threat analysis and session tracking.
  The FTP GraphQL API now returns a `commands` array containing all commands
  and their responses from a session.
