### PR TITLE
Add module tests for config and ingest/publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "proc-macro2",
  "quinn",
  "quote",
+ "rcgen",
  "regex",
  "reqwest",
  "rocksdb",
@@ -2101,6 +2102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2469,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec0a99f2de91c3cddc84b37e7db80e4d96b743e05607f647eb236fc0455907f"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -4372,8 +4397,18 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ async-graphql-poem = "7"
 
 [dev-dependencies]
 mockito = "1"
+rcgen = "0.14"
 regex = "1"
 serial_test = "3"
 tempfile = "3"

--- a/src/comm.rs
+++ b/src/comm.rs
@@ -91,3 +91,107 @@ pub(crate) fn new_peers_data(peers_list: Option<HashSet<PeerIdentity>>) -> (Peer
         Arc::new(RwLock::new(peers_list.unwrap_or_default())),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn generate_test_cert() -> rcgen::CertifiedKey<rcgen::KeyPair> {
+        rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap()
+    }
+
+    #[test]
+    fn test_to_cert_chain_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.cert.pem();
+        let chain = to_cert_chain(pem.as_bytes());
+        assert!(chain.is_ok());
+        let chain = chain.unwrap();
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn test_to_cert_chain_invalid() {
+        let pem = b"invalid pem";
+        let chain = to_cert_chain(pem);
+        assert!(chain.is_ok());
+        assert!(chain.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_to_private_key_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.signing_key.serialize_pem();
+        let key = to_private_key(pem.as_bytes());
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn test_to_private_key_invalid() {
+        let pem = b"invalid pem";
+        let key = to_private_key(pem);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn test_to_root_cert_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.cert.pem();
+
+        let dir = tempdir().expect("failed to create temp dir");
+        let file_path = dir.path().join("ca.pem");
+        let mut file = fs::File::create(&file_path).expect("failed to create ca file");
+        file.write_all(pem.as_bytes())
+            .expect("failed to write ca file");
+
+        let paths = vec![file_path.to_str().unwrap().to_string()];
+        let root_cert = to_root_cert(&paths);
+        assert!(root_cert.is_ok());
+        assert!(!root_cert.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_to_root_cert_invalid_path() {
+        let paths = vec!["/non/existent/path".to_string()];
+        let root_cert = to_root_cert(&paths);
+        assert!(root_cert.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_new_pcap_sensors() {
+        let sensors = new_pcap_sensors();
+        assert!(sensors.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_runtime_ingest_sensors() {
+        let sensors = new_runtime_ingest_sensors();
+        assert!(sensors.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_stream_direct_channels() {
+        let channels = new_stream_direct_channels();
+        assert!(channels.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_peers_data() {
+        let (peers, idents) = new_peers_data(None);
+        assert!(peers.read().await.is_empty());
+        assert!(idents.read().await.is_empty());
+
+        let mut set = HashSet::new();
+        set.insert(PeerIdentity {
+            addr: "127.0.0.1:0".parse().unwrap(),
+            hostname: "test".to_string(),
+        });
+        let (peers, idents) = new_peers_data(Some(set));
+        assert!(peers.read().await.is_empty());
+        assert!(!idents.read().await.is_empty());
+    }
+}

--- a/src/comm/ingest/generation.rs
+++ b/src/comm/ingest/generation.rs
@@ -40,3 +40,85 @@ impl SequenceGenerator {
         utc_now.day()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn test_sequence_generator_increment() {
+        let generator = SequenceGenerator::new();
+        assert_eq!(generator.generate_sequence_number(), 0);
+        assert_eq!(generator.generate_sequence_number(), 1);
+        assert_eq!(generator.generate_sequence_number(), 2);
+    }
+
+    #[test]
+    fn test_sequence_generator_thread_safety() {
+        let generator = Arc::new(SequenceGenerator::new());
+        let mut handles = vec![];
+        let num_threads = 10;
+        let counts_per_thread = 100;
+
+        for _ in 0..num_threads {
+            let gen_clone = Arc::clone(&generator);
+            let handle = thread::spawn(move || {
+                let mut local_sequences = Vec::new();
+                for _ in 0..counts_per_thread {
+                    local_sequences.push(gen_clone.generate_sequence_number());
+                }
+                local_sequences
+            });
+            handles.push(handle);
+        }
+
+        let mut all_sequences = Vec::new();
+        for handle in handles {
+            all_sequences.extend(handle.join().unwrap());
+        }
+
+        assert_eq!(all_sequences.len(), num_threads * counts_per_thread);
+        let unique_sequences: HashSet<_> = all_sequences.into_iter().collect();
+        assert_eq!(unique_sequences.len(), num_threads * counts_per_thread);
+    }
+
+    #[test]
+    fn test_init_generator() {
+        let generator = SequenceGenerator::init_generator();
+        assert_eq!(generator.generate_sequence_number(), 0);
+    }
+
+    #[test]
+    fn test_get_current_date_time() {
+        let date = SequenceGenerator::get_current_date_time();
+        assert!((1..=31).contains(&date));
+    }
+
+    #[test]
+    fn test_sequence_generator_reset() {
+        let generator = SequenceGenerator::new();
+        // First call: initial state (0)
+        assert_eq!(generator.generate_sequence_number(), 0);
+
+        // Manually manipulate the last_reset_date to simulate a "yesterday"
+        // Use a value that is definitely different from today (e.g., today + 1 mod 31 + 1)
+        let today = SequenceGenerator::get_current_date_time();
+        let different_day = if today == 1 { 2 } else { 1 };
+        generator
+            .last_reset_date
+            .store(different_day, Ordering::SeqCst);
+
+        // Next call: should detect date change, reset counter to 1, and return 1
+        assert_eq!(generator.generate_sequence_number(), 1);
+
+        // Subsequent call: should increment from 1, so fetch_add(1) returns 1
+        assert_eq!(generator.generate_sequence_number(), 1);
+
+        // Next call: should return 2
+        assert_eq!(generator.generate_sequence_number(), 2);
+    }
+}

--- a/src/comm/publish/tests.rs
+++ b/src/comm/publish/tests.rs
@@ -6,6 +6,7 @@ use std::{
     net::{IpAddr, Ipv6Addr, SocketAddr},
     path::Path,
     sync::{Arc, OnceLock},
+    time::Duration as StdDuration,
 };
 
 use base64::{Engine, engine::general_purpose::STANDARD as base64_engine};
@@ -14,18 +15,25 @@ use giganto_client::{
     connection::client_handshake,
     ingest::{
         log::Log,
+        netflow::{Netflow5, Netflow9},
         network::{
             Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, FtpCommand, Http, Kerberos, Ldap, MalformedDns,
             Mqtt, Nfs, Ntlm, Radius, Rdp, Smb, Smtp, Ssh, Tls,
         },
+        sysmon::{
+            DnsEvent, FileCreate, FileCreateStreamHash, FileCreationTimeChanged, FileDelete,
+            FileDeleteDetected, ImageLoaded, NetworkConnection, PipeEvent, ProcessCreate,
+            ProcessTampering, ProcessTerminated, RegistryKeyValueRename, RegistryValueSet,
+        },
         timeseries::PeriodicTimeSeries,
     },
     publish::{
+        PcapFilter,
         range::{MessageCode, RequestRange, RequestRawData, ResponseRangeData},
         receive_range_data, receive_semi_supervised_data,
         receive_semi_supervised_stream_start_message, receive_time_series_generator_data,
-        receive_time_series_generator_stream_start_message, send_range_data_request,
-        send_stream_request,
+        receive_time_series_generator_stream_start_message, recv_ack_response,
+        send_range_data_request, send_stream_request,
         stream::{
             RequestSemiSupervisedStream, RequestStreamRecord, RequestTimeSeriesGeneratorStream,
             StreamRequestPayload,
@@ -33,50 +41,191 @@ use giganto_client::{
     },
 };
 use quinn::{Connection, Endpoint, SendStream};
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::{
+    RootCertStore,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+};
 use serial_test::serial;
-use tokio::sync::{Mutex, Notify, RwLock};
-
-static INIT: OnceLock<()> = OnceLock::new();
-
-fn init_crypto() {
-    INIT.get_or_init(|| {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    });
-}
+use tempfile::TempDir;
+use tokio::sync::{Mutex, MutexGuard, Notify, RwLock, mpsc};
 
 use super::Server;
 use crate::{
     comm::{
+        IngestSensors, PcapSensors, StreamDirectChannels,
+        ingest::NetworkKey,
         new_pcap_sensors, new_peers_data, new_stream_direct_channels,
         peer::{PeerIdentity, PeerInfo},
+        publish::{implement::RequestStreamMessage, send_direct_stream},
         to_cert_chain, to_private_key, to_root_cert,
     },
     server::Certs,
     storage::{Database, DbOptions, RawEventStore},
 };
 
-fn get_token() -> &'static Mutex<u32> {
-    static TOKEN: OnceLock<Mutex<u32>> = OnceLock::new();
+static INIT: OnceLock<()> = OnceLock::new();
 
-    TOKEN.get_or_init(|| Mutex::new(0))
-}
+const NETWORK_KINDS: &[&str] = &[
+    "conn",
+    "dns",
+    "malformed_dns",
+    "http",
+    "rdp",
+    "smtp",
+    "ntlm",
+    "kerberos",
+    "ssh",
+    "dce rpc",
+    "ftp",
+    "mqtt",
+    "ldap",
+    "tls",
+    "smb",
+    "nfs",
+    "bootp",
+    "dhcp",
+    "radius",
+];
 
+const SYSMON_KINDS: &[&str] = &[
+    "process_create",
+    "file_create_time",
+    "network_connect",
+    "process_terminate",
+    "image_load",
+    "file_create",
+    "registry_value_set",
+    "registry_key_rename",
+    "file_create_stream_hash",
+    "pipe_event",
+    "dns_query",
+    "file_delete",
+    "process_tamper",
+    "file_delete_detected",
+];
+
+const NETFLOW_KINDS: &[&str] = &["netflow5", "netflow9"];
+const SENSOR_SEMI_SUPERVISED_ONE: &str = "src1";
+const SENSOR_SEMI_SUPERVISED_TWO: &str = "src2";
+const SENSOR_TIME_SERIES_GENERATOR_THREE: &str = "src3";
+const POLICY_ID: u32 = 1;
 const CA_CERT_PATH: &str = "tests/certs/ca_cert.pem";
 const PROTOCOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+const LOG_KIND: &str = "Hello";
 
-const NODE1_CERT_PATH: &str = "tests/certs/node1/cert.pem";
-const NODE1_KEY_PATH: &str = "tests/certs/node1/key.pem";
-const NODE1_HOST: &str = "node1";
-const NODE1_TEST_PORT: u16 = 60191;
+const NODE1: NodeConfig = NodeConfig {
+    cert_path: "tests/certs/node1/cert.pem",
+    key_path: "tests/certs/node1/key.pem",
+    host: "node1",
+    port: 60200,
+    ingest_sensors: &["src1", "src 1", "ingest src 1"],
+};
 
-const NODE2_CERT_PATH: &str = "tests/certs/node2/cert.pem";
-const NODE2_KEY_PATH: &str = "tests/certs/node2/key.pem";
-const NODE2_HOST: &str = "node2";
-const NODE2_PORT: u16 = 60192;
+const NODE2: NodeConfig = NodeConfig {
+    cert_path: "tests/certs/node2/cert.pem",
+    key_path: "tests/certs/node2/key.pem",
+    host: "node2",
+    port: 60201,
+    ingest_sensors: &["src2", "src 2", "ingest src 2"],
+};
 
-const NODE1_GIGANTO_INGEST_SENSORS: [&str; 3] = ["src1", "src 1", "ingest src 1"];
-const NODE2_GIGANTO_INGEST_SENSORS: [&str; 3] = ["src2", "src 2", "ingest src 2"];
+// Stream types that do not have a time-series generator path.
+type StreamsWithoutTsgCase = (RequestStreamRecord, &'static str, fn() -> Vec<u8>);
+
+struct ClusterContext<T> {
+    _lock: MutexGuard<'static, u32>,
+    publish: TestClient,
+    cases: Vec<T>,
+}
+
+struct ClusterRangeCase {
+    kind: &'static str,
+    expected: Vec<u8>,
+    done: Vec<u8>,
+}
+
+type StreamInsertFn = fn(&Database, &str, i64) -> Vec<u8>;
+
+struct NetworkStreamCase {
+    record_type: RequestStreamRecord,
+    kind: &'static str,
+    semi_payload: fn() -> Vec<u8>,
+    direct_payload: fn() -> Vec<u8>,
+    insert_db: StreamInsertFn,
+}
+
+struct NodeConfig {
+    cert_path: &'static str,
+    key_path: &'static str,
+    host: &'static str,
+    port: u16,
+    ingest_sensors: &'static [&'static str],
+}
+
+impl NodeConfig {
+    fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), self.port)
+    }
+
+    fn socket_addr_v4(&self) -> SocketAddr {
+        SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), self.port)
+    }
+
+    fn build_certs(&self) -> Arc<Certs> {
+        build_certs_from_paths(self.cert_path, self.key_path)
+    }
+
+    fn build_ingest_sensors(&self) -> IngestSensors {
+        build_ingest_sensors_from_list(self.ingest_sensors)
+    }
+
+    fn peer_info(&self) -> PeerInfo {
+        PeerInfo {
+            ingest_sensors: self
+                .ingest_sensors
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<HashSet<String>>(),
+            graphql_port: None,
+            publish_port: Some(self.port),
+        }
+    }
+
+    fn peer_identity(&self) -> PeerIdentity {
+        PeerIdentity {
+            addr: self.socket_addr(),
+            hostname: self.host.to_string(),
+        }
+    }
+
+    fn peer_identity_v4(&self) -> PeerIdentity {
+        PeerIdentity {
+            addr: self.socket_addr_v4(),
+            hostname: self.host.to_string(),
+        }
+    }
+}
+
+struct RawEventCase {
+    kind: &'static str,
+    insert: fn(&Database, &str, i64) -> Vec<u8>,
+    build_expected: fn(&[u8], i64, &str) -> Vec<u8>,
+}
+
+struct RawEventClusterCase {
+    kind: &'static str,
+    timestamp: i64,
+    expected: Vec<u8>,
+}
+
+struct TestHarness {
+    _lock: MutexGuard<'static, u32>,
+    _temp_dir: TempDir,
+    db: Database,
+    publish: TestClient,
+    stream_direct_channels: StreamDirectChannels,
+    pcap_sensors: PcapSensors,
+}
 
 struct TestClient {
     send: SendStream,
@@ -88,10 +237,7 @@ impl TestClient {
     async fn new() -> Self {
         let endpoint = init_client();
         let conn = endpoint
-            .connect(
-                SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-                NODE1_HOST,
-            )
+            .connect(NODE1.socket_addr(), NODE1.host)
             .expect(
                 "Failed to connect server's endpoint, Please check if the setting value is correct",
             )
@@ -104,43 +250,1039 @@ impl TestClient {
             endpoint,
         }
     }
+
+    async fn send_range_request<T: serde::de::DeserializeOwned>(
+        &self,
+        message_code: MessageCode,
+        message: RequestRange,
+    ) -> Vec<Option<T>> {
+        let (mut send_pub_req, mut recv_pub_resp) =
+            self.conn.open_bi().await.expect("failed to open stream");
+        send_range_data_request(&mut send_pub_req, message_code, message)
+            .await
+            .unwrap();
+
+        let mut result_data = Vec::new();
+        loop {
+            let resp_data = receive_range_data::<Option<T>>(&mut recv_pub_resp)
+                .await
+                .unwrap();
+            let is_done = resp_data.is_none();
+
+            result_data.push(resp_data);
+            if is_done {
+                break;
+            }
+        }
+
+        result_data
+    }
 }
 
-fn server() -> Server {
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
+fn init_crypto() {
+    INIT.get_or_init(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+fn get_token() -> &'static Mutex<u32> {
+    static TOKEN: OnceLock<Mutex<u32>> = OnceLock::new();
+
+    TOKEN.get_or_init(|| Mutex::new(0))
+}
+
+fn build_ingest_sensors_from_list(list: &[&str]) -> IngestSensors {
+    Arc::new(RwLock::new(
+        list.iter()
+            .copied()
+            .map(str::to_string)
+            .collect::<HashSet<String>>(),
+    ))
+}
+
+fn build_ingest_sensors() -> IngestSensors {
+    NODE1.build_ingest_sensors()
+}
+
+fn build_certs_from_paths(cert_path: &str, key_path: &str) -> Arc<Certs> {
+    let cert_pem = fs::read(cert_path).unwrap();
     let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
+    let key_pem = fs::read(key_path).unwrap();
     let key = to_private_key(&key_pem).unwrap();
     let ca_cert_path = vec![CA_CERT_PATH.to_string()];
     let root = to_root_cert(&ca_cert_path).unwrap();
 
-    let certs = Arc::new(Certs {
+    Arc::new(Certs {
         certs: cert,
         key,
         root,
+    })
+}
+
+fn build_test_certs() -> Arc<Certs> {
+    NODE1.build_certs()
+}
+
+async fn setup_test_harness() -> TestHarness {
+    init_crypto();
+
+    let lock = get_token().lock().await;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db = Database::open(temp_dir.path(), &DbOptions::default()).unwrap();
+    let pcap_sensors = new_pcap_sensors();
+    let stream_direct_channels = new_stream_direct_channels();
+    let ingest_sensors = build_ingest_sensors();
+    let (peers, peer_idents) = new_peers_data(None);
+    let certs = build_test_certs();
+
+    tokio::spawn(server().run(
+        db.clone(),
+        pcap_sensors.clone(),
+        stream_direct_channels.clone(),
+        ingest_sensors,
+        peers,
+        peer_idents,
+        certs,
+        Arc::new(Notify::new()),
+    ));
+
+    let publish = TestClient::new().await;
+
+    TestHarness {
+        _lock: lock,
+        _temp_dir: temp_dir,
+        db,
+        publish,
+        stream_direct_channels,
+        pcap_sensors,
+    }
+}
+
+fn assert_range_result<T: serde::Serialize>(
+    mut result_data: Vec<Option<T>>,
+    expected: &[u8],
+    done: &[u8],
+    context: &str,
+) {
+    let done_payload = bincode::serialize(&result_data.pop().unwrap()).unwrap();
+    assert_eq!(done, done_payload, "done payload mismatch: {context}");
+    let payload = bincode::serialize(&result_data.pop().unwrap()).unwrap();
+    assert_eq!(expected, payload, "response payload mismatch: {context}");
+}
+
+async fn fetch_raw_data(
+    publish: &TestClient,
+    kind: &str,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<(i64, String, Vec<u8>)> {
+    fetch_raw_data_with_payload(publish, kind, sensor, timestamp).await
+}
+
+async fn fetch_raw_data_with_payload<T: serde::de::DeserializeOwned>(
+    publish: &TestClient,
+    kind: &str,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<(i64, String, T)> {
+    let (mut send_pub_req, mut recv_pub_resp) =
+        publish.conn.open_bi().await.expect("failed to open stream");
+
+    let message = RequestRawData {
+        kind: String::from(kind),
+        input: vec![(String::from(sensor), vec![timestamp])],
+    };
+
+    send_range_data_request(&mut send_pub_req, MessageCode::RawData, message)
+        .await
+        .unwrap();
+
+    let mut result_data = Vec::new();
+    loop {
+        let resp_data = receive_range_data::<Option<(i64, String, T)>>(&mut recv_pub_resp)
+            .await
+            .unwrap();
+
+        if let Some(data) = resp_data {
+            result_data.push(data);
+        } else {
+            break;
+        }
+    }
+
+    result_data
+}
+
+async fn setup_pcap_sensor_connection(
+    host: &str,
+) -> (
+    Connection,
+    mpsc::UnboundedReceiver<PcapFilter>,
+    Endpoint,
+    Endpoint,
+) {
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec![host.to_string()])
+            .expect("Failed to generate sensor cert");
+    let cert_der = cert.der().clone();
+    let cert_chain = vec![cert_der.clone()];
+    let key = PrivatePkcs8KeyDer::from(signing_key.serialize_der());
+
+    let server_config =
+        quinn::ServerConfig::with_single_cert(cert_chain.clone(), PrivateKeyDer::Pkcs8(key))
+            .expect("Failed to build sensor server config");
+
+    let mut roots = RootCertStore::empty();
+    roots.add(cert_der).expect("Failed to add sensor cert");
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let mut client_config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls_config)
+            .expect("Failed to build sensor client config"),
+    ));
+    client_config.transport_config(Arc::new(quinn::TransportConfig::default()));
+
+    let sensor_server = Endpoint::server(
+        server_config,
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+    )
+    .expect("Failed to start sensor server endpoint");
+    let sensor_addr = sensor_server
+        .local_addr()
+        .expect("Failed to get sensor server addr");
+
+    let sensor_server_for_accept = sensor_server.clone();
+    let accept_handle = tokio::spawn(async move {
+        sensor_server_for_accept
+            .accept()
+            .await
+            .expect("Failed to accept sensor connection")
+            .await
+            .expect("Failed to build sensor connection")
     });
 
-    Server::new(
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-        &certs,
+    let mut sensor_client_endpoint =
+        Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
+            .expect("Failed to create sensor client endpoint");
+    sensor_client_endpoint.set_default_client_config(client_config);
+
+    let sensor_client_conn = sensor_client_endpoint
+        .connect(sensor_addr, host)
+        .expect("Failed to connect to sensor server")
+        .await
+        .expect("Failed to establish sensor connection");
+    let sensor_server_conn = accept_handle.await.expect("accept task failed");
+
+    let (filter_tx, filter_rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let conn = sensor_server_conn;
+        while let Ok((send, recv)) = conn.accept_bi().await {
+            if let Ok(filter) = giganto_client::publish::pcap_extract_response(send, recv).await {
+                let _ = filter_tx.send(filter);
+            }
+        }
+    });
+
+    (
+        sensor_client_conn,
+        filter_rx,
+        sensor_server,
+        sensor_client_endpoint,
     )
 }
 
+async fn build_ack_stream(host: &str) -> (SendStream, Endpoint, Endpoint) {
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec![host.to_string()])
+            .expect("Failed to generate ack cert");
+    let cert_der = cert.der().clone();
+    let cert_chain = vec![cert_der.clone()];
+    let key = PrivatePkcs8KeyDer::from(signing_key.serialize_der());
+
+    let server_config =
+        quinn::ServerConfig::with_single_cert(cert_chain.clone(), PrivateKeyDer::Pkcs8(key))
+            .expect("Failed to build ack server config");
+
+    let mut roots = RootCertStore::empty();
+    roots.add(cert_der).expect("Failed to add ack cert");
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let mut client_config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls_config)
+            .expect("Failed to build ack client config"),
+    ));
+    client_config.transport_config(Arc::new(quinn::TransportConfig::default()));
+
+    let ack_server = Endpoint::server(
+        server_config,
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+    )
+    .expect("Failed to start ack server");
+    let ack_addr = ack_server.local_addr().expect("Ack server addr");
+    let mut ack_client = Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
+        .expect("Failed to create ack client");
+    ack_client.set_default_client_config(client_config);
+
+    let ack_server_for_accept = ack_server.clone();
+    let accept_handle = tokio::spawn(async move {
+        ack_server_for_accept
+            .accept()
+            .await
+            .expect("Ack accept failed")
+            .await
+            .expect("Ack server conn failed")
+    });
+    let _client_conn = ack_client
+        .connect(ack_addr, host)
+        .expect("Ack connect failed")
+        .await
+        .expect("Ack connection failed");
+    let server_conn = accept_handle.await.expect("Ack accept task failed");
+
+    let server_send = server_conn.open_uni().await.expect("server uni");
+
+    (server_send, ack_server, ack_client)
+}
+
+macro_rules! build_network_expected_case {
+    ($kind:expr, $type:ty, $insert_fn:ident, $store_fn:ident, $db:expr, $sensor:expr, $timestamp:expr, $done_type:ty) => {{
+        let ser_body = $insert_fn(&$db.$store_fn().unwrap(), $sensor, $timestamp);
+        let expected = bincode::deserialize::<$type>(&ser_body)
+            .unwrap()
+            .response_data($timestamp, $sensor)
+            .unwrap();
+        (expected, <$done_type>::response_done().unwrap())
+    }};
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_network_expected(
+    db: &Database,
+    kind: &str,
+    sensor: &str,
+    timestamp: i64,
+) -> (Vec<u8>, Vec<u8>) {
+    match kind {
+        "conn" => build_network_expected_case!(
+            kind,
+            Conn,
+            insert_conn_raw_event,
+            conn_store,
+            db,
+            sensor,
+            timestamp,
+            Conn
+        ),
+        "dns" => build_network_expected_case!(
+            kind,
+            Dns,
+            insert_dns_raw_event,
+            dns_store,
+            db,
+            sensor,
+            timestamp,
+            Dns
+        ),
+        "malformed_dns" => build_network_expected_case!(
+            kind,
+            MalformedDns,
+            insert_malformed_dns_raw_event,
+            malformed_dns_store,
+            db,
+            sensor,
+            timestamp,
+            MalformedDns
+        ),
+        "http" => build_network_expected_case!(
+            kind,
+            Http,
+            insert_http_raw_event,
+            http_store,
+            db,
+            sensor,
+            timestamp,
+            Http
+        ),
+        "rdp" => build_network_expected_case!(
+            kind,
+            Rdp,
+            insert_rdp_raw_event,
+            rdp_store,
+            db,
+            sensor,
+            timestamp,
+            Rdp
+        ),
+        "smtp" => build_network_expected_case!(
+            kind,
+            Smtp,
+            insert_smtp_raw_event,
+            smtp_store,
+            db,
+            sensor,
+            timestamp,
+            Conn
+        ),
+        "ntlm" => build_network_expected_case!(
+            kind,
+            Ntlm,
+            insert_ntlm_raw_event,
+            ntlm_store,
+            db,
+            sensor,
+            timestamp,
+            Ntlm
+        ),
+        "kerberos" => build_network_expected_case!(
+            kind,
+            Kerberos,
+            insert_kerberos_raw_event,
+            kerberos_store,
+            db,
+            sensor,
+            timestamp,
+            Kerberos
+        ),
+        "ssh" => build_network_expected_case!(
+            kind,
+            Ssh,
+            insert_ssh_raw_event,
+            ssh_store,
+            db,
+            sensor,
+            timestamp,
+            Ssh
+        ),
+        "dce rpc" => build_network_expected_case!(
+            kind,
+            DceRpc,
+            insert_dce_rpc_raw_event,
+            dce_rpc_store,
+            db,
+            sensor,
+            timestamp,
+            DceRpc
+        ),
+        "ftp" => build_network_expected_case!(
+            kind,
+            Ftp,
+            insert_ftp_raw_event,
+            ftp_store,
+            db,
+            sensor,
+            timestamp,
+            Ftp
+        ),
+        "mqtt" => build_network_expected_case!(
+            kind,
+            Mqtt,
+            insert_mqtt_raw_event,
+            mqtt_store,
+            db,
+            sensor,
+            timestamp,
+            Mqtt
+        ),
+        "ldap" => build_network_expected_case!(
+            kind,
+            Ldap,
+            insert_ldap_raw_event,
+            ldap_store,
+            db,
+            sensor,
+            timestamp,
+            Ldap
+        ),
+        "tls" => build_network_expected_case!(
+            kind,
+            Tls,
+            insert_tls_raw_event,
+            tls_store,
+            db,
+            sensor,
+            timestamp,
+            Tls
+        ),
+        "smb" => build_network_expected_case!(
+            kind,
+            Smb,
+            insert_smb_raw_event,
+            smb_store,
+            db,
+            sensor,
+            timestamp,
+            Smb
+        ),
+        "nfs" => build_network_expected_case!(
+            kind,
+            Nfs,
+            insert_nfs_raw_event,
+            nfs_store,
+            db,
+            sensor,
+            timestamp,
+            Nfs
+        ),
+        "bootp" => build_network_expected_case!(
+            kind,
+            Bootp,
+            insert_bootp_raw_event,
+            bootp_store,
+            db,
+            sensor,
+            timestamp,
+            Bootp
+        ),
+        "dhcp" => build_network_expected_case!(
+            kind,
+            Dhcp,
+            insert_dhcp_raw_event,
+            dhcp_store,
+            db,
+            sensor,
+            timestamp,
+            Dhcp
+        ),
+        "radius" => build_network_expected_case!(
+            kind,
+            Radius,
+            insert_radius_raw_event,
+            radius_store,
+            db,
+            sensor,
+            timestamp,
+            Radius
+        ),
+        _ => unreachable!("unknown network kind: {kind}"),
+    }
+}
+
+macro_rules! build_sysmon_expected_case {
+    ($type:ty, $insert_fn:ident, $store_fn:ident, $db:expr, $sensor:expr, $timestamp:expr) => {{
+        let ser_body = $insert_fn(&$db.$store_fn().unwrap(), $sensor, $timestamp);
+        bincode::deserialize::<$type>(&ser_body)
+            .unwrap()
+            .response_data($timestamp, $sensor)
+            .unwrap()
+    }};
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_sysmon_expected(db: &Database, kind: &str, sensor: &str, timestamp: i64) -> Vec<u8> {
+    match kind {
+        "process_create" => build_sysmon_expected_case!(
+            ProcessCreate,
+            insert_process_create_raw_event,
+            process_create_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "file_create_time" => build_sysmon_expected_case!(
+            FileCreationTimeChanged,
+            insert_file_create_time_raw_event,
+            file_create_time_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "network_connect" => build_sysmon_expected_case!(
+            NetworkConnection,
+            insert_network_connect_raw_event,
+            network_connect_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "process_terminate" => build_sysmon_expected_case!(
+            ProcessTerminated,
+            insert_process_terminate_raw_event,
+            process_terminate_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "image_load" => build_sysmon_expected_case!(
+            ImageLoaded,
+            insert_image_load_raw_event,
+            image_load_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "file_create" => build_sysmon_expected_case!(
+            FileCreate,
+            insert_file_create_raw_event,
+            file_create_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "registry_value_set" => build_sysmon_expected_case!(
+            RegistryValueSet,
+            insert_registry_value_set_raw_event,
+            registry_value_set_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "registry_key_rename" => build_sysmon_expected_case!(
+            RegistryKeyValueRename,
+            insert_registry_key_rename_raw_event,
+            registry_key_rename_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "file_create_stream_hash" => build_sysmon_expected_case!(
+            FileCreateStreamHash,
+            insert_file_create_stream_hash_raw_event,
+            file_create_stream_hash_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "pipe_event" => build_sysmon_expected_case!(
+            PipeEvent,
+            insert_pipe_event_raw_event,
+            pipe_event_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "dns_query" => build_sysmon_expected_case!(
+            DnsEvent,
+            insert_dns_query_raw_event,
+            dns_query_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "file_delete" => build_sysmon_expected_case!(
+            FileDelete,
+            insert_file_delete_raw_event,
+            file_delete_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "process_tamper" => build_sysmon_expected_case!(
+            ProcessTampering,
+            insert_process_tamper_raw_event,
+            process_tamper_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        "file_delete_detected" => build_sysmon_expected_case!(
+            FileDeleteDetected,
+            insert_file_delete_detected_raw_event,
+            file_delete_detected_store,
+            db,
+            sensor,
+            timestamp
+        ),
+        _ => unreachable!("unknown sysmon kind: {kind}"),
+    }
+}
+
+macro_rules! raw_event_case {
+    ($kind:expr, $insert_fn:ident, $store_fn:ident, $typ:ty) => {
+        RawEventCase {
+            kind: $kind,
+            insert: |db, sensor, timestamp| $insert_fn(&db.$store_fn().unwrap(), sensor, timestamp),
+            build_expected: |ser_body, timestamp, sensor| {
+                bincode::deserialize::<$typ>(ser_body)
+                    .unwrap()
+                    .response_data(timestamp, sensor)
+                    .unwrap()
+            },
+        }
+    };
+}
+
+fn network_raw_event_cases() -> Vec<RawEventCase> {
+    vec![
+        raw_event_case!("conn", insert_conn_raw_event, conn_store, Conn),
+        raw_event_case!("dns", insert_dns_raw_event, dns_store, Dns),
+        raw_event_case!(
+            "malformed_dns",
+            insert_malformed_dns_raw_event,
+            malformed_dns_store,
+            MalformedDns
+        ),
+        raw_event_case!("http", insert_http_raw_event, http_store, Http),
+        raw_event_case!("rdp", insert_rdp_raw_event, rdp_store, Rdp),
+        raw_event_case!("smtp", insert_smtp_raw_event, smtp_store, Smtp),
+        raw_event_case!("ntlm", insert_ntlm_raw_event, ntlm_store, Ntlm),
+        raw_event_case!(
+            "kerberos",
+            insert_kerberos_raw_event,
+            kerberos_store,
+            Kerberos
+        ),
+        raw_event_case!("ssh", insert_ssh_raw_event, ssh_store, Ssh),
+        raw_event_case!("dce rpc", insert_dce_rpc_raw_event, dce_rpc_store, DceRpc),
+        raw_event_case!("ftp", insert_ftp_raw_event, ftp_store, Ftp),
+        raw_event_case!("mqtt", insert_mqtt_raw_event, mqtt_store, Mqtt),
+        raw_event_case!("ldap", insert_ldap_raw_event, ldap_store, Ldap),
+        raw_event_case!("tls", insert_tls_raw_event, tls_store, Tls),
+        raw_event_case!("smb", insert_smb_raw_event, smb_store, Smb),
+        raw_event_case!("nfs", insert_nfs_raw_event, nfs_store, Nfs),
+        raw_event_case!("bootp", insert_bootp_raw_event, bootp_store, Bootp),
+        raw_event_case!("dhcp", insert_dhcp_raw_event, dhcp_store, Dhcp),
+        raw_event_case!("radius", insert_radius_raw_event, radius_store, Radius),
+    ]
+}
+
+fn sysmon_raw_event_cases() -> Vec<RawEventCase> {
+    vec![
+        raw_event_case!(
+            "process_create",
+            insert_process_create_raw_event,
+            process_create_store,
+            ProcessCreate
+        ),
+        raw_event_case!(
+            "file_create_time",
+            insert_file_create_time_raw_event,
+            file_create_time_store,
+            FileCreationTimeChanged
+        ),
+        raw_event_case!(
+            "network_connect",
+            insert_network_connect_raw_event,
+            network_connect_store,
+            NetworkConnection
+        ),
+        raw_event_case!(
+            "process_terminate",
+            insert_process_terminate_raw_event,
+            process_terminate_store,
+            ProcessTerminated
+        ),
+        raw_event_case!(
+            "image_load",
+            insert_image_load_raw_event,
+            image_load_store,
+            ImageLoaded
+        ),
+        raw_event_case!(
+            "file_create",
+            insert_file_create_raw_event,
+            file_create_store,
+            FileCreate
+        ),
+        raw_event_case!(
+            "registry_value_set",
+            insert_registry_value_set_raw_event,
+            registry_value_set_store,
+            RegistryValueSet
+        ),
+        raw_event_case!(
+            "registry_key_rename",
+            insert_registry_key_rename_raw_event,
+            registry_key_rename_store,
+            RegistryKeyValueRename
+        ),
+        raw_event_case!(
+            "file_create_stream_hash",
+            insert_file_create_stream_hash_raw_event,
+            file_create_stream_hash_store,
+            FileCreateStreamHash
+        ),
+        raw_event_case!(
+            "pipe_event",
+            insert_pipe_event_raw_event,
+            pipe_event_store,
+            PipeEvent
+        ),
+        raw_event_case!(
+            "dns_query",
+            insert_dns_query_raw_event,
+            dns_query_store,
+            DnsEvent
+        ),
+        raw_event_case!(
+            "file_delete",
+            insert_file_delete_raw_event,
+            file_delete_store,
+            FileDelete
+        ),
+        raw_event_case!(
+            "process_tamper",
+            insert_process_tamper_raw_event,
+            process_tamper_store,
+            ProcessTampering
+        ),
+        raw_event_case!(
+            "file_delete_detected",
+            insert_file_delete_detected_raw_event,
+            file_delete_detected_store,
+            FileDeleteDetected
+        ),
+    ]
+}
+
+fn netflow_raw_event_cases() -> Vec<RawEventCase> {
+    vec![
+        raw_event_case!(
+            "netflow5",
+            insert_netflow5_raw_event,
+            netflow5_store,
+            Netflow5
+        ),
+        raw_event_case!(
+            "netflow9",
+            insert_netflow9_raw_event,
+            netflow9_store,
+            Netflow9
+        ),
+    ]
+}
+
+fn insert_log_raw_event_case(db: &Database, sensor: &str, timestamp: i64) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_log_body = gen_log_raw_event();
+    db.log_store().unwrap().append(&key, &ser_log_body).unwrap();
+    ser_log_body
+}
+
+fn build_log_raw_expected(ser_body: &[u8], timestamp: i64, sensor: &str) -> Vec<u8> {
+    bincode::deserialize::<Log>(ser_body)
+        .unwrap()
+        .response_data(timestamp, sensor)
+        .unwrap()
+}
+
+fn insert_periodic_time_series_raw_event_case(
+    db: &Database,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    insert_periodic_time_series_raw_event(
+        &db.periodic_time_series_store().unwrap(),
+        sensor,
+        timestamp,
+    )
+}
+
+fn build_periodic_time_series_raw_expected(
+    ser_body: &[u8],
+    timestamp: i64,
+    sensor: &str,
+) -> Vec<u8> {
+    bincode::deserialize::<PeriodicTimeSeries>(ser_body)
+        .unwrap()
+        .response_data(timestamp, sensor)
+        .unwrap()
+}
+
+fn log_raw_event_case() -> RawEventCase {
+    RawEventCase {
+        kind: LOG_KIND,
+        insert: insert_log_raw_event_case,
+        build_expected: build_log_raw_expected,
+    }
+}
+
+fn periodic_time_series_raw_event_case() -> RawEventCase {
+    RawEventCase {
+        kind: "timeseries",
+        insert: insert_periodic_time_series_raw_event_case,
+        build_expected: build_periodic_time_series_raw_expected,
+    }
+}
+
+fn all_raw_event_cases() -> Vec<RawEventCase> {
+    let mut cases = network_raw_event_cases();
+    cases.extend(sysmon_raw_event_cases());
+    cases.extend(netflow_raw_event_cases());
+    cases.push(log_raw_event_case());
+    cases.push(periodic_time_series_raw_event_case());
+    cases
+}
+
+fn prepare_raw_event(db: &Database, sensor: &str, case: &RawEventCase) -> (i64, Vec<u8>) {
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let ser_body = (case.insert)(db, sensor, timestamp);
+    let expected_resp = (case.build_expected)(&ser_body, timestamp, sensor);
+
+    (timestamp, expected_resp)
+}
+
+async fn assert_raw_event_case(
+    publish: &TestClient,
+    db: &Database,
+    sensor: &str,
+    case: &RawEventCase,
+) {
+    let (timestamp, expected_resp) = prepare_raw_event(db, sensor, case);
+    let mut result_data = fetch_raw_data(publish, case.kind, sensor, timestamp).await;
+
+    assert_eq!(result_data.len(), 1, "Failed for kind: {}", case.kind);
+    assert_eq!(result_data[0].0, timestamp);
+    assert_eq!(&result_data[0].1, sensor);
+    assert_eq!(
+        expected_resp,
+        bincode::serialize(&Some(result_data.pop().unwrap())).unwrap()
+    );
+}
+
+async fn assert_semi_supervised_stream(
+    publish: &mut TestClient,
+    record_type: RequestStreamRecord,
+    request: &RequestSemiSupervisedStream,
+    stream_direct_channels: &StreamDirectChannels,
+    kind: &str,
+    sensors: &[&str],
+    payload_fn: fn() -> Vec<u8>,
+) {
+    send_stream_request(
+        &mut publish.send,
+        StreamRequestPayload::SemiSupervised {
+            record_type,
+            request: request.clone(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut stream = publish.conn.accept_uni().await.unwrap();
+    let start_msg = receive_semi_supervised_stream_start_message(&mut stream)
+        .await
+        .unwrap();
+    assert_eq!(start_msg, record_type);
+
+    for sensor in sensors {
+        let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+        let key = NetworkKey::new(sensor, kind);
+        let payload = payload_fn();
+
+        send_direct_stream(
+            &key,
+            &payload,
+            send_time,
+            sensor,
+            stream_direct_channels.clone(),
+        )
+        .await
+        .unwrap();
+
+        let recv_data = receive_semi_supervised_data(&mut stream).await.unwrap();
+        assert_eq!(payload, recv_data[20..]);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn assert_time_series_generator_stream(
+    publish: &mut TestClient,
+    record_type: RequestStreamRecord,
+    request: &RequestTimeSeriesGeneratorStream,
+    stream_direct_channels: &StreamDirectChannels,
+    kind: &str,
+    sensor: &str,
+    policy_id: u32,
+    db_timestamp: i64,
+    db_payload: Vec<u8>,
+    direct_timestamp: i64,
+    direct_payload: Vec<u8>,
+) {
+    send_stream_request(
+        &mut publish.send,
+        StreamRequestPayload::TimeSeriesGenerator {
+            record_type,
+            request: request.clone(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut stream = publish.conn.accept_uni().await.unwrap();
+    let start_msg = receive_time_series_generator_stream_start_message(&mut stream)
+        .await
+        .unwrap();
+    assert_eq!(start_msg, policy_id);
+
+    let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut stream)
+        .await
+        .unwrap();
+    assert_eq!(db_timestamp, recv_timestamp);
+    assert_eq!(db_payload, recv_data);
+
+    let key = NetworkKey::new(sensor, kind);
+    send_direct_stream(
+        &key,
+        &direct_payload,
+        direct_timestamp,
+        sensor,
+        stream_direct_channels.clone(),
+    )
+    .await
+    .unwrap();
+
+    let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut stream)
+        .await
+        .unwrap();
+    assert_eq!(direct_timestamp, recv_timestamp);
+    assert_eq!(direct_payload, recv_data);
+}
+
+macro_rules! impl_insert_stream {
+    ($($name:ident, $raw_fn:ident, $store_fn:ident);+ $(;)?) => {
+        $(
+            fn $name(db: &Database, sensor: &str, timestamp: i64) -> Vec<u8> {
+                $raw_fn(&db.$store_fn().unwrap(), sensor, timestamp)
+            }
+        )+
+    };
+}
+
+impl_insert_stream! {
+    insert_conn_stream, insert_conn_raw_event, conn_store;
+    insert_dns_stream, insert_dns_raw_event, dns_store;
+    insert_rdp_stream, insert_rdp_raw_event, rdp_store;
+    insert_http_stream, insert_http_raw_event, http_store;
+    insert_smtp_stream, insert_smtp_raw_event, smtp_store;
+    insert_ntlm_stream, insert_ntlm_raw_event, ntlm_store;
+    insert_kerberos_stream, insert_kerberos_raw_event, kerberos_store;
+    insert_ssh_stream, insert_ssh_raw_event, ssh_store;
+    insert_dce_rpc_stream, insert_dce_rpc_raw_event, dce_rpc_store;
+    insert_ftp_stream, insert_ftp_raw_event, ftp_store;
+    insert_mqtt_stream, insert_mqtt_raw_event, mqtt_store;
+    insert_ldap_stream, insert_ldap_raw_event, ldap_store;
+    insert_tls_stream, insert_tls_raw_event, tls_store;
+    insert_smb_stream, insert_smb_raw_event, smb_store;
+    insert_nfs_stream, insert_nfs_raw_event, nfs_store;
+    insert_bootp_stream, insert_bootp_raw_event, bootp_store;
+    insert_dhcp_stream, insert_dhcp_raw_event, dhcp_store;
+    insert_radius_stream, insert_radius_raw_event, radius_store;
+}
+
+fn server() -> Server {
+    let certs = build_test_certs();
+
+    Server::new(NODE1.socket_addr(), &certs)
+}
+
 fn init_client() -> Endpoint {
-    let (cert, key): (Vec<u8>, Vec<u8>) = if let Ok(x) = fs::read(NODE1_CERT_PATH).map(|x| {
+    let (cert, key): (Vec<u8>, Vec<u8>) = if let Ok(x) = fs::read(NODE1.cert_path).map(|x| {
         (
             x,
-            fs::read(NODE1_KEY_PATH).expect("Failed to Read key file"),
+            fs::read(NODE1.key_path).expect("Failed to Read key file"),
         )
     }) {
         x
     } else {
         panic!(
-            "failed to read (cert, key) file, {NODE1_CERT_PATH}, {NODE1_KEY_PATH} read file error. Cert or key doesn't exist in default test folder"
+            "failed to read (cert, key) file, {}, {} read file error. Cert or key doesn't exist in default test folder",
+            NODE1.cert_path, NODE1.key_path
         );
     };
 
-    let pv_key = if Path::new(NODE1_KEY_PATH)
+    let pv_key = if Path::new(NODE1.key_path)
         .extension()
         .is_some_and(|x| x == "der")
     {
@@ -151,7 +1293,7 @@ fn init_client() -> Endpoint {
             .expect("no private keys found")
     };
 
-    let cert_chain = if Path::new(NODE1_CERT_PATH)
+    let cert_chain = if Path::new(NODE1.cert_path)
         .extension()
         .is_some_and(|x| x == "der")
     {
@@ -169,14 +1311,45 @@ fn init_client() -> Endpoint {
         .with_client_auth_cert(cert_chain, pv_key)
         .expect("the server root, cert chain or private key are not valid");
 
-    let mut endpoint =
-        quinn::Endpoint::client("[::]:0".parse().expect("Failed to parse Endpoint addr"))
-            .expect("Failed to create endpoint");
+    let mut endpoint = Endpoint::client("[::]:0".parse().expect("Failed to parse Endpoint addr"))
+        .expect("Failed to create endpoint");
     endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(
         quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)
             .expect("Failed to generate QuicClientConfig"),
     )));
     endpoint
+}
+
+fn default_time_range() -> (i64, i64) {
+    let start = DateTime::<Utc>::from_naive_utc_and_offset(
+        NaiveDate::from_ymd_opt(1970, 1, 1)
+            .expect("valid date")
+            .and_hms_opt(0, 0, 0)
+            .expect("valid time"),
+        Utc,
+    );
+    let end = DateTime::<Utc>::from_naive_utc_and_offset(
+        NaiveDate::from_ymd_opt(2050, 12, 31)
+            .expect("valid date")
+            .and_hms_opt(23, 59, 59)
+            .expect("valid time"),
+        Utc,
+    );
+    (
+        start.timestamp_nanos_opt().unwrap(),
+        end.timestamp_nanos_opt().unwrap(),
+    )
+}
+
+fn build_range_request(sensor: &str, kind: &str) -> RequestRange {
+    let (start, end) = default_time_range();
+    RequestRange {
+        sensor: sensor.to_string(),
+        kind: kind.to_string(),
+        start,
+        end,
+        count: 5,
+    }
 }
 
 fn gen_network_event_key(sensor: &str, kind: Option<&str>, timestamp: i64) -> Vec<u8> {
@@ -825,86 +1998,39 @@ fn gen_radius_raw_event() -> Vec<u8> {
     bincode::serialize(&radius_body).unwrap()
 }
 
-fn insert_conn_raw_event(store: &RawEventStore<Conn>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_conn_body = gen_conn_raw_event();
-    store.append(&key, &ser_conn_body).unwrap();
-    ser_conn_body
+macro_rules! impl_insert_network_raw_event {
+    ($($name:ident, $type:ty, $gen_fn:ident);+ $(;)?) => {
+        $(
+            fn $name(store: &RawEventStore<$type>, sensor: &str, timestamp: i64) -> Vec<u8> {
+                let key = gen_network_event_key(sensor, None, timestamp);
+                let ser_body = $gen_fn();
+                store.append(&key, &ser_body).unwrap();
+                ser_body
+            }
+        )+
+    };
 }
 
-fn insert_dns_raw_event(store: &RawEventStore<Dns>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_dns_body = gen_dns_raw_event();
-    store.append(&key, &ser_dns_body).unwrap();
-    ser_dns_body
-}
-
-fn insert_malformed_dns_raw_event(
-    store: &RawEventStore<MalformedDns>,
-    sensor: &str,
-    timestamp: i64,
-) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_malformed_dns_body = gen_malformed_dns_raw_event();
-    store.append(&key, &ser_malformed_dns_body).unwrap();
-    ser_malformed_dns_body
-}
-
-fn insert_rdp_raw_event(store: &RawEventStore<Rdp>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_rdp_body = gen_rdp_raw_event();
-    store.append(&key, &ser_rdp_body).unwrap();
-    ser_rdp_body
-}
-
-fn insert_http_raw_event(store: &RawEventStore<Http>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_http_body = gen_http_raw_event();
-    store.append(&key, &ser_http_body).unwrap();
-    ser_http_body
-}
-
-fn insert_smtp_raw_event(store: &RawEventStore<Smtp>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_smtp_body = gen_smtp_raw_event();
-    store.append(&key, &ser_smtp_body).unwrap();
-    ser_smtp_body
-}
-
-fn insert_ntlm_raw_event(store: &RawEventStore<Ntlm>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_ntlm_body = gen_ntlm_raw_event();
-    store.append(&key, &ser_ntlm_body).unwrap();
-    ser_ntlm_body
-}
-
-fn insert_kerberos_raw_event(
-    store: &RawEventStore<Kerberos>,
-    sensor: &str,
-    timestamp: i64,
-) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_kerberos_body = gen_kerberos_raw_event();
-    store.append(&key, &ser_kerberos_body).unwrap();
-    ser_kerberos_body
-}
-
-fn insert_ssh_raw_event(store: &RawEventStore<Ssh>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_ssh_body = gen_ssh_raw_event();
-    store.append(&key, &ser_ssh_body).unwrap();
-    ser_ssh_body
-}
-
-fn insert_dce_rpc_raw_event(
-    store: &RawEventStore<DceRpc>,
-    sensor: &str,
-    timestamp: i64,
-) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_dce_rpc_body = gen_dce_rpc_raw_event();
-    store.append(&key, &ser_dce_rpc_body).unwrap();
-    ser_dce_rpc_body
+impl_insert_network_raw_event! {
+    insert_conn_raw_event, Conn, gen_conn_raw_event;
+    insert_dns_raw_event, Dns, gen_dns_raw_event;
+    insert_malformed_dns_raw_event, MalformedDns, gen_malformed_dns_raw_event;
+    insert_rdp_raw_event, Rdp, gen_rdp_raw_event;
+    insert_http_raw_event, Http, gen_http_raw_event;
+    insert_smtp_raw_event, Smtp, gen_smtp_raw_event;
+    insert_ntlm_raw_event, Ntlm, gen_ntlm_raw_event;
+    insert_kerberos_raw_event, Kerberos, gen_kerberos_raw_event;
+    insert_ssh_raw_event, Ssh, gen_ssh_raw_event;
+    insert_dce_rpc_raw_event, DceRpc, gen_dce_rpc_raw_event;
+    insert_ftp_raw_event, Ftp, gen_ftp_raw_event;
+    insert_mqtt_raw_event, Mqtt, gen_mqtt_raw_event;
+    insert_ldap_raw_event, Ldap, gen_ldap_raw_event;
+    insert_tls_raw_event, Tls, gen_tls_raw_event;
+    insert_smb_raw_event, Smb, gen_smb_raw_event;
+    insert_nfs_raw_event, Nfs, gen_nfs_raw_event;
+    insert_bootp_raw_event, Bootp, gen_bootp_raw_event;
+    insert_dhcp_raw_event, Dhcp, gen_dhcp_raw_event;
+    insert_radius_raw_event, Radius, gen_radius_raw_event;
 }
 
 fn insert_log_raw_event(
@@ -930,120 +2056,797 @@ fn insert_periodic_time_series_raw_event(
     ser_periodic_time_series_body
 }
 
-fn insert_ftp_raw_event(store: &RawEventStore<Ftp>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_ftp_body = gen_ftp_raw_event();
-    store.append(&key, &ser_ftp_body).unwrap();
-    ser_ftp_body
+fn gen_process_create_raw_event() -> Vec<u8> {
+    let body = ProcessCreate {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        file_version: "1.0".to_string(),
+        description: "desc".to_string(),
+        product: "product".to_string(),
+        company: "company".to_string(),
+        original_file_name: "orig".to_string(),
+        command_line: "cmd".to_string(),
+        current_directory: "dir".to_string(),
+        user: "user".to_string(),
+        logon_guid: "logon".to_string(),
+        logon_id: 1,
+        terminal_session_id: 1,
+        integrity_level: "high".to_string(),
+        hashes: vec!["hash".to_string()],
+        parent_process_guid: "pguid".to_string(),
+        parent_process_id: 1,
+        parent_image: "pimage".to_string(),
+        parent_command_line: "pcmd".to_string(),
+        agent_id: "agent_id".to_string(),
+        parent_user: "puser".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
 }
 
-fn insert_mqtt_raw_event(store: &RawEventStore<Mqtt>, sensor: &str, timestamp: i64) -> Vec<u8> {
+fn insert_process_create_raw_event(
+    store: &RawEventStore<ProcessCreate>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
     let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_mqtt_body = gen_mqtt_raw_event();
-    store.append(&key, &ser_mqtt_body).unwrap();
-    ser_mqtt_body
+    let ser_body = gen_process_create_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
 }
 
-fn insert_ldap_raw_event(store: &RawEventStore<Ldap>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_ldap_body = gen_ldap_raw_event();
-    store.append(&key, &ser_ldap_body).unwrap();
-    ser_ldap_body
+fn gen_file_create_time_raw_event() -> Vec<u8> {
+    let body = FileCreationTimeChanged {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_filename: "target".to_string(),
+        creation_utc_time: 1000,
+        previous_creation_utc_time: 900,
+        agent_id: "agent_id".to_string(),
+        user: "user".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
 }
 
-fn insert_tls_raw_event(store: &RawEventStore<Tls>, sensor: &str, timestamp: i64) -> Vec<u8> {
+fn insert_file_create_time_raw_event(
+    store: &RawEventStore<FileCreationTimeChanged>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
     let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_tls_body = gen_tls_raw_event();
-    store.append(&key, &ser_tls_body).unwrap();
-    ser_tls_body
+    let ser_body = gen_file_create_time_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
 }
 
-fn insert_smb_raw_event(store: &RawEventStore<Smb>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_smb_body = gen_smb_raw_event();
-    store.append(&key, &ser_smb_body).unwrap();
-    ser_smb_body
+fn gen_network_connect_raw_event() -> Vec<u8> {
+    let body = NetworkConnection {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        user: "user".to_string(),
+        protocol: "tcp".to_string(),
+        initiated: true,
+        source_is_ipv6: false,
+        source_ip: "192.168.1.1".parse::<IpAddr>().unwrap(),
+        source_hostname: "src".to_string(),
+        source_port: 1234,
+        source_port_name: "port".to_string(),
+        destination_is_ipv6: false,
+        destination_ip: "1.1.1.1".parse::<IpAddr>().unwrap(),
+        destination_hostname: "dst".to_string(),
+        destination_port: 80,
+        destination_port_name: "http".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
 }
 
-fn insert_nfs_raw_event(store: &RawEventStore<Nfs>, sensor: &str, timestamp: i64) -> Vec<u8> {
+fn insert_network_connect_raw_event(
+    store: &RawEventStore<NetworkConnection>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
     let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_nfs_body = gen_nfs_raw_event();
-    store.append(&key, &ser_nfs_body).unwrap();
-    ser_nfs_body
+    let ser_body = gen_network_connect_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
 }
 
-fn insert_bootp_raw_event(store: &RawEventStore<Bootp>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_bootp_body = gen_bootp_raw_event();
-    store.append(&key, &ser_bootp_body).unwrap();
-    ser_bootp_body
+fn gen_process_terminate_raw_event() -> Vec<u8> {
+    let body = ProcessTerminated {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
 }
 
-fn insert_dhcp_raw_event(store: &RawEventStore<Dhcp>, sensor: &str, timestamp: i64) -> Vec<u8> {
+fn insert_process_terminate_raw_event(
+    store: &RawEventStore<ProcessTerminated>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
     let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_dhcp_body = gen_dhcp_raw_event();
-    store.append(&key, &ser_dhcp_body).unwrap();
-    ser_dhcp_body
+    let ser_body = gen_process_terminate_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
 }
 
-fn insert_radius_raw_event(store: &RawEventStore<Radius>, sensor: &str, timestamp: i64) -> Vec<u8> {
-    let key = gen_network_event_key(sensor, None, timestamp);
-    let ser_radius_body = gen_radius_raw_event();
-    store.append(&key, &ser_radius_body).unwrap();
-    ser_radius_body
+fn gen_image_load_raw_event() -> Vec<u8> {
+    let body = ImageLoaded {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        image_loaded: "loaded".to_string(),
+        file_version: "1.0".to_string(),
+        description: "desc".to_string(),
+        product: "product".to_string(),
+        company: "company".to_string(),
+        original_file_name: "orig".to_string(),
+        hashes: vec!["hash".to_string()],
+        signed: true,
+        signature: "sig".to_string(),
+        signature_status: "status".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
 }
 
-#[tokio::test]
+fn insert_image_load_raw_event(
+    store: &RawEventStore<ImageLoaded>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_image_load_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_file_create_raw_event() -> Vec<u8> {
+    let body = FileCreate {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_filename: "target".to_string(),
+        creation_utc_time: 1000,
+        agent_id: "agent_id".to_string(),
+        user: "user".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_file_create_raw_event(
+    store: &RawEventStore<FileCreate>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_file_create_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_registry_value_set_raw_event() -> Vec<u8> {
+    let body = RegistryValueSet {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_object: "target".to_string(),
+        details: "details".to_string(),
+        event_type: "type".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_registry_value_set_raw_event(
+    store: &RawEventStore<RegistryValueSet>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_registry_value_set_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_registry_key_rename_raw_event() -> Vec<u8> {
+    let body = RegistryKeyValueRename {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_object: "target".to_string(),
+        new_name: "new".to_string(),
+        event_type: "type".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_registry_key_rename_raw_event(
+    store: &RawEventStore<RegistryKeyValueRename>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_registry_key_rename_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_file_create_stream_hash_raw_event() -> Vec<u8> {
+    let body = FileCreateStreamHash {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_filename: "target".to_string(),
+        creation_utc_time: 1000,
+        hash: vec!["hash".to_string()],
+        contents: "contents".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_file_create_stream_hash_raw_event(
+    store: &RawEventStore<FileCreateStreamHash>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_file_create_stream_hash_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_pipe_event_raw_event() -> Vec<u8> {
+    let body = PipeEvent {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        pipe_name: "pipe".to_string(),
+        image: "image".to_string(),
+        event_type: "type".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_pipe_event_raw_event(
+    store: &RawEventStore<PipeEvent>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_pipe_event_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_dns_query_raw_event() -> Vec<u8> {
+    let body = DnsEvent {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        query_name: "query".to_string(),
+        query_status: 0,
+        query_results: vec!["result".to_string()],
+        image: "image".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_dns_query_raw_event(
+    store: &RawEventStore<DnsEvent>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_dns_query_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_file_delete_raw_event() -> Vec<u8> {
+    let body = FileDelete {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_filename: "target".to_string(),
+        agent_id: "agent_id".to_string(),
+        hashes: vec!["hash".to_string()],
+        is_executable: true,
+        archived: true,
+        user: "user".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_file_delete_raw_event(
+    store: &RawEventStore<FileDelete>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_file_delete_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_process_tamper_raw_event() -> Vec<u8> {
+    let body = ProcessTampering {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        tamper_type: "type".to_string(),
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_process_tamper_raw_event(
+    store: &RawEventStore<ProcessTampering>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_process_tamper_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_file_delete_detected_raw_event() -> Vec<u8> {
+    let body = FileDeleteDetected {
+        agent_name: "agent".to_string(),
+        process_guid: "guid".to_string(),
+        process_id: 123,
+        image: "image".to_string(),
+        target_filename: "target".to_string(),
+        hashes: vec!["hash".to_string()],
+        is_executable: true,
+        user: "user".to_string(),
+        agent_id: "agent_id".to_string(),
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_file_delete_detected_raw_event(
+    store: &RawEventStore<FileDeleteDetected>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_file_delete_detected_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_netflow5_raw_event() -> Vec<u8> {
+    let body = Netflow5 {
+        src_addr: "192.168.1.1".parse::<IpAddr>().unwrap(),
+        dst_addr: "192.168.1.2".parse::<IpAddr>().unwrap(),
+        next_hop: "10.0.0.1".parse::<IpAddr>().unwrap(),
+        input: 1,
+        output: 2,
+        d_pkts: 10,
+        d_octets: 1000,
+        first: 100,
+        last: 200,
+        src_port: 1234,
+        dst_port: 80,
+        tcp_flags: 0,
+        prot: 6,
+        tos: 0,
+        src_as: 0,
+        dst_as: 0,
+        src_mask: 24,
+        dst_mask: 24,
+        sampling_mode: 0,
+        sampling_rate: 0,
+        engine_type: 0,
+        engine_id: 0,
+        sequence: 0,
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_netflow5_raw_event(
+    store: &RawEventStore<Netflow5>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_netflow5_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn gen_netflow9_raw_event() -> Vec<u8> {
+    let body = Netflow9 {
+        orig_addr: "192.168.1.1".parse::<IpAddr>().unwrap(),
+        orig_port: 1234,
+        resp_addr: "192.168.1.2".parse::<IpAddr>().unwrap(),
+        resp_port: 80,
+        proto: 6,
+        contents: "payload".to_string(),
+        sequence: 1,
+        source_id: 1,
+        template_id: 256,
+    };
+    bincode::serialize(&body).unwrap()
+}
+
+fn insert_netflow9_raw_event(
+    store: &RawEventStore<Netflow9>,
+    sensor: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    let key = gen_network_event_key(sensor, None, timestamp);
+    let ser_body = gen_netflow9_raw_event();
+    store.append(&key, &ser_body).unwrap();
+    ser_body
+}
+
+fn build_network_semi_supervised_request() -> RequestSemiSupervisedStream {
+    RequestSemiSupervisedStream {
+        start: 0,
+        sensor: Some(vec![
+            String::from(SENSOR_SEMI_SUPERVISED_ONE),
+            String::from(SENSOR_SEMI_SUPERVISED_TWO),
+        ]),
+    }
+}
+
+fn build_network_time_series_generator_request() -> RequestTimeSeriesGeneratorStream {
+    RequestTimeSeriesGeneratorStream {
+        start: 0,
+        id: POLICY_ID.to_string(),
+        src_ip: Some("192.168.4.76".parse::<IpAddr>().unwrap()),
+        dst_ip: Some("31.3.245.133".parse::<IpAddr>().unwrap()),
+        sensor: Some(String::from(SENSOR_TIME_SERIES_GENERATOR_THREE)),
+    }
+}
+
 #[allow(clippy::too_many_lines)]
-async fn request_range_data_with_protocol() {
-    init_crypto();
-    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
-    const SENSOR: &str = "ingest src 1";
-    const CONN_KIND: &str = "conn";
-    const DNS_KIND: &str = "dns";
-    const MALFORMED_DNS_KIND: &str = "malformed_dns";
-    const HTTP_KIND: &str = "http";
-    const RDP_KIND: &str = "rdp";
-    const SMTP_KIND: &str = "smtp";
-    const NTLM_KIND: &str = "ntlm";
-    const KERBEROS_KIND: &str = "kerberos";
-    const SSH_KIND: &str = "ssh";
-    const DCE_RPC_KIND: &str = "dce rpc";
-    const FTP_KIND: &str = "ftp";
-    const MQTT_KIND: &str = "mqtt";
-    const LDAP_KIND: &str = "ldap";
-    const TLS_KIND: &str = "tls";
-    const SMB_KIND: &str = "smb";
-    const NFS_KIND: &str = "nfs";
-    const BOOTP_KIND: &str = "bootp";
-    const DHCP_KIND: &str = "dhcp";
-    const RADIUS_KIND: &str = "radius";
+fn build_network_stream_cases() -> Vec<NetworkStreamCase> {
+    vec![
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Conn,
+            kind: "conn",
+            semi_payload: gen_conn_raw_event,
+            direct_payload: gen_conn_raw_event,
+            insert_db: insert_conn_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Dns,
+            kind: "dns",
+            semi_payload: gen_conn_raw_event,
+            direct_payload: gen_dns_raw_event,
+            insert_db: insert_dns_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Rdp,
+            kind: "rdp",
+            semi_payload: gen_conn_raw_event,
+            direct_payload: gen_rdp_raw_event,
+            insert_db: insert_rdp_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Http,
+            kind: "http",
+            semi_payload: gen_conn_raw_event,
+            direct_payload: gen_http_raw_event,
+            insert_db: insert_http_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Smtp,
+            kind: "smtp",
+            semi_payload: gen_smtp_raw_event,
+            direct_payload: gen_smtp_raw_event,
+            insert_db: insert_smtp_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Ntlm,
+            kind: "ntlm",
+            semi_payload: gen_ntlm_raw_event,
+            direct_payload: gen_ntlm_raw_event,
+            insert_db: insert_ntlm_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Kerberos,
+            kind: "kerberos",
+            semi_payload: gen_kerberos_raw_event,
+            direct_payload: gen_kerberos_raw_event,
+            insert_db: insert_kerberos_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Ssh,
+            kind: "ssh",
+            semi_payload: gen_ssh_raw_event,
+            direct_payload: gen_ssh_raw_event,
+            insert_db: insert_ssh_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::DceRpc,
+            kind: "dce rpc",
+            semi_payload: gen_dce_rpc_raw_event,
+            direct_payload: gen_dce_rpc_raw_event,
+            insert_db: insert_dce_rpc_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Ftp,
+            kind: "ftp",
+            semi_payload: gen_ftp_raw_event,
+            direct_payload: gen_ftp_raw_event,
+            insert_db: insert_ftp_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Mqtt,
+            kind: "mqtt",
+            semi_payload: gen_mqtt_raw_event,
+            direct_payload: gen_mqtt_raw_event,
+            insert_db: insert_mqtt_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Ldap,
+            kind: "ldap",
+            semi_payload: gen_ldap_raw_event,
+            direct_payload: gen_ldap_raw_event,
+            insert_db: insert_ldap_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Tls,
+            kind: "tls",
+            semi_payload: gen_tls_raw_event,
+            direct_payload: gen_tls_raw_event,
+            insert_db: insert_tls_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Smb,
+            kind: "smb",
+            semi_payload: gen_smb_raw_event,
+            direct_payload: gen_smb_raw_event,
+            insert_db: insert_smb_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Nfs,
+            kind: "nfs",
+            semi_payload: gen_nfs_raw_event,
+            direct_payload: gen_nfs_raw_event,
+            insert_db: insert_nfs_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Bootp,
+            kind: "bootp",
+            semi_payload: gen_bootp_raw_event,
+            direct_payload: gen_bootp_raw_event,
+            insert_db: insert_bootp_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Dhcp,
+            kind: "dhcp",
+            semi_payload: gen_dhcp_raw_event,
+            direct_payload: gen_dhcp_raw_event,
+            insert_db: insert_dhcp_stream,
+        },
+        NetworkStreamCase {
+            record_type: RequestStreamRecord::Radius,
+            kind: "radius",
+            semi_payload: gen_radius_raw_event,
+            direct_payload: gen_radius_raw_event,
+            insert_db: insert_radius_stream,
+        },
+    ]
+}
 
-    let _lock = get_token().lock().await;
+fn build_streams_without_tsg() -> Vec<StreamsWithoutTsgCase> {
+    vec![
+        (
+            RequestStreamRecord::MalformedDns,
+            "malformed_dns",
+            gen_malformed_dns_raw_event,
+        ),
+        (
+            RequestStreamRecord::FileCreate,
+            "file_create",
+            gen_file_create_raw_event,
+        ),
+        (
+            RequestStreamRecord::FileDelete,
+            "file_delete",
+            gen_file_delete_raw_event,
+        ),
+        (RequestStreamRecord::Log, "log", gen_log_raw_event),
+    ]
+}
+
+fn prepare_cluster_network_cases(db: &Database, sensor: &str) -> Vec<ClusterRangeCase> {
+    NETWORK_KINDS
+        .iter()
+        .map(|kind| {
+            let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+            let (expected, done) = build_network_expected(db, kind, sensor, send_time);
+            ClusterRangeCase {
+                kind,
+                expected,
+                done,
+            }
+        })
+        .collect()
+}
+
+fn prepare_cluster_sysmon_cases(db: &Database, sensor: &str) -> Vec<ClusterRangeCase> {
+    SYSMON_KINDS
+        .iter()
+        .map(|kind| {
+            let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+            let expected = build_sysmon_expected(db, kind, sensor, send_time);
+            ClusterRangeCase {
+                kind,
+                expected,
+                done: Conn::response_done().unwrap(),
+            }
+        })
+        .collect()
+}
+
+fn prepare_cluster_netflow_cases(db: &Database, sensor: &str) -> Vec<ClusterRangeCase> {
+    NETFLOW_KINDS
+        .iter()
+        .map(|kind| {
+            let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+            let expected = match *kind {
+                "netflow5" => bincode::deserialize::<Netflow5>(&insert_netflow5_raw_event(
+                    &db.netflow5_store().unwrap(),
+                    sensor,
+                    send_time,
+                ))
+                .unwrap()
+                .response_data(send_time, sensor)
+                .unwrap(),
+                "netflow9" => bincode::deserialize::<Netflow9>(&insert_netflow9_raw_event(
+                    &db.netflow9_store().unwrap(),
+                    sensor,
+                    send_time,
+                ))
+                .unwrap()
+                .response_data(send_time, sensor)
+                .unwrap(),
+                _ => unreachable!(),
+            };
+
+            ClusterRangeCase {
+                kind,
+                expected,
+                done: Conn::response_done().unwrap(),
+            }
+        })
+        .collect()
+}
+
+fn prepare_cluster_log_cases(
+    db: &Database,
+    sensor: &str,
+    kind: &'static str,
+) -> Vec<ClusterRangeCase> {
+    let log_store = db.log_store().unwrap();
+    let send_log_time = Utc::now().timestamp_nanos_opt().unwrap();
+    let log_data = bincode::deserialize::<Log>(&insert_log_raw_event(
+        &log_store,
+        sensor,
+        kind,
+        send_log_time,
+    ))
+    .unwrap();
+
+    vec![ClusterRangeCase {
+        kind,
+        expected: log_data.response_data(send_log_time, sensor).unwrap(),
+        done: Conn::response_done().unwrap(),
+    }]
+}
+
+fn prepare_cluster_periodic_time_series_cases(
+    db: &Database,
+    sensor: &str,
+) -> Vec<ClusterRangeCase> {
+    let time_series_store = db.periodic_time_series_store().unwrap();
+    let send_time_series_time = Utc::now().timestamp_nanos_opt().unwrap();
+    let time_series_data = bincode::deserialize::<PeriodicTimeSeries>(
+        &insert_periodic_time_series_raw_event(&time_series_store, sensor, send_time_series_time),
+    )
+    .unwrap();
+
+    vec![ClusterRangeCase {
+        kind: "timeseries",
+        expected: time_series_data
+            .response_data(send_time_series_time, sensor)
+            .unwrap(),
+        done: PeriodicTimeSeries::response_done().unwrap(),
+    }]
+}
+
+async fn setup_cluster_with_cases<T, F>(prepare_cases: F) -> ClusterContext<T>
+where
+    F: FnOnce(&Database) -> Vec<T>,
+{
+    init_crypto();
+    let node2_dir = tempfile::tempdir().unwrap();
+    let node2_db = Database::open(node2_dir.path(), &DbOptions::default()).unwrap();
+    let node2_pcap_sensors = new_pcap_sensors();
+    let node2_stream_direct_channels = new_stream_direct_channels();
+    let node2_ingest_sensors = NODE2.build_ingest_sensors();
+    let node2_certs = NODE2.build_certs();
+
+    let prepared_cluster_cases = prepare_cases(&node2_db);
+
+    let node2_peers = Arc::new(RwLock::new(HashMap::from([(
+        Ipv6Addr::LOCALHOST.to_string(),
+        NODE1.peer_info(),
+    )])));
+
+    let mut node2_peer_identities = HashSet::new();
+    node2_peer_identities.insert(NODE1.peer_identity());
+    let node2_peer_idents = Arc::new(RwLock::new(node2_peer_identities));
+
+    let node2_notify_shutdown = Arc::new(Notify::new());
+
+    tokio::spawn(async move {
+        let node2_server = Server::new(NODE2.socket_addr_v4(), &node2_certs);
+        node2_server
+            .run(
+                node2_db,
+                node2_pcap_sensors,
+                node2_stream_direct_channels,
+                node2_ingest_sensors,
+                node2_peers,
+                node2_peer_idents,
+                node2_certs,
+                node2_notify_shutdown,
+            )
+            .await;
+    });
+
+    let lock = get_token().lock().await;
     let db_dir = tempfile::tempdir().unwrap();
     let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
     let pcap_sensors = new_pcap_sensors();
     let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
+    let ingest_sensors = build_ingest_sensors();
 
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
+    let peers = Arc::new(RwLock::new(HashMap::from([(
+        "127.0.0.1".to_string(),
+        NODE2.peer_info(),
+    )])));
+    let mut peer_identities = HashSet::new();
+    peer_identities.insert(NODE2.peer_identity_v4());
+    let peer_idents = Arc::new(RwLock::new(peer_identities));
 
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
+    let certs = build_test_certs();
 
     tokio::spawn(server().run(
         db.clone(),
@@ -1055,1202 +2858,70 @@ async fn request_range_data_with_protocol() {
         certs,
         Arc::new(Notify::new()),
     ));
+
     let publish = TestClient::new().await;
 
-    // conn protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let conn_store = db.conn_store().unwrap();
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let conn_data = bincode::deserialize::<Conn>(&insert_conn_raw_event(
-            &conn_store,
-            SENSOR,
-            send_conn_time,
-        ))
-        .unwrap();
+    ClusterContext {
+        _lock: lock,
+        publish,
+        cases: prepared_cluster_cases,
+    }
+}
 
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(CONN_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
+async fn request_range_data_on_cluster<T, F>(sensor: &str, prepare_cases: F)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+    F: FnOnce(&Database) -> Vec<ClusterRangeCase>,
+{
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
+    let ClusterContext {
+        publish,
+        cases: prepared_cluster_range_cases,
+        ..
+    } = setup_cluster_with_cases(prepare_cases).await;
 
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
+    for case in prepared_cluster_range_cases {
+        let result_data = publish
+            .send_range_request::<(i64, String, T)>(
+                PUBLISH_RANGE_MESSAGE_CODE,
+                build_range_request(sensor, case.kind),
+            )
+            .await;
 
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Conn::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            conn_data.response_data(send_conn_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
+        assert_range_result(
+            result_data,
+            case.expected.as_slice(),
+            case.done.as_slice(),
+            case.kind,
         );
     }
 
-    // dns protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let dns_store = db.dns_store().unwrap();
-        let send_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dns_data =
-            bincode::deserialize::<Dns>(&insert_dns_raw_event(&dns_store, SENSOR, send_dns_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(DNS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Dns::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            dns_data.response_data(send_dns_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // malformed_dns protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let malformed_dns_store = db.malformed_dns_store().unwrap();
-        let send_malformed_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let malformed_dns_data: MalformedDns = bincode::deserialize::<MalformedDns>(
-            &insert_malformed_dns_raw_event(&malformed_dns_store, SENSOR, send_malformed_dns_time),
-        )
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(MALFORMED_DNS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            MalformedDns::response_done().unwrap(),
-            bincode::serialize(&result_data.pop().unwrap()).unwrap()
-        );
-        assert_eq!(
-            malformed_dns_data
-                .response_data(send_malformed_dns_time, SENSOR)
-                .unwrap(),
-            bincode::serialize(&result_data.pop().unwrap()).unwrap()
-        );
-    }
-
-    // http protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let http_store = db.http_store().unwrap();
-        let send_http_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let http_data = bincode::deserialize::<Http>(&insert_http_raw_event(
-            &http_store,
-            SENSOR,
-            send_http_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(HTTP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Http::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            http_data.response_data(send_http_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // rdp protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let rdp_store = db.rdp_store().unwrap();
-        let send_rdp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let rdp_data =
-            bincode::deserialize::<Rdp>(&insert_rdp_raw_event(&rdp_store, SENSOR, send_rdp_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(RDP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Rdp::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            rdp_data.response_data(send_rdp_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // smtp protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let smtp_store = db.smtp_store().unwrap();
-        let send_smtp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let smtp_data = bincode::deserialize::<Smtp>(&insert_smtp_raw_event(
-            &smtp_store,
-            SENSOR,
-            send_smtp_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(SMTP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Conn::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            smtp_data.response_data(send_smtp_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // ntlm protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let ntlm_store = db.ntlm_store().unwrap();
-        let send_ntlm_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ntlm_data = bincode::deserialize::<Ntlm>(&insert_ntlm_raw_event(
-            &ntlm_store,
-            SENSOR,
-            send_ntlm_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(NTLM_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Ntlm::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            ntlm_data.response_data(send_ntlm_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // kerberos protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let kerberos_store = db.kerberos_store().unwrap();
-        let send_kerberos_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let kerberos_data = bincode::deserialize::<Kerberos>(&insert_kerberos_raw_event(
-            &kerberos_store,
-            SENSOR,
-            send_kerberos_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(KERBEROS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Kerberos::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            kerberos_data
-                .response_data(send_kerberos_time, SENSOR)
-                .unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // ssh protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let ssh_store = db.ssh_store().unwrap();
-        let send_ssh_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ssh_data =
-            bincode::deserialize::<Ssh>(&insert_ssh_raw_event(&ssh_store, SENSOR, send_ssh_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(SSH_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Ssh::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            ssh_data.response_data(send_ssh_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // dce_rpc protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let dce_rpc_store = db.dce_rpc_store().unwrap();
-        let send_dce_rpc_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dce_rpc_data = bincode::deserialize::<DceRpc>(&insert_dce_rpc_raw_event(
-            &dce_rpc_store,
-            SENSOR,
-            send_dce_rpc_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(DCE_RPC_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            DceRpc::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            dce_rpc_data
-                .response_data(send_dce_rpc_time, SENSOR)
-                .unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // ftp protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let ftp_store = db.ftp_store().unwrap();
-        let send_ftp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ftp_data =
-            bincode::deserialize::<Ftp>(&insert_ftp_raw_event(&ftp_store, SENSOR, send_ftp_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(FTP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Ftp::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            ftp_data.response_data(send_ftp_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // mqtt protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let mqtt_store = db.mqtt_store().unwrap();
-        let send_mqtt_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let mqtt_data = bincode::deserialize::<Mqtt>(&insert_mqtt_raw_event(
-            &mqtt_store,
-            SENSOR,
-            send_mqtt_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(MQTT_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Mqtt::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            mqtt_data.response_data(send_mqtt_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // ldap protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let ldap_store = db.ldap_store().unwrap();
-        let send_ldap_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ldap_data = bincode::deserialize::<Ldap>(&insert_ldap_raw_event(
-            &ldap_store,
-            SENSOR,
-            send_ldap_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(LDAP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Ldap::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            ldap_data.response_data(send_ldap_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // tls protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let tls_store = db.tls_store().unwrap();
-        let send_tls_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let tls_data =
-            bincode::deserialize::<Tls>(&insert_tls_raw_event(&tls_store, SENSOR, send_tls_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(TLS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Tls::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            tls_data.response_data(send_tls_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // smb protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let smb_store = db.smb_store().unwrap();
-        let send_smb_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let smb_data =
-            bincode::deserialize::<Smb>(&insert_smb_raw_event(&smb_store, SENSOR, send_smb_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(SMB_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Smb::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            smb_data.response_data(send_smb_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // nfs protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let nfs_store = db.nfs_store().unwrap();
-        let send_nfs_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let nfs_data =
-            bincode::deserialize::<Nfs>(&insert_nfs_raw_event(&nfs_store, SENSOR, send_nfs_time))
-                .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(NFS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Nfs::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            nfs_data.response_data(send_nfs_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // bootp protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let bootp_store = db.bootp_store().unwrap();
-        let send_bootp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let bootp_data = bincode::deserialize::<Bootp>(&insert_bootp_raw_event(
-            &bootp_store,
-            SENSOR,
-            send_bootp_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(BOOTP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Bootp::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            bootp_data.response_data(send_bootp_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // dhcp protocol
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let dhcp_store = db.dhcp_store().unwrap();
-        let send_dhcp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dhcp_data = bincode::deserialize::<Dhcp>(&insert_dhcp_raw_event(
-            &dhcp_store,
-            SENSOR,
-            send_dhcp_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(DHCP_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Dhcp::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            dhcp_data.response_data(send_dhcp_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-    }
-
-    // radius test
-    {
-        let (mut send_pub_req, mut recv_pub_resp) =
-            publish.conn.open_bi().await.expect("failed to open stream");
-        let radius_store = db.radius_store().unwrap();
-        let send_radius_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let radius_data = bincode::deserialize::<Radius>(&insert_radius_raw_event(
-            &radius_store,
-            SENSOR,
-            send_radius_time,
-        ))
-        .unwrap();
-
-        let start = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(1970, 1, 1)
-                .expect("valid date")
-                .and_hms_opt(00, 00, 00)
-                .expect("valid time"),
-            Utc,
-        );
-        let end = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2050, 12, 31)
-                .expect("valid date")
-                .and_hms_opt(23, 59, 59)
-                .expect("valid time"),
-            Utc,
-        );
-        let message = RequestRange {
-            sensor: String::from(SENSOR),
-            kind: String::from(RADIUS_KIND),
-            start: start.timestamp_nanos_opt().unwrap(),
-            end: end.timestamp_nanos_opt().unwrap(),
-            count: 5,
-        };
-
-        send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-            .await
-            .unwrap();
-
-        let mut result_data = Vec::new();
-        loop {
-            let resp_data =
-                receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-                    .await
-                    .unwrap();
-
-            result_data.push(resp_data.clone());
-            if resp_data.is_none() {
-                break;
-            }
-        }
-
-        assert_eq!(
-            Radius::response_done().unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
-        assert_eq!(
-            radius_data.response_data(send_radius_time, SENSOR).unwrap(),
-            bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap())
-                .unwrap()
-        );
+    publish.conn.close(0u32.into(), b"publish_range_done");
+    publish.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+#[serial]
+#[allow(clippy::too_many_lines)]
+async fn request_range_data_with_protocol() {
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
+    const SENSOR: &str = "ingest src 1";
+
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
+
+    for kind in NETWORK_KINDS {
+        let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+        let (expected, done) = build_network_expected(db, kind, SENSOR, send_time);
+        let result_data = publish
+            .send_range_request::<(i64, String, Vec<u8>)>(
+                PUBLISH_RANGE_MESSAGE_CODE,
+                build_range_request(SENSOR, kind),
+            )
+            .await;
+
+        assert_range_result(result_data, expected.as_slice(), done.as_slice(), kind);
     }
 
     publish.conn.close(0u32.into(), b"publish_protocol_done");
@@ -2258,51 +2929,15 @@ async fn request_range_data_with_protocol() {
 }
 
 #[tokio::test]
+#[serial]
 async fn request_range_data_with_log() {
-    init_crypto();
     const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SENSOR: &str = "src1";
-    const KIND: &str = "Hello";
+    const KIND: &str = LOG_KIND;
 
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
 
     let log_store = db.log_store().unwrap();
     let send_log_time = Utc::now().timestamp_nanos_opt().unwrap();
@@ -2314,51 +2949,19 @@ async fn request_range_data_with_log() {
     ))
     .unwrap();
 
-    let start = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .expect("valid date")
-            .and_hms_opt(00, 00, 00)
-            .expect("valid time"),
-        Utc,
-    );
-    let end = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2050, 12, 31)
-            .expect("valid date")
-            .and_hms_opt(23, 59, 59)
-            .expect("valid time"),
-        Utc,
-    );
-    let message = RequestRange {
-        sensor: String::from(SENSOR),
-        kind: String::from(KIND),
-        start: start.timestamp_nanos_opt().unwrap(),
-        end: end.timestamp_nanos_opt().unwrap(),
-        count: 5,
-    };
+    let result_data = publish
+        .send_range_request::<(i64, String, Vec<u8>)>(
+            PUBLISH_RANGE_MESSAGE_CODE,
+            build_range_request(SENSOR, KIND),
+        )
+        .await;
 
-    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-        .await
-        .unwrap();
-
-    let mut result_data = Vec::new();
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        result_data.push(resp_data.clone());
-        if resp_data.is_none() {
-            break;
-        }
-    }
-
-    assert_eq!(
-        Conn::response_done().unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-    assert_eq!(
-        log_data.response_data(send_log_time, SENSOR).unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
+    let expected = log_data.response_data(send_log_time, SENSOR).unwrap();
+    assert_range_result(
+        result_data,
+        expected.as_slice(),
+        Conn::response_done().unwrap().as_slice(),
+        KIND,
     );
 
     publish.conn.close(0u32.into(), b"publish_log_done");
@@ -2366,51 +2969,102 @@ async fn request_range_data_with_log() {
 }
 
 #[tokio::test]
+#[serial]
+#[allow(clippy::too_many_lines)]
+async fn request_range_data_with_sysmon() {
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
+    const SENSOR: &str = "ingest src 1";
+
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
+
+    for kind in SYSMON_KINDS {
+        let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+        let expected_resp = build_sysmon_expected(db, kind, SENSOR, send_time);
+        let result_data = publish
+            .send_range_request::<(i64, String, Vec<u8>)>(
+                PUBLISH_RANGE_MESSAGE_CODE,
+                build_range_request(SENSOR, kind),
+            )
+            .await;
+
+        assert_range_result(
+            result_data,
+            expected_resp.as_slice(),
+            Conn::response_done().unwrap().as_slice(),
+            kind,
+        );
+    }
+
+    publish.conn.close(0u32.into(), b"publish_sysmon_done");
+    publish.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn request_range_data_with_netflow() {
+    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
+    const SENSOR: &str = "ingest src 1";
+
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
+
+    for kind in NETFLOW_KINDS {
+        let send_time = Utc::now().timestamp_nanos_opt().unwrap();
+
+        let ser_body = match *kind {
+            "netflow5" => {
+                insert_netflow5_raw_event(&db.netflow5_store().unwrap(), SENSOR, send_time)
+            }
+            "netflow9" => {
+                insert_netflow9_raw_event(&db.netflow9_store().unwrap(), SENSOR, send_time)
+            }
+            _ => unreachable!(),
+        };
+
+        let result_data = publish
+            .send_range_request::<(i64, String, Vec<u8>)>(
+                PUBLISH_RANGE_MESSAGE_CODE,
+                build_range_request(SENSOR, kind),
+            )
+            .await;
+
+        let expected_resp = match *kind {
+            "netflow5" => bincode::deserialize::<Netflow5>(&ser_body)
+                .unwrap()
+                .response_data(send_time, SENSOR)
+                .unwrap(),
+            "netflow9" => bincode::deserialize::<Netflow9>(&ser_body)
+                .unwrap()
+                .response_data(send_time, SENSOR)
+                .unwrap(),
+            _ => unreachable!(),
+        };
+
+        assert_range_result(
+            result_data,
+            expected_resp.as_slice(),
+            Conn::response_done().unwrap().as_slice(),
+            kind,
+        );
+    }
+
+    publish.conn.close(0u32.into(), b"publish_netflow_done");
+    publish.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn request_range_data_with_period_time_series() {
-    init_crypto();
     const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SAMPLING_POLICY_ID_AS_SENSOR: &str = "ingest src 1";
     const KIND: &str = "timeseries";
 
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
 
     let time_series_store = db.periodic_time_series_store().unwrap();
     let send_time_series_time = Utc::now().timestamp_nanos_opt().unwrap();
@@ -2422,53 +3076,21 @@ async fn request_range_data_with_period_time_series() {
         ))
         .unwrap();
 
-    let start = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .expect("valid date")
-            .and_hms_opt(00, 00, 00)
-            .expect("valid time"),
-        Utc,
-    );
-    let end = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2050, 12, 31)
-            .expect("valid date")
-            .and_hms_opt(23, 59, 59)
-            .expect("valid time"),
-        Utc,
-    );
-    let message = RequestRange {
-        sensor: String::from(SAMPLING_POLICY_ID_AS_SENSOR),
-        kind: String::from(KIND),
-        start: start.timestamp_nanos_opt().unwrap(),
-        end: end.timestamp_nanos_opt().unwrap(),
-        count: 5,
-    };
+    let result_data = publish
+        .send_range_request::<(i64, String, Vec<f64>)>(
+            PUBLISH_RANGE_MESSAGE_CODE,
+            build_range_request(SAMPLING_POLICY_ID_AS_SENSOR, KIND),
+        )
+        .await;
 
-    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-        .await
+    let expected = time_series_data
+        .response_data(send_time_series_time, SAMPLING_POLICY_ID_AS_SENSOR)
         .unwrap();
-
-    let mut result_data = Vec::new();
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<f64>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        result_data.push(resp_data.clone());
-        if resp_data.is_none() {
-            break;
-        }
-    }
-
-    assert_eq!(
-        PeriodicTimeSeries::response_done().unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<f64>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-    assert_eq!(
-        time_series_data
-            .response_data(send_time_series_time, SAMPLING_POLICY_ID_AS_SENSOR)
-            .unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<f64>)>>(&result_data.pop().unwrap()).unwrap()
+    assert_range_result(
+        result_data,
+        expected.as_slice(),
+        PeriodicTimeSeries::response_done().unwrap().as_slice(),
+        KIND,
     );
 
     publish.conn.close(0u32.into(), b"publish_time_done");
@@ -2476,2105 +3098,61 @@ async fn request_range_data_with_period_time_series() {
 }
 
 #[tokio::test]
+#[serial]
 #[allow(clippy::too_many_lines)]
 async fn request_network_event_stream() {
-    init_crypto();
-    use crate::comm::{ingest::NetworkKey, publish::send_direct_stream};
+    let mut harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &mut harness.publish;
+    let stream_direct_channels = harness.stream_direct_channels.clone();
 
-    const NETWORK_STREAM_CONN: RequestStreamRecord = RequestStreamRecord::Conn;
-    const NETWORK_STREAM_DNS: RequestStreamRecord = RequestStreamRecord::Dns;
-    const NETWORK_STREAM_RDP: RequestStreamRecord = RequestStreamRecord::Rdp;
-    const NETWORK_STREAM_HTTP: RequestStreamRecord = RequestStreamRecord::Http;
-    const NETWORK_STREAM_SMTP: RequestStreamRecord = RequestStreamRecord::Smtp;
-    const NETWORK_STREAM_NTLM: RequestStreamRecord = RequestStreamRecord::Ntlm;
-    const NETWORK_STREAM_KERBEROS: RequestStreamRecord = RequestStreamRecord::Kerberos;
-    const NETWORK_STREAM_SSH: RequestStreamRecord = RequestStreamRecord::Ssh;
-    const NETWORK_STREAM_DCE_RPC: RequestStreamRecord = RequestStreamRecord::DceRpc;
-    const NETWORK_STREAM_FTP: RequestStreamRecord = RequestStreamRecord::Ftp;
-    const NETWORK_STREAM_MQTT: RequestStreamRecord = RequestStreamRecord::Mqtt;
-    const NETWORK_STREAM_LDAP: RequestStreamRecord = RequestStreamRecord::Ldap;
-    const NETWORK_STREAM_TLS: RequestStreamRecord = RequestStreamRecord::Tls;
-    const NETWORK_STREAM_SMB: RequestStreamRecord = RequestStreamRecord::Smb;
-    const NETWORK_STREAM_NFS: RequestStreamRecord = RequestStreamRecord::Nfs;
-    const NETWORK_STREAM_BOOTP: RequestStreamRecord = RequestStreamRecord::Bootp;
-    const NETWORK_STREAM_DHCP: RequestStreamRecord = RequestStreamRecord::Dhcp;
-    const NETWORK_STREAM_RADIUS: RequestStreamRecord = RequestStreamRecord::Radius;
+    let semi_supervised_msg = build_network_semi_supervised_request();
+    let time_series_generator_msg = build_network_time_series_generator_request();
 
-    const SENSOR_SEMI_SUPERVISED_ONE: &str = "src1";
-    const SENSOR_SEMI_SUPERVISED_TWO: &str = "src2";
-    const SENSOR_TIME_SERIES_GENERATOR_THREE: &str = "src3";
-    const POLICY_ID: u32 = 1;
-
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-
-    let semi_supervised_msg = RequestSemiSupervisedStream {
-        start: 0,
-        sensor: Some(vec![
-            String::from(SENSOR_SEMI_SUPERVISED_ONE),
-            String::from(SENSOR_SEMI_SUPERVISED_TWO),
-        ]),
-    };
-    let time_series_generator_msg = RequestTimeSeriesGeneratorStream {
-        start: 0,
-        id: POLICY_ID.to_string(),
-        src_ip: Some("192.168.4.76".parse::<IpAddr>().unwrap()),
-        dst_ip: Some("31.3.245.133".parse::<IpAddr>().unwrap()),
-        sensor: Some(String::from(SENSOR_TIME_SERIES_GENERATOR_THREE)),
-    };
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels.clone(),
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let mut publish = TestClient::new().await;
-
-    {
-        let conn_store = db.conn_store().unwrap();
-
-        // direct conn network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_CONN,
-                request: semi_supervised_msg.clone(),
-            },
+    for case in build_network_stream_cases() {
+        assert_semi_supervised_stream(
+            publish,
+            case.record_type,
+            &semi_supervised_msg,
+            &stream_direct_channels,
+            case.kind,
+            &[SENSOR_SEMI_SUPERVISED_ONE, SENSOR_SEMI_SUPERVISED_TWO],
+            case.semi_payload,
         )
-        .await
-        .unwrap();
+        .await;
 
-        let mut send_conn_stream = publish.conn.accept_uni().await.unwrap();
+        let db_timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+        let db_payload = (case.insert_db)(db, SENSOR_TIME_SERIES_GENERATOR_THREE, db_timestamp);
+        let direct_timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+        let direct_payload = (case.direct_payload)();
 
-        let conn_start_msg = receive_semi_supervised_stream_start_message(&mut send_conn_stream)
-            .await
-            .unwrap();
-        assert_eq!(conn_start_msg, NETWORK_STREAM_CONN);
-
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "conn");
-        let conn_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &conn_data,
-            send_conn_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_conn_stream)
-            .await
-            .unwrap();
-        assert_eq!(conn_data, recv_data[20..]);
-
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "conn");
-        let conn_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &conn_data,
-            send_conn_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-        let recv_data = receive_semi_supervised_data(&mut send_conn_stream)
-            .await
-            .unwrap();
-        assert_eq!(conn_data, recv_data[20..]);
-
-        // database conn network event for the Time Series Generator
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let conn_data = insert_conn_raw_event(
-            &conn_store,
+        assert_time_series_generator_stream(
+            publish,
+            case.record_type,
+            &time_series_generator_msg,
+            &stream_direct_channels,
+            case.kind,
             SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_conn_time,
-        );
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_CONN,
-                request: time_series_generator_msg.clone(),
-            },
+            POLICY_ID,
+            db_timestamp,
+            db_payload,
+            direct_timestamp,
+            direct_payload,
         )
-        .await
-        .unwrap();
-
-        let mut send_conn_stream = publish.conn.accept_uni().await.unwrap();
-        let conn_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_conn_stream)
-                .await
-                .unwrap();
-        assert_eq!(conn_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_conn_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_conn_time, recv_timestamp);
-        assert_eq!(conn_data, recv_data);
-
-        // direct conn network event for the Time Series Generator
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "conn");
-        let conn_data = gen_conn_raw_event();
-
-        send_direct_stream(
-            &key,
-            &conn_data,
-            send_conn_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_conn_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_conn_time, recv_timestamp);
-        assert_eq!(conn_data, recv_data);
+        .await;
     }
 
-    {
-        let dns_store = db.dns_store().unwrap();
-
-        // direct dns network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_DNS,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dns_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dns_start_msg = receive_semi_supervised_stream_start_message(&mut send_dns_stream)
-            .await
-            .unwrap();
-        assert_eq!(dns_start_msg, NETWORK_STREAM_DNS);
-
-        let send_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "dns");
-        let dns_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &dns_data,
-            send_dns_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dns_stream)
-            .await
-            .unwrap();
-        assert_eq!(dns_data, recv_data[20..]);
-
-        let send_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "dns");
-        let dns_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &dns_data,
-            send_dns_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dns_stream)
-            .await
-            .unwrap();
-        assert_eq!(dns_data, recv_data[20..]);
-
-        // database dns network event for the Time Series Generator
-        let send_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dns_data = insert_dns_raw_event(
-            &dns_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_dns_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_DNS,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dns_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dns_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_dns_stream)
-                .await
-                .unwrap();
-        assert_eq!(dns_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_dns_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_dns_time, recv_timestamp);
-        assert_eq!(dns_data, recv_data);
-
-        // direct dns network event for the Time Series Generator
-        let send_dns_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "dns");
-        let dns_data = gen_dns_raw_event();
-
-        send_direct_stream(
-            &key,
-            &dns_data,
-            send_dns_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_dns_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_dns_time, recv_timestamp);
-        assert_eq!(dns_data, recv_data);
-    }
-
-    {
-        let rdp_store = db.rdp_store().unwrap();
-
-        // direct rdp network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_RDP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_rdp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let rdp_start_msg = receive_semi_supervised_stream_start_message(&mut send_rdp_stream)
-            .await
-            .unwrap();
-        assert_eq!(rdp_start_msg, NETWORK_STREAM_RDP);
-
-        let send_rdp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "rdp");
-        let rdp_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &rdp_data,
-            send_rdp_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_rdp_stream)
-            .await
-            .unwrap();
-        assert_eq!(rdp_data, recv_data[20..]);
-
-        let send_rdp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "rdp");
-        let rdp_data = gen_conn_raw_event();
-        send_direct_stream(
-            &key,
-            &rdp_data,
-            send_rdp_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_rdp_stream)
-            .await
-            .unwrap();
-        assert_eq!(rdp_data, recv_data[20..]);
-
-        // database rdp network event for the Time Series Generator
-        let send_rdp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let rdp_data = insert_rdp_raw_event(
-            &rdp_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_rdp_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_RDP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_rdp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let rdp_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_rdp_stream)
-                .await
-                .unwrap();
-        assert_eq!(rdp_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_rdp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_rdp_time, recv_timestamp);
-        assert_eq!(rdp_data, recv_data);
-
-        // direct rdp network event for the Time Series Generator
-        let send_rdp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "rdp");
-        let rdp_data = gen_rdp_raw_event();
-        send_direct_stream(
-            &key,
-            &rdp_data,
-            send_rdp_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_rdp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_rdp_time, recv_timestamp);
-        assert_eq!(rdp_data, recv_data);
-    }
-
-    {
-        let http_store = db.http_store().unwrap();
-
-        // direct http network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_HTTP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_http_stream = publish.conn.accept_uni().await.unwrap();
-
-        let http_start_msg = receive_semi_supervised_stream_start_message(&mut send_http_stream)
-            .await
-            .unwrap();
-        assert_eq!(http_start_msg, NETWORK_STREAM_HTTP);
-
-        let send_http_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "http");
-        let http_data = gen_conn_raw_event();
-
-        send_direct_stream(
-            &key,
-            &http_data,
-            send_http_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_http_stream)
-            .await
-            .unwrap();
-        assert_eq!(http_data, recv_data[20..]);
-
-        let send_http_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "http");
-        let http_data = gen_conn_raw_event();
-
-        send_direct_stream(
-            &key,
-            &http_data,
-            send_http_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_http_stream)
-            .await
-            .unwrap();
-        assert_eq!(http_data, recv_data[20..]);
-
-        // database http network event for the Time Series Generator
-        let send_http_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let http_data = insert_http_raw_event(
-            &http_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_http_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_HTTP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_http_stream = publish.conn.accept_uni().await.unwrap();
-
-        let http_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_http_stream)
-                .await
-                .unwrap();
-        assert_eq!(http_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_http_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_http_time, recv_timestamp);
-        assert_eq!(http_data, recv_data);
-
-        // direct http network event for the Time Series Generator
-        let send_http_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "http");
-        let http_data = gen_http_raw_event();
-        send_direct_stream(
-            &key,
-            &http_data,
-            send_http_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_http_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_http_time, recv_timestamp);
-        assert_eq!(http_data, recv_data);
-    }
-
-    {
-        let smtp_store = db.smtp_store().unwrap();
-
-        // direct smtp network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_SMTP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_smtp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let smtp_start_msg = receive_semi_supervised_stream_start_message(&mut send_smtp_stream)
-            .await
-            .unwrap();
-        assert_eq!(smtp_start_msg, NETWORK_STREAM_SMTP);
-
-        let send_smtp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "smtp");
-        let smtp_data = gen_smtp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &smtp_data,
-            send_smtp_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_smtp_stream)
-            .await
-            .unwrap();
-        assert_eq!(smtp_data, recv_data[20..]);
-
-        let send_smtp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "smtp");
-        let smtp_data = gen_smtp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &smtp_data,
-            send_smtp_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_smtp_stream)
-            .await
-            .unwrap();
-        assert_eq!(smtp_data, recv_data[20..]);
-
-        // database smtp network event for the Time Series Generator
-        let send_smtp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let smtp_data = insert_smtp_raw_event(
-            &smtp_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_smtp_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_SMTP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_smtp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let smtp_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_smtp_stream)
-                .await
-                .unwrap();
-        assert_eq!(smtp_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_smtp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_smtp_time, recv_timestamp);
-        assert_eq!(smtp_data, recv_data);
-
-        // direct smtp network event for the Time Series Generator
-        let send_smtp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "smtp");
-        let smtp_data = gen_smtp_raw_event();
-        send_direct_stream(
-            &key,
-            &smtp_data,
-            send_smtp_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_smtp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_smtp_time, recv_timestamp);
-        assert_eq!(smtp_data, recv_data);
-    }
-
-    {
-        let ntlm_store = db.ntlm_store().unwrap();
-
-        // direct ntlm network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_NTLM,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ntlm_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ntlm_start_msg = receive_semi_supervised_stream_start_message(&mut send_ntlm_stream)
-            .await
-            .unwrap();
-        assert_eq!(ntlm_start_msg, NETWORK_STREAM_NTLM);
-
-        let send_ntlm_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "ntlm");
-        let ntlm_data = gen_ntlm_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ntlm_data,
-            send_ntlm_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ntlm_stream)
-            .await
-            .unwrap();
-        assert_eq!(ntlm_data, recv_data[20..]);
-
-        let send_ntlm_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "ntlm");
-        let ntlm_data = gen_ntlm_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ntlm_data,
-            send_ntlm_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ntlm_stream)
-            .await
-            .unwrap();
-        assert_eq!(ntlm_data, recv_data[20..]);
-
-        // database ntlm network event for the Time Series Generator
-        let send_ntlm_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ntlm_data = insert_ntlm_raw_event(
-            &ntlm_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_ntlm_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_NTLM,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ntlm_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ntlm_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_ntlm_stream)
-                .await
-                .unwrap();
-        assert_eq!(ntlm_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ntlm_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ntlm_time, recv_timestamp);
-        assert_eq!(ntlm_data, recv_data);
-
-        // direct ntlm network event for the Time Series Generator
-        let send_ntlm_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "ntlm");
-        let ntlm_data = gen_ntlm_raw_event();
-        send_direct_stream(
-            &key,
-            &ntlm_data,
-            send_ntlm_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ntlm_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ntlm_time, recv_timestamp);
-        assert_eq!(ntlm_data, recv_data);
-    }
-
-    {
-        let kerberos_store = db.kerberos_store().unwrap();
-
-        // direct kerberos network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_KERBEROS,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_kerberos_stream = publish.conn.accept_uni().await.unwrap();
-        let kerberos_start_msg =
-            receive_semi_supervised_stream_start_message(&mut send_kerberos_stream)
-                .await
-                .unwrap();
-        assert_eq!(kerberos_start_msg, NETWORK_STREAM_KERBEROS);
-
-        let send_kerberos_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "kerberos");
-        let kerberos_data = gen_kerberos_raw_event();
-
-        send_direct_stream(
-            &key,
-            &kerberos_data,
-            send_kerberos_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_kerberos_stream)
-            .await
-            .unwrap();
-        assert_eq!(kerberos_data, recv_data[20..]);
-
-        let send_kerberos_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "kerberos");
-        let kerberos_data = gen_kerberos_raw_event();
-
-        send_direct_stream(
-            &key,
-            &kerberos_data,
-            send_kerberos_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_kerberos_stream)
-            .await
-            .unwrap();
-        assert_eq!(kerberos_data, recv_data[20..]);
-
-        // database kerberos network event for the Time Series Generator
-        let send_kerberos_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let kerberos_data = insert_kerberos_raw_event(
-            &kerberos_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_kerberos_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_KERBEROS,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_kerberos_stream = publish.conn.accept_uni().await.unwrap();
-
-        let kerberos_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_kerberos_stream)
-                .await
-                .unwrap();
-        assert_eq!(kerberos_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_kerberos_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_kerberos_time, recv_timestamp);
-        assert_eq!(kerberos_data, recv_data);
-
-        // direct kerberos network event for the Time Series Generator
-        let send_kerberos_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "kerberos");
-        let kerberos_data = gen_kerberos_raw_event();
-        send_direct_stream(
-            &key,
-            &kerberos_data,
-            send_kerberos_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_kerberos_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_kerberos_time, recv_timestamp);
-        assert_eq!(kerberos_data, recv_data);
-    }
-
-    {
-        let ssh_store = db.ssh_store().unwrap();
-
-        // direct ssh network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_SSH,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ssh_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ssh_start_msg = receive_semi_supervised_stream_start_message(&mut send_ssh_stream)
-            .await
-            .unwrap();
-        assert_eq!(ssh_start_msg, NETWORK_STREAM_SSH);
-
-        let send_ssh_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "ssh");
-        let ssh_data = gen_ssh_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ssh_data,
-            send_ssh_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ssh_stream)
-            .await
-            .unwrap();
-        assert_eq!(ssh_data, recv_data[20..]);
-
-        let send_ssh_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "ssh");
-        let ssh_data = gen_ssh_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ssh_data,
-            send_ssh_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ssh_stream)
-            .await
-            .unwrap();
-        assert_eq!(ssh_data, recv_data[20..]);
-
-        // database ssh network event for the Time Series Generator
-        let send_ssh_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ssh_data = insert_ssh_raw_event(
-            &ssh_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_ssh_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_SSH,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ssh_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ssh_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_ssh_stream)
-                .await
-                .unwrap();
-        assert_eq!(ssh_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ssh_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ssh_time, recv_timestamp);
-        assert_eq!(ssh_data, recv_data);
-
-        // direct ssh network event for the Time Series Generator
-        let send_ssh_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "ssh");
-        let ssh_data = gen_ssh_raw_event();
-        send_direct_stream(
-            &key,
-            &ssh_data,
-            send_ssh_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ssh_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ssh_time, recv_timestamp);
-        assert_eq!(ssh_data, recv_data);
-    }
-
-    {
-        let dce_rpc_store = db.dce_rpc_store().unwrap();
-
-        // direct dce_rpc network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_DCE_RPC,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dce_rpc_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dce_rpc_start_msg =
-            receive_semi_supervised_stream_start_message(&mut send_dce_rpc_stream)
-                .await
-                .unwrap();
-        assert_eq!(dce_rpc_start_msg, NETWORK_STREAM_DCE_RPC);
-
-        let send_dce_rpc_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "dce rpc");
-        let dce_rpc_data = gen_dce_rpc_raw_event();
-
-        send_direct_stream(
-            &key,
-            &dce_rpc_data,
-            send_dce_rpc_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dce_rpc_stream)
-            .await
-            .unwrap();
-        assert_eq!(dce_rpc_data, recv_data[20..]);
-
-        let send_dce_rpc_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "dce rpc");
-        let dce_rpc_data = gen_dce_rpc_raw_event();
-
-        send_direct_stream(
-            &key,
-            &dce_rpc_data,
-            send_dce_rpc_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dce_rpc_stream)
-            .await
-            .unwrap();
-        assert_eq!(dce_rpc_data, recv_data[20..]);
-
-        // database dce_rpc network event for the Time Series Generator
-        let send_dce_rpc_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dce_rpc_data = insert_dce_rpc_raw_event(
-            &dce_rpc_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_dce_rpc_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_DCE_RPC,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dce_rpc_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dce_rpc_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_dce_rpc_stream)
-                .await
-                .unwrap();
-        assert_eq!(dce_rpc_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_dce_rpc_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_dce_rpc_time, recv_timestamp);
-        assert_eq!(dce_rpc_data, recv_data);
-
-        // direct dce_rpc network event for the Time Series Generator
-        let send_dce_rpc_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "dce rpc");
-        let dce_rpc_data = gen_dce_rpc_raw_event();
-        send_direct_stream(
-            &key,
-            &dce_rpc_data,
-            send_dce_rpc_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_dce_rpc_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_dce_rpc_time, recv_timestamp);
-        assert_eq!(dce_rpc_data, recv_data);
-    }
-
-    {
-        let ftp_store = db.ftp_store().unwrap();
-
-        // direct ftp network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_FTP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ftp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ftp_start_msg = receive_semi_supervised_stream_start_message(&mut send_ftp_stream)
-            .await
-            .unwrap();
-        assert_eq!(ftp_start_msg, NETWORK_STREAM_FTP);
-
-        let send_ftp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "ftp");
-        let ftp_data = gen_ftp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ftp_data,
-            send_ftp_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ftp_stream)
-            .await
-            .unwrap();
-        assert_eq!(ftp_data, recv_data[20..]);
-
-        let send_ftp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "ftp");
-        let ftp_data = gen_ftp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ftp_data,
-            send_ftp_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ftp_stream)
-            .await
-            .unwrap();
-        assert_eq!(ftp_data, recv_data[20..]);
-
-        // database ftp network event for the Time Series Generator
-        let send_ftp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ftp_data = insert_ftp_raw_event(
-            &ftp_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_ftp_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_FTP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ftp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ftp_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_ftp_stream)
-                .await
-                .unwrap();
-        assert_eq!(ftp_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ftp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ftp_time, recv_timestamp);
-        assert_eq!(ftp_data, recv_data);
-
-        // direct ftp network event for the Time Series Generator
-        let send_ftp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "ftp");
-        let ftp_data = gen_ftp_raw_event();
-        send_direct_stream(
-            &key,
-            &ftp_data,
-            send_ftp_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ftp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ftp_time, recv_timestamp);
-        assert_eq!(ftp_data, recv_data);
-    }
-
-    {
-        let mqtt_store = db.mqtt_store().unwrap();
-
-        // direct mqtt network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_MQTT,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_mqtt_stream = publish.conn.accept_uni().await.unwrap();
-
-        let mqtt_start_msg = receive_semi_supervised_stream_start_message(&mut send_mqtt_stream)
-            .await
-            .unwrap();
-        assert_eq!(mqtt_start_msg, NETWORK_STREAM_MQTT);
-
-        let send_mqtt_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "mqtt");
-        let mqtt_data = gen_mqtt_raw_event();
-
-        send_direct_stream(
-            &key,
-            &mqtt_data,
-            send_mqtt_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_mqtt_stream)
-            .await
-            .unwrap();
-        assert_eq!(mqtt_data, recv_data[20..]);
-
-        let send_mqtt_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "mqtt");
-        let mqtt_data = gen_mqtt_raw_event();
-
-        send_direct_stream(
-            &key,
-            &mqtt_data,
-            send_mqtt_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_mqtt_stream)
-            .await
-            .unwrap();
-        assert_eq!(mqtt_data, recv_data[20..]);
-
-        // database mqtt network event for the Time Series Generator
-        let send_mqtt_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let mqtt_data = insert_mqtt_raw_event(
-            &mqtt_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_mqtt_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_MQTT,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_mqtt_stream = publish.conn.accept_uni().await.unwrap();
-
-        let mqtt_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_mqtt_stream)
-                .await
-                .unwrap();
-        assert_eq!(mqtt_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_mqtt_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_mqtt_time, recv_timestamp);
-        assert_eq!(mqtt_data, recv_data);
-
-        // direct mqtt network event for the Time Series Generator
-        let send_mqtt_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "mqtt");
-        let mqtt_data = gen_mqtt_raw_event();
-        send_direct_stream(
-            &key,
-            &mqtt_data,
-            send_mqtt_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_mqtt_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_mqtt_time, recv_timestamp);
-        assert_eq!(mqtt_data, recv_data);
-    }
-
-    {
-        let ldap_store = db.ldap_store().unwrap();
-
-        // direct ldap network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_LDAP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ldap_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ldap_start_msg = receive_semi_supervised_stream_start_message(&mut send_ldap_stream)
-            .await
-            .unwrap();
-        assert_eq!(ldap_start_msg, NETWORK_STREAM_LDAP);
-
-        let send_ldap_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "ldap");
-        let ldap_data = gen_ldap_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ldap_data,
-            send_ldap_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ldap_stream)
-            .await
-            .unwrap();
-        assert_eq!(ldap_data, recv_data[20..]);
-
-        let send_ldap_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "ldap");
-        let ldap_data = gen_ldap_raw_event();
-
-        send_direct_stream(
-            &key,
-            &ldap_data,
-            send_ldap_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_ldap_stream)
-            .await
-            .unwrap();
-        assert_eq!(ldap_data, recv_data[20..]);
-
-        // database ldap network event for the Time Series Generator
-        let send_ldap_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let ldap_data = insert_ldap_raw_event(
-            &ldap_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_ldap_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_LDAP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_ldap_stream = publish.conn.accept_uni().await.unwrap();
-
-        let ldap_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_ldap_stream)
-                .await
-                .unwrap();
-        assert_eq!(ldap_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ldap_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ldap_time, recv_timestamp);
-        assert_eq!(ldap_data, recv_data);
-
-        // direct ldap network event for the Time Series Generator
-        let send_ldap_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "ldap");
-        let ldap_data = gen_ldap_raw_event();
-        send_direct_stream(
-            &key,
-            &ldap_data,
-            send_ldap_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_ldap_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_ldap_time, recv_timestamp);
-        assert_eq!(ldap_data, recv_data);
-    }
-
-    {
-        let tls_store = db.tls_store().unwrap();
-
-        // direct tls network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_TLS,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_tls_stream = publish.conn.accept_uni().await.unwrap();
-
-        let tls_start_msg = receive_semi_supervised_stream_start_message(&mut send_tls_stream)
-            .await
-            .unwrap();
-        assert_eq!(tls_start_msg, NETWORK_STREAM_TLS);
-
-        let send_tls_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "tls");
-        let tls_data = gen_tls_raw_event();
-
-        send_direct_stream(
-            &key,
-            &tls_data,
-            send_tls_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_tls_stream)
-            .await
-            .unwrap();
-        assert_eq!(tls_data, recv_data[20..]);
-
-        let send_tls_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "tls");
-        let tls_data = gen_tls_raw_event();
-
-        send_direct_stream(
-            &key,
-            &tls_data,
-            send_tls_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_tls_stream)
-            .await
-            .unwrap();
-        assert_eq!(tls_data, recv_data[20..]);
-
-        // database tls network event for the Time Series Generator
-        let send_tls_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let tls_data = insert_tls_raw_event(
-            &tls_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_tls_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_TLS,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_tls_stream = publish.conn.accept_uni().await.unwrap();
-
-        let tls_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_tls_stream)
-                .await
-                .unwrap();
-        assert_eq!(tls_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_tls_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_tls_time, recv_timestamp);
-        assert_eq!(tls_data, recv_data);
-
-        // direct tls network event for the Time Series Generator
-        let send_tls_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "tls");
-        let tls_data = gen_tls_raw_event();
-        send_direct_stream(
-            &key,
-            &tls_data,
-            send_tls_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_tls_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_tls_time, recv_timestamp);
-        assert_eq!(tls_data, recv_data);
-    }
-
-    {
-        let smb_store = db.smb_store().unwrap();
-
-        // direct smb network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_SMB,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_smb_stream = publish.conn.accept_uni().await.unwrap();
-
-        let smb_start_msg = receive_semi_supervised_stream_start_message(&mut send_smb_stream)
-            .await
-            .unwrap();
-        assert_eq!(smb_start_msg, NETWORK_STREAM_SMB);
-
-        let send_smb_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "smb");
-        let smb_data = gen_smb_raw_event();
-
-        send_direct_stream(
-            &key,
-            &smb_data,
-            send_smb_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_smb_stream)
-            .await
-            .unwrap();
-        assert_eq!(smb_data, recv_data[20..]);
-
-        let send_smb_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "smb");
-        let smb_data = gen_smb_raw_event();
-
-        send_direct_stream(
-            &key,
-            &smb_data,
-            send_smb_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_smb_stream)
-            .await
-            .unwrap();
-        assert_eq!(smb_data, recv_data[20..]);
-
-        // database smb network event for the Time Series Generator
-        let send_smb_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let smb_data = insert_smb_raw_event(
-            &smb_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_smb_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_SMB,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_smb_stream = publish.conn.accept_uni().await.unwrap();
-
-        let smb_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_smb_stream)
-                .await
-                .unwrap();
-        assert_eq!(smb_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_smb_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_smb_time, recv_timestamp);
-        assert_eq!(smb_data, recv_data);
-
-        // direct smb network event for the Time Series Generator
-        let send_smb_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "smb");
-        let smb_data = gen_smb_raw_event();
-        send_direct_stream(
-            &key,
-            &smb_data,
-            send_smb_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_smb_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_smb_time, recv_timestamp);
-        assert_eq!(smb_data, recv_data);
-    }
-
-    {
-        let nfs_store = db.nfs_store().unwrap();
-
-        // direct nfs network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_NFS,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_nfs_stream = publish.conn.accept_uni().await.unwrap();
-
-        let nfs_start_msg = receive_semi_supervised_stream_start_message(&mut send_nfs_stream)
-            .await
-            .unwrap();
-        assert_eq!(nfs_start_msg, NETWORK_STREAM_NFS);
-
-        let send_nfs_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "nfs");
-        let nfs_data = gen_nfs_raw_event();
-
-        send_direct_stream(
-            &key,
-            &nfs_data,
-            send_nfs_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_nfs_stream)
-            .await
-            .unwrap();
-        assert_eq!(nfs_data, recv_data[20..]);
-
-        let send_nfs_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "nfs");
-        let nfs_data = gen_nfs_raw_event();
-
-        send_direct_stream(
-            &key,
-            &nfs_data,
-            send_nfs_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_nfs_stream)
-            .await
-            .unwrap();
-        assert_eq!(nfs_data, recv_data[20..]);
-
-        // database nfs network event for the Time Series Generator
-        let send_nfs_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let nfs_data = insert_nfs_raw_event(
-            &nfs_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_nfs_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_NFS,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_nfs_stream = publish.conn.accept_uni().await.unwrap();
-
-        let nfs_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_nfs_stream)
-                .await
-                .unwrap();
-        assert_eq!(nfs_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_nfs_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_nfs_time, recv_timestamp);
-        assert_eq!(nfs_data, recv_data);
-
-        // direct nfs network event for the Time Series Generator
-        let send_nfs_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "nfs");
-        let nfs_data = gen_nfs_raw_event();
-        send_direct_stream(
-            &key,
-            &nfs_data,
-            send_nfs_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_nfs_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_nfs_time, recv_timestamp);
-        assert_eq!(nfs_data, recv_data);
-    }
-
-    {
-        let bootp_store = db.bootp_store().unwrap();
-
-        // direct bootp network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_BOOTP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_bootp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let bootp_start_msg = receive_semi_supervised_stream_start_message(&mut send_bootp_stream)
-            .await
-            .unwrap();
-        assert_eq!(bootp_start_msg, NETWORK_STREAM_BOOTP);
-
-        let send_bootp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "bootp");
-        let bootp_data = gen_bootp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &bootp_data,
-            send_bootp_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_bootp_stream)
-            .await
-            .unwrap();
-        assert_eq!(bootp_data, recv_data[20..]);
-
-        let send_bootp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "bootp");
-        let bootp_data = gen_bootp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &bootp_data,
-            send_bootp_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_bootp_stream)
-            .await
-            .unwrap();
-        assert_eq!(bootp_data, recv_data[20..]);
-
-        // database bootp network event for the Time Series Generator
-        let send_bootp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let bootp_data = insert_bootp_raw_event(
-            &bootp_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_bootp_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_BOOTP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_bootp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let bootp_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_bootp_stream)
-                .await
-                .unwrap();
-        assert_eq!(bootp_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_bootp_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_bootp_time, recv_timestamp);
-        assert_eq!(bootp_data, recv_data);
-
-        // direct bootp network event for the Time Series Generator
-        let send_bootp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "bootp");
-        let bootp_data = gen_bootp_raw_event();
-        send_direct_stream(
-            &key,
-            &bootp_data,
-            send_bootp_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_bootp_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_bootp_time, recv_timestamp);
-        assert_eq!(bootp_data, recv_data);
-    }
-
-    {
-        let dhcp_store = db.dhcp_store().unwrap();
-
-        // direct dhcp network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_DHCP,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dhcp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dhcp_start_msg = receive_semi_supervised_stream_start_message(&mut send_dhcp_stream)
-            .await
-            .unwrap();
-        assert_eq!(dhcp_start_msg, NETWORK_STREAM_DHCP);
-
-        let send_dhcp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "dhcp");
-        let dhcp_data = gen_dhcp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &dhcp_data,
-            send_dhcp_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dhcp_stream)
-            .await
-            .unwrap();
-        assert_eq!(dhcp_data, recv_data[20..]);
-
-        let send_dhcp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "dhcp");
-        let dhcp_data = gen_dhcp_raw_event();
-
-        send_direct_stream(
-            &key,
-            &dhcp_data,
-            send_dhcp_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_dhcp_stream)
-            .await
-            .unwrap();
-        assert_eq!(dhcp_data, recv_data[20..]);
-
-        // database dhcp network event for the Time Series Generator
-        let send_dhcp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let dhcp_data = insert_dhcp_raw_event(
-            &dhcp_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_dhcp_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_DHCP,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_dhcp_stream = publish.conn.accept_uni().await.unwrap();
-
-        let dhcp_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_dhcp_stream)
-                .await
-                .unwrap();
-        assert_eq!(dhcp_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_dhcp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_dhcp_time, recv_timestamp);
-        assert_eq!(dhcp_data, recv_data);
-
-        // direct dhcp network event for the Time Series Generator
-        let send_dhcp_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "dhcp");
-        let dhcp_data = gen_dhcp_raw_event();
-        send_direct_stream(
-            &key,
-            &dhcp_data,
-            send_dhcp_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) = receive_time_series_generator_data(&mut send_dhcp_stream)
-            .await
-            .unwrap();
-        assert_eq!(send_dhcp_time, recv_timestamp);
-        assert_eq!(dhcp_data, recv_data);
-    }
-
-    {
-        let radius_store = db.radius_store().unwrap();
-
-        // direct radius network event for the Semi-supervised Engine (src1,src2)
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::SemiSupervised {
-                record_type: NETWORK_STREAM_RADIUS,
-                request: semi_supervised_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_radius_stream = publish.conn.accept_uni().await.unwrap();
-
-        let radius_start_msg =
-            receive_semi_supervised_stream_start_message(&mut send_radius_stream)
-                .await
-                .unwrap();
-        assert_eq!(radius_start_msg, NETWORK_STREAM_RADIUS);
-
-        let send_radius_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_ONE, "radius");
-        let radius_data = gen_radius_raw_event();
-
-        send_direct_stream(
-            &key,
-            &radius_data,
-            send_radius_time,
-            SENSOR_SEMI_SUPERVISED_ONE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_radius_stream)
-            .await
-            .unwrap();
-        assert_eq!(radius_data, recv_data[20..]);
-
-        let send_radius_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_SEMI_SUPERVISED_TWO, "radius");
-        let radius_data = gen_radius_raw_event();
-
-        send_direct_stream(
-            &key,
-            &radius_data,
-            send_radius_time,
-            SENSOR_SEMI_SUPERVISED_TWO,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let recv_data = receive_semi_supervised_data(&mut send_radius_stream)
-            .await
-            .unwrap();
-        assert_eq!(radius_data, recv_data[20..]);
-
-        // database radius network event for the Time Series Generator
-        let send_radius_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let radius_data = insert_radius_raw_event(
-            &radius_store,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            send_radius_time,
-        );
-
-        send_stream_request(
-            &mut publish.send,
-            StreamRequestPayload::TimeSeriesGenerator {
-                record_type: NETWORK_STREAM_RADIUS,
-                request: time_series_generator_msg.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut send_radius_stream = publish.conn.accept_uni().await.unwrap();
-
-        let radius_start_msg =
-            receive_time_series_generator_stream_start_message(&mut send_radius_stream)
-                .await
-                .unwrap();
-        assert_eq!(radius_start_msg, POLICY_ID);
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_radius_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_radius_time, recv_timestamp);
-        assert_eq!(radius_data, recv_data);
-
-        // direct radius network event for the Time Series Generator
-        let send_radius_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let key = NetworkKey::new(SENSOR_TIME_SERIES_GENERATOR_THREE, "radius");
-        let radius_data = gen_radius_raw_event();
-        send_direct_stream(
-            &key,
-            &radius_data,
-            send_radius_time,
-            SENSOR_TIME_SERIES_GENERATOR_THREE,
-            stream_direct_channels.clone(),
-        )
-        .await
-        .unwrap();
-
-        let (recv_data, recv_timestamp) =
-            receive_time_series_generator_data(&mut send_radius_stream)
-                .await
-                .unwrap();
-        assert_eq!(send_radius_time, recv_timestamp);
-        assert_eq!(radius_data, recv_data);
+    for (record_type, kind, payload_fn) in build_streams_without_tsg() {
+        assert_semi_supervised_stream(
+            publish,
+            record_type,
+            &semi_supervised_msg,
+            &stream_direct_channels,
+            kind,
+            &[SENSOR_SEMI_SUPERVISED_ONE],
+            payload_fn,
+        )
+        .await;
     }
 
     publish.conn.close(0u32.into(), b"publish_time_done");
@@ -4582,981 +3160,420 @@ async fn request_network_event_stream() {
 }
 
 #[tokio::test]
+#[serial]
 async fn request_raw_events() {
-    init_crypto();
     const SENSOR: &str = "src 1";
-    const KIND: &str = "conn";
-    const TIMESTAMP: i64 = 100;
 
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
 
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let conn_store = db.conn_store().unwrap();
-    let send_conn_time = TIMESTAMP;
-    let conn_raw_data = insert_conn_raw_event(&conn_store, SENSOR, send_conn_time);
-    let conn_data = bincode::deserialize::<Conn>(&conn_raw_data).unwrap();
-    let raw_data = conn_data.response_data(TIMESTAMP, SENSOR).unwrap();
-
-    let message = RequestRawData {
-        kind: String::from(KIND),
-        input: vec![(String::from(SENSOR), vec![TIMESTAMP])],
-    };
-
-    send_range_data_request(&mut send_pub_req, MessageCode::RawData, message)
-        .await
-        .unwrap();
-
-    let mut result_data = vec![];
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        if let Some(data) = resp_data {
-            result_data.push(data);
-        } else {
-            break;
-        }
+    let cases = network_raw_event_cases();
+    for case in &cases {
+        assert_raw_event_case(publish, db, SENSOR, case).await;
     }
-    assert_eq!(result_data.len(), 1);
-    assert_eq!(result_data[0].0, TIMESTAMP);
-    assert_eq!(&result_data[0].1, SENSOR);
-    assert_eq!(
-        raw_data,
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop()).unwrap()
-    );
 }
 
 #[tokio::test]
-async fn request_malformed_dns_raw_events() {
-    init_crypto();
+#[serial]
+async fn request_raw_events_sysmon() {
     const SENSOR: &str = "src 1";
-    const KIND: &str = "malformed_dns";
-    const TIMESTAMP: i64 = 200;
 
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-    let (peers, peer_idents) = new_peers_data(None);
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
 
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let malformed_dns_store = db.malformed_dns_store().unwrap();
-    let send_malformed_dns_time = TIMESTAMP;
-    let malformed_dns_raw =
-        insert_malformed_dns_raw_event(&malformed_dns_store, SENSOR, send_malformed_dns_time);
-    let malformed_dns_data: MalformedDns =
-        bincode::deserialize::<MalformedDns>(&malformed_dns_raw).unwrap();
-    let raw_data = malformed_dns_data.response_data(TIMESTAMP, SENSOR).unwrap();
-
-    let message = RequestRawData {
-        kind: String::from(KIND),
-        input: vec![(String::from(SENSOR), vec![TIMESTAMP])],
-    };
-
-    send_range_data_request(&mut send_pub_req, MessageCode::RawData, message)
-        .await
-        .unwrap();
-
-    let mut result_data = vec![];
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        if let Some(data) = resp_data {
-            result_data.push(data);
-        } else {
-            break;
-        }
+    let cases = sysmon_raw_event_cases();
+    for case in &cases {
+        assert_raw_event_case(publish, db, SENSOR, case).await;
     }
-    assert_eq!(result_data.len(), 1);
-    assert_eq!(result_data[0].0, TIMESTAMP);
-    assert_eq!(&result_data[0].1, SENSOR);
-    assert_eq!(raw_data, bincode::serialize(&result_data.pop()).unwrap());
+}
+
+#[tokio::test]
+#[serial]
+async fn request_raw_events_netflow() {
+    const SENSOR: &str = "src 1";
+
+    let harness = setup_test_harness().await;
+    let db = &harness.db;
+    let publish = &harness.publish;
+
+    let cases = netflow_raw_event_cases();
+    for case in &cases {
+        assert_raw_event_case(publish, db, SENSOR, case).await;
+    }
 }
 
 #[tokio::test]
 #[serial]
 async fn request_range_data_with_protocol_giganto_cluster() {
-    init_crypto();
-    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SENSOR: &str = "ingest src 2";
-    const CONN_KIND: &str = "conn";
 
-    let (oneshot_send, oneshot_recv) = tokio::sync::oneshot::channel();
-
-    // spawn node2 publish server
-    tokio::spawn(async {
-        let db_dir = tempfile::tempdir().unwrap();
-        let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-        let pcap_sensors = new_pcap_sensors();
-        let stream_direct_channels = new_stream_direct_channels();
-        let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-            NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-        ));
-
-        let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
-        let cert = to_cert_chain(&cert_pem).unwrap();
-        let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
-        let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-        let root = to_root_cert(&ca_cert_path).unwrap();
-        let certs = Arc::new(Certs {
-            certs: cert,
-            key,
-            root,
-        });
-
-        let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-            Ipv6Addr::LOCALHOST.to_string(),
-            PeerInfo {
-                ingest_sensors: NODE1_GIGANTO_INGEST_SENSORS
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect::<HashSet<String>>(),
-                graphql_port: None,
-                publish_port: Some(NODE1_TEST_PORT),
-            },
-        )])));
-
-        let mut peer_identities = HashSet::new();
-        peer_identities.insert(PeerIdentity {
-            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            hostname: NODE1_HOST.to_string(),
-        });
-        let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-        let notify_shutdown = Arc::new(Notify::new());
-
-        // prepare data in node2 database
-        let conn_store = db.conn_store().unwrap();
-        let send_conn_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let conn_data = bincode::deserialize::<Conn>(&insert_conn_raw_event(
-            &conn_store,
-            SENSOR,
-            send_conn_time,
-        ))
-        .unwrap();
-
-        if oneshot_send
-            .send(conn_data.response_data(send_conn_time, SENSOR).unwrap())
-            .is_err()
-        {
-            eprintln!("the receiver is dropped");
-        }
-
-        let node2_server = Server::new(
-            SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT),
-            &certs,
-        );
-        node2_server
-            .run(
-                db,
-                pcap_sensors,
-                stream_direct_channels,
-                ingest_sensors,
-                peers,
-                peer_idents,
-                certs,
-                notify_shutdown,
-            )
-            .await;
-    });
-
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-
-    let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-        "127.0.0.1".to_string(),
-        PeerInfo {
-            ingest_sensors: NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-            graphql_port: None,
-            publish_port: Some(NODE2_PORT),
-        },
-    )])));
-    let mut peer_identities = HashSet::new();
-    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
-    peer_identities.insert(PeerIdentity {
-        addr: addr_to_peers,
-        hostname: NODE2_HOST.to_string(),
-    });
-    let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-
-    let publish = TestClient::new().await;
-
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let start = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .expect("valid date")
-            .and_hms_opt(00, 00, 00)
-            .expect("valid time"),
-        Utc,
-    );
-    let end = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2050, 12, 31)
-            .expect("valid date")
-            .and_hms_opt(23, 59, 59)
-            .expect("valid time"),
-        Utc,
-    );
-    let message = RequestRange {
-        sensor: String::from(SENSOR),
-        kind: String::from(CONN_KIND),
-        start: start.timestamp_nanos_opt().unwrap(),
-        end: end.timestamp_nanos_opt().unwrap(),
-        count: 5,
-    };
-
-    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-        .await
-        .unwrap();
-
-    let mut result_data = Vec::new();
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        result_data.push(resp_data.clone());
-        if resp_data.is_none() {
-            break;
-        }
-    }
-
-    let raw_data = if let Ok(v) = oneshot_recv.await {
-        v
-    } else {
-        eprintln!("the sender dropped");
-        Vec::new()
-    };
-
-    assert_eq!(
-        Conn::response_done().unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-    assert_eq!(
-        raw_data,
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-
-    publish.conn.close(0u32.into(), b"publish_time_done");
-    publish.endpoint.wait_idle().await;
+    request_range_data_on_cluster::<Vec<u8>, _>(SENSOR, |db| {
+        prepare_cluster_network_cases(db, SENSOR)
+    })
+    .await;
 }
 
 #[tokio::test]
 #[serial]
 async fn request_range_data_with_log_giganto_cluster() {
-    init_crypto();
-    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SENSOR: &str = "src2";
-    const KIND: &str = "Hello";
+    const KIND: &str = LOG_KIND;
 
-    let (oneshot_send, oneshot_recv) = tokio::sync::oneshot::channel();
+    request_range_data_on_cluster::<Vec<u8>, _>(SENSOR, |db| {
+        prepare_cluster_log_cases(db, SENSOR, KIND)
+    })
+    .await;
+}
 
-    // spawn node2 publish server
-    tokio::spawn(async {
-        let db_dir = tempfile::tempdir().unwrap();
-        let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-        let pcap_sensors = new_pcap_sensors();
-        let stream_direct_channels = new_stream_direct_channels();
-        let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-            NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-        ));
+#[tokio::test]
+#[serial]
+async fn request_range_data_with_sysmon_giganto_cluster() {
+    const SENSOR: &str = "ingest src 2";
 
-        let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
-        let cert = to_cert_chain(&cert_pem).unwrap();
-        let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
-        let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-        let root = to_root_cert(&ca_cert_path).unwrap();
-        let certs = Arc::new(Certs {
-            certs: cert,
-            key,
-            root,
-        });
+    request_range_data_on_cluster::<Vec<u8>, _>(SENSOR, |db| {
+        prepare_cluster_sysmon_cases(db, SENSOR)
+    })
+    .await;
+}
 
-        let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-            Ipv6Addr::LOCALHOST.to_string(),
-            PeerInfo {
-                ingest_sensors: NODE1_GIGANTO_INGEST_SENSORS
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect::<HashSet<String>>(),
-                graphql_port: None,
-                publish_port: Some(NODE1_TEST_PORT),
-            },
-        )])));
+#[tokio::test]
+#[serial]
+async fn request_range_data_with_netflow_giganto_cluster() {
+    const SENSOR: &str = "ingest src 2";
 
-        let mut peer_identities = HashSet::new();
-        peer_identities.insert(PeerIdentity {
-            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            hostname: NODE1_HOST.to_string(),
-        });
-        let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-        let notify_shutdown = Arc::new(Notify::new());
-
-        // prepare data in node2 database
-        let log_store = db.log_store().unwrap();
-        let send_log_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let log_data = bincode::deserialize::<Log>(&insert_log_raw_event(
-            &log_store,
-            SENSOR,
-            KIND,
-            send_log_time,
-        ))
-        .unwrap();
-
-        if oneshot_send
-            .send(log_data.response_data(send_log_time, SENSOR).unwrap())
-            .is_err()
-        {
-            eprintln!("the receiver is dropped");
-        }
-
-        let node2_server = Server::new(
-            SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT),
-            &certs,
-        );
-        node2_server
-            .run(
-                db,
-                pcap_sensors,
-                stream_direct_channels,
-                ingest_sensors,
-                peers,
-                peer_idents,
-                certs,
-                notify_shutdown,
-            )
-            .await;
-    });
-
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-
-    let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-        "127.0.0.1".to_string(),
-        PeerInfo {
-            ingest_sensors: NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-            graphql_port: None,
-            publish_port: Some(NODE2_PORT),
-        },
-    )])));
-    let mut peer_identities = HashSet::new();
-    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
-    peer_identities.insert(PeerIdentity {
-        addr: addr_to_peers,
-        hostname: NODE2_HOST.to_string(),
-    });
-    let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let start = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .expect("valid date")
-            .and_hms_opt(00, 00, 00)
-            .expect("valid time"),
-        Utc,
-    );
-    let end = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2050, 12, 31)
-            .expect("valid date")
-            .and_hms_opt(23, 59, 59)
-            .expect("valid time"),
-        Utc,
-    );
-    let message = RequestRange {
-        sensor: String::from(SENSOR),
-        kind: String::from(KIND),
-        start: start.timestamp_nanos_opt().unwrap(),
-        end: end.timestamp_nanos_opt().unwrap(),
-        count: 5,
-    };
-
-    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-        .await
-        .unwrap();
-
-    let mut result_data = Vec::new();
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        result_data.push(resp_data.clone());
-        if resp_data.is_none() {
-            break;
-        }
-    }
-
-    let raw_data = if let Ok(v) = oneshot_recv.await {
-        v
-    } else {
-        eprintln!("the sender dropped");
-        Vec::new()
-    };
-
-    assert_eq!(
-        Conn::response_done().unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-    assert_eq!(
-        raw_data,
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-
-    publish.conn.close(0u32.into(), b"publish_log_done");
-    publish.endpoint.wait_idle().await;
+    request_range_data_on_cluster::<Vec<u8>, _>(SENSOR, |db| {
+        prepare_cluster_netflow_cases(db, SENSOR)
+    })
+    .await;
 }
 
 #[tokio::test]
 #[serial]
 async fn request_range_data_with_period_time_series_giganto_cluster() {
-    init_crypto();
-    const PUBLISH_RANGE_MESSAGE_CODE: MessageCode = MessageCode::ReqRange;
     const SAMPLING_POLICY_ID_AS_SENSOR: &str = "ingest src 2";
-    const KIND: &str = "timeseries";
 
-    let (oneshot_send, oneshot_recv) = tokio::sync::oneshot::channel();
-
-    // spawn node2 publish server
-    tokio::spawn(async {
-        let db_dir = tempfile::tempdir().unwrap();
-        let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-        let pcap_sensors = new_pcap_sensors();
-        let stream_direct_channels = new_stream_direct_channels();
-        let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-            NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-        ));
-
-        let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
-        let cert = to_cert_chain(&cert_pem).unwrap();
-        let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
-        let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-        let root = to_root_cert(&ca_cert_path).unwrap();
-        let certs = Arc::new(Certs {
-            certs: cert,
-            key,
-            root,
-        });
-
-        let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-            Ipv6Addr::LOCALHOST.to_string(),
-            PeerInfo {
-                ingest_sensors: NODE1_GIGANTO_INGEST_SENSORS
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect::<HashSet<String>>(),
-                graphql_port: None,
-                publish_port: Some(NODE1_TEST_PORT),
-            },
-        )])));
-
-        let mut peer_identities = HashSet::new();
-        peer_identities.insert(PeerIdentity {
-            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            hostname: NODE1_HOST.to_string(),
-        });
-        let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-        let notify_shutdown = Arc::new(Notify::new());
-
-        // prepare data in node2 database
-        let time_series_store = db.periodic_time_series_store().unwrap();
-        let send_time_series_time = Utc::now().timestamp_nanos_opt().unwrap();
-        let time_series_data =
-            bincode::deserialize::<PeriodicTimeSeries>(&insert_periodic_time_series_raw_event(
-                &time_series_store,
-                SAMPLING_POLICY_ID_AS_SENSOR,
-                send_time_series_time,
-            ))
-            .unwrap();
-
-        if oneshot_send
-            .send(
-                time_series_data
-                    .response_data(send_time_series_time, SAMPLING_POLICY_ID_AS_SENSOR)
-                    .unwrap(),
-            )
-            .is_err()
-        {
-            eprintln!("the receiver is dropped");
-        }
-
-        let node2_server = Server::new(
-            SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT),
-            &certs,
-        );
-        node2_server
-            .run(
-                db,
-                pcap_sensors,
-                stream_direct_channels,
-                ingest_sensors,
-                peers,
-                peer_idents,
-                certs,
-                notify_shutdown,
-            )
-            .await;
-    });
-
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-
-    let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-        "127.0.0.1".to_string(),
-        PeerInfo {
-            ingest_sensors: NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-            graphql_port: None,
-            publish_port: Some(NODE2_PORT),
-        },
-    )])));
-
-    let mut peer_identities = HashSet::new();
-    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
-    peer_identities.insert(PeerIdentity {
-        addr: addr_to_peers,
-        hostname: NODE2_HOST.to_string(),
-    });
-    let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let start = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(1970, 1, 1)
-            .expect("valid date")
-            .and_hms_opt(00, 00, 00)
-            .expect("valid time"),
-        Utc,
-    );
-    let end = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2050, 12, 31)
-            .expect("valid date")
-            .and_hms_opt(23, 59, 59)
-            .expect("valid time"),
-        Utc,
-    );
-    let message = RequestRange {
-        sensor: String::from(SAMPLING_POLICY_ID_AS_SENSOR),
-        kind: String::from(KIND),
-        start: start.timestamp_nanos_opt().unwrap(),
-        end: end.timestamp_nanos_opt().unwrap(),
-        count: 5,
-    };
-
-    send_range_data_request(&mut send_pub_req, PUBLISH_RANGE_MESSAGE_CODE, message)
-        .await
-        .unwrap();
-
-    let mut result_data = Vec::new();
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<f64>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        result_data.push(resp_data.clone());
-        if resp_data.is_none() {
-            break;
-        }
-    }
-
-    let raw_data = if let Ok(v) = oneshot_recv.await {
-        v
-    } else {
-        eprintln!("the sender dropped");
-        Vec::new()
-    };
-
-    assert_eq!(
-        PeriodicTimeSeries::response_done().unwrap(),
-        bincode::serialize::<Option<(i64, String, Vec<f64>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-    assert_eq!(
-        raw_data,
-        bincode::serialize::<Option<(i64, String, Vec<f64>)>>(&result_data.pop().unwrap()).unwrap()
-    );
-
-    publish.conn.close(0u32.into(), b"publish_time_done");
-    publish.endpoint.wait_idle().await;
+    request_range_data_on_cluster::<Vec<f64>, _>(SAMPLING_POLICY_ID_AS_SENSOR, |db| {
+        prepare_cluster_periodic_time_series_cases(db, SAMPLING_POLICY_ID_AS_SENSOR)
+    })
+    .await;
 }
 
 #[tokio::test]
 #[serial]
 async fn request_raw_events_giganto_cluster() {
-    init_crypto();
     const SENSOR: &str = "src 2";
-    const KIND: &str = "conn";
-    const TIMESTAMP: i64 = 100;
 
-    let (oneshot_send, oneshot_recv) = tokio::sync::oneshot::channel();
+    let ClusterContext {
+        publish,
+        cases: prepared_cases,
+        ..
+    } = setup_cluster_with_cases(|node2_db| {
+        let cases = all_raw_event_cases();
+        cases
+            .iter()
+            .map(|case| {
+                let (timestamp, expected) = prepare_raw_event(node2_db, SENSOR, case);
+                RawEventClusterCase {
+                    kind: case.kind,
+                    timestamp,
+                    expected,
+                }
+            })
+            .collect()
+    })
+    .await;
 
-    // spawn node2 publish server
-    tokio::spawn(async {
-        let db_dir = tempfile::tempdir().unwrap();
-        let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-        let pcap_sensors = new_pcap_sensors();
-        let stream_direct_channels = new_stream_direct_channels();
-        let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-            NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-        ));
+    for RawEventClusterCase {
+        kind,
+        timestamp,
+        expected,
+    } in prepared_cases
+    {
+        if kind == "timeseries" {
+            let mut result_data =
+                fetch_raw_data_with_payload::<Vec<f64>>(&publish, kind, SENSOR, timestamp).await;
 
-        let cert_pem = fs::read(NODE2_CERT_PATH).unwrap();
-        let cert = to_cert_chain(&cert_pem).unwrap();
-        let key_pem = fs::read(NODE2_KEY_PATH).unwrap();
-        let key = to_private_key(&key_pem).unwrap();
-        let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-        let root = to_root_cert(&ca_cert_path).unwrap();
-        let certs = Arc::new(Certs {
-            certs: cert,
-            key,
-            root,
-        });
-
-        let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-            Ipv6Addr::LOCALHOST.to_string(),
-            PeerInfo {
-                ingest_sensors: NODE1_GIGANTO_INGEST_SENSORS
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect::<HashSet<String>>(),
-                graphql_port: None,
-                publish_port: Some(NODE1_TEST_PORT),
-            },
-        )])));
-
-        let mut peer_identities = HashSet::new();
-        peer_identities.insert(PeerIdentity {
-            addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), NODE1_TEST_PORT),
-            hostname: NODE1_HOST.to_string(),
-        });
-        let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-        let notify_shutdown = Arc::new(Notify::new());
-
-        // prepare data in node2 database
-        let conn_store = db.conn_store().unwrap();
-        let send_conn_time = TIMESTAMP;
-        let conn_raw_data = insert_conn_raw_event(&conn_store, SENSOR, send_conn_time);
-        let conn_data = bincode::deserialize::<Conn>(&conn_raw_data).unwrap();
-        let raw_data = conn_data.response_data(TIMESTAMP, SENSOR).unwrap();
-
-        if oneshot_send.send(raw_data).is_err() {
-            eprintln!("the receiver is dropped");
-        }
-
-        let node2_server = Server::new(
-            SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT),
-            &certs,
-        );
-        node2_server
-            .run(
-                db,
-                pcap_sensors,
-                stream_direct_channels,
-                ingest_sensors,
-                peers,
-                peer_idents,
-                certs,
-                notify_shutdown,
-            )
-            .await;
-    });
-
-    let _lock = get_token().lock().await;
-    let db_dir = tempfile::tempdir().unwrap();
-    let db = Database::open(db_dir.path(), &DbOptions::default()).unwrap();
-    let pcap_sensors = new_pcap_sensors();
-    let stream_direct_channels = new_stream_direct_channels();
-    let ingest_sensors = Arc::new(tokio::sync::RwLock::new(
-        NODE1_GIGANTO_INGEST_SENSORS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<HashSet<String>>(),
-    ));
-
-    let peers = Arc::new(tokio::sync::RwLock::new(HashMap::from([(
-        "127.0.0.1".to_string(),
-        PeerInfo {
-            ingest_sensors: NODE2_GIGANTO_INGEST_SENSORS
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<String>>(),
-            graphql_port: None,
-            publish_port: Some(NODE2_PORT),
-        },
-    )])));
-
-    let mut peer_identities = HashSet::new();
-    let addr_to_peers = SocketAddr::new("127.0.0.1".parse::<IpAddr>().unwrap(), NODE2_PORT);
-    peer_identities.insert(PeerIdentity {
-        addr: addr_to_peers,
-        hostname: NODE2_HOST.to_string(),
-    });
-    let peer_idents = Arc::new(RwLock::new(peer_identities));
-
-    let cert_pem = fs::read(NODE1_CERT_PATH).unwrap();
-    let cert = to_cert_chain(&cert_pem).unwrap();
-    let key_pem = fs::read(NODE1_KEY_PATH).unwrap();
-    let key = to_private_key(&key_pem).unwrap();
-    let ca_cert_path = vec![CA_CERT_PATH.to_string()];
-    let root = to_root_cert(&ca_cert_path).unwrap();
-
-    let certs = Arc::new(Certs {
-        certs: cert,
-        key,
-        root,
-    });
-
-    tokio::spawn(server().run(
-        db.clone(),
-        pcap_sensors,
-        stream_direct_channels,
-        ingest_sensors,
-        peers,
-        peer_idents,
-        certs,
-        Arc::new(Notify::new()),
-    ));
-    let publish = TestClient::new().await;
-
-    let (mut send_pub_req, mut recv_pub_resp) =
-        publish.conn.open_bi().await.expect("failed to open stream");
-
-    let message = RequestRawData {
-        kind: String::from(KIND),
-        input: vec![(String::from(SENSOR), vec![TIMESTAMP])],
-    };
-
-    send_range_data_request(&mut send_pub_req, MessageCode::RawData, message)
-        .await
-        .unwrap();
-
-    let mut result_data = vec![];
-    loop {
-        let resp_data = receive_range_data::<Option<(i64, String, Vec<u8>)>>(&mut recv_pub_resp)
-            .await
-            .unwrap();
-
-        if let Some(data) = resp_data {
-            result_data.push(data);
+            assert_eq!(result_data.len(), 1, "Failed for kind: {kind}");
+            assert_eq!(result_data[0].0, timestamp);
+            assert_eq!(&result_data[0].1, SENSOR);
+            assert_eq!(
+                expected,
+                bincode::serialize(&Some(result_data.pop().unwrap())).unwrap()
+            );
         } else {
-            break;
+            let mut result_data = fetch_raw_data(&publish, kind, SENSOR, timestamp).await;
+
+            assert_eq!(result_data.len(), 1, "Failed for kind: {kind}");
+            assert_eq!(result_data[0].0, timestamp);
+            assert_eq!(&result_data[0].1, SENSOR);
+            assert_eq!(
+                expected,
+                bincode::serialize(&Some(result_data.pop().unwrap())).unwrap()
+            );
         }
     }
 
-    let raw_data = if let Ok(v) = oneshot_recv.await {
-        v
-    } else {
-        eprintln!("the sender dropped");
-        Vec::new()
+    publish.conn.close(0u32.into(), b"publish_raw_events_done");
+    publish.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn request_pcap_extract() {
+    const SENSOR: &str = "pcap_sensor_1";
+
+    let harness = setup_test_harness().await;
+    let pcap_sensors = harness.pcap_sensors.clone();
+    let publish = &harness.publish;
+
+    let (sensor_conn, mut filter_rx, _sensor_server_endpoint, _sensor_client_endpoint) =
+        setup_pcap_sensor_connection(NODE1.host).await;
+    pcap_sensors
+        .write()
+        .await
+        .insert(SENSOR.to_string(), vec![sensor_conn]);
+
+    let filter = PcapFilter {
+        start_time: 12345,
+        sensor: SENSOR.to_string(),
+        src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+        src_port: 46378,
+        dst_addr: "192.168.4.77".parse::<IpAddr>().unwrap(),
+        dst_port: 80,
+        proto: 6,
+        end_time: 13345,
     };
 
-    assert_eq!(result_data.len(), 1);
-    assert_eq!(result_data[0].0, TIMESTAMP);
-    assert_eq!(&result_data[0].1, SENSOR);
+    let (mut send_pub_req, mut recv_pub_resp) =
+        publish.conn.open_bi().await.expect("failed to open stream");
+    send_range_data_request(&mut send_pub_req, MessageCode::Pcap, vec![filter.clone()])
+        .await
+        .unwrap();
+    recv_ack_response(&mut recv_pub_resp).await.unwrap();
+
+    let received_filter = tokio::time::timeout(StdDuration::from_secs(15), filter_rx.recv())
+        .await
+        .expect("pcap sensor did not respond")
+        .expect("pcap sensor channel closed");
+
+    assert_eq!(received_filter.sensor, filter.sensor);
+    assert_eq!(received_filter.src_addr, filter.src_addr);
+    assert_eq!(received_filter.dst_addr, filter.dst_addr);
+
+    publish.conn.close(0u32.into(), b"pcap_extract_done");
+    publish.endpoint.wait_idle().await;
+}
+
+#[tokio::test]
+async fn peer_in_charge_publish_addr_returns_peer() {
+    let peers = Arc::new(RwLock::new(HashMap::from([(
+        "10.0.0.2".to_string(),
+        PeerInfo {
+            ingest_sensors: HashSet::from(["sensor_a".to_string()]),
+            graphql_port: None,
+            publish_port: Some(61000),
+        },
+    )])));
+
+    let addr = super::peer_in_charge_publish_addr(peers, "sensor_a").await;
     assert_eq!(
-        raw_data,
-        bincode::serialize::<Option<(i64, String, Vec<u8>)>>(&result_data.pop()).unwrap()
+        addr,
+        Some(SocketAddr::new(
+            "10.0.0.2".parse::<IpAddr>().unwrap(),
+            61000
+        ))
     );
+}
+
+#[tokio::test]
+async fn peer_in_charge_publish_addr_returns_none_without_match() {
+    let peers = Arc::new(RwLock::new(HashMap::from([(
+        "10.0.0.3".to_string(),
+        PeerInfo {
+            ingest_sensors: HashSet::from(["other_sensor".to_string()]),
+            graphql_port: None,
+            publish_port: Some(62000),
+        },
+    )])));
+
+    let addr_missing_sensor = super::peer_in_charge_publish_addr(peers.clone(), "unknown").await;
+    assert!(addr_missing_sensor.is_none());
+}
+
+#[tokio::test]
+async fn process_pcap_extract_filters_sends_to_local_sensor() {
+    init_crypto();
+    const SENSOR: &str = "pcap_local";
+    let filter = PcapFilter {
+        start_time: 11111,
+        sensor: SENSOR.to_string(),
+        src_addr: "192.168.4.1".parse::<IpAddr>().unwrap(),
+        src_port: 1234,
+        dst_addr: "192.168.4.2".parse::<IpAddr>().unwrap(),
+        dst_port: 80,
+        proto: 6,
+        end_time: 22222,
+    };
+
+    let (sensor_conn, mut filter_rx, _sensor_server_endpoint, _sensor_client_endpoint) =
+        setup_pcap_sensor_connection(NODE1.host).await;
+
+    let pcap_sensors = new_pcap_sensors();
+    pcap_sensors
+        .write()
+        .await
+        .insert(SENSOR.to_string(), vec![sensor_conn]);
+
+    let peers = Arc::new(RwLock::new(HashMap::new()));
+    let peer_idents = Arc::new(RwLock::new(HashSet::new()));
+    let certs = build_test_certs();
+
+    let (mut server_send, _ack_server, _ack_client) = build_ack_stream("ack.local").await;
+
+    super::process_pcap_extract_filters(
+        vec![filter.clone()],
+        pcap_sensors,
+        peers,
+        peer_idents,
+        certs,
+        &mut server_send,
+    )
+    .await
+    .expect("process_pcap_extract_filters failed");
+
+    let received_filter = tokio::time::timeout(StdDuration::from_secs(5), filter_rx.recv())
+        .await
+        .expect("pcap sensor did not respond")
+        .expect("pcap sensor channel closed");
+    assert_eq!(received_filter.sensor, filter.sensor);
+    assert_eq!(received_filter.src_addr, filter.src_addr);
+    assert_eq!(received_filter.dst_addr, filter.dst_addr);
+}
+
+#[tokio::test]
+async fn process_pcap_extract_filters_handles_multiple_filters() {
+    init_crypto();
+    const SENSOR: &str = "pcap_multi";
+    let filter_one = PcapFilter {
+        start_time: 1,
+        sensor: SENSOR.to_string(),
+        src_addr: "192.168.4.1".parse::<IpAddr>().unwrap(),
+        src_port: 1111,
+        dst_addr: "192.168.4.2".parse::<IpAddr>().unwrap(),
+        dst_port: 80,
+        proto: 6,
+        end_time: 2,
+    };
+    let filter_two = PcapFilter {
+        start_time: 3,
+        sensor: SENSOR.to_string(),
+        src_addr: "192.168.4.3".parse::<IpAddr>().unwrap(),
+        src_port: 2222,
+        dst_addr: "192.168.4.4".parse::<IpAddr>().unwrap(),
+        dst_port: 443,
+        proto: 17,
+        end_time: 4,
+    };
+
+    let (sensor_conn, mut filter_rx, _sensor_server_endpoint, _sensor_client_endpoint) =
+        setup_pcap_sensor_connection(NODE1.host).await;
+
+    let pcap_sensors = new_pcap_sensors();
+    pcap_sensors
+        .write()
+        .await
+        .insert(SENSOR.to_string(), vec![sensor_conn]);
+
+    let peers = Arc::new(RwLock::new(HashMap::new()));
+    let peer_idents = Arc::new(RwLock::new(HashSet::new()));
+    let certs = build_test_certs();
+    let (mut server_send, _ack_server, _ack_client) = build_ack_stream("ack.local").await;
+
+    super::process_pcap_extract_filters(
+        vec![filter_one.clone(), filter_two.clone()],
+        pcap_sensors,
+        peers,
+        peer_idents,
+        certs,
+        &mut server_send,
+    )
+    .await
+    .expect("process_pcap_extract_filters failed");
+
+    let recv_one = tokio::time::timeout(StdDuration::from_secs(5), filter_rx.recv())
+        .await
+        .expect("first pcap sensor message missing")
+        .expect("pcap sensor channel closed");
+    let recv_two = tokio::time::timeout(StdDuration::from_secs(5), filter_rx.recv())
+        .await
+        .expect("second pcap sensor message missing")
+        .expect("pcap sensor channel closed");
+
+    let mut received = [recv_one, recv_two];
+    received.sort_by_key(|f| f.start_time);
+    assert_eq!(received[0].start_time, filter_one.start_time);
+    assert_eq!(received[1].start_time, filter_two.start_time);
+}
+
+#[test]
+fn filter_ip_semi_supervised_always_true() {
+    let semi = RequestSemiSupervisedStream {
+        start: 0,
+        sensor: None,
+    };
+    assert!(semi.filter_ip("1.1.1.1".parse().unwrap(), "2.2.2.2".parse().unwrap()));
+}
+
+#[test]
+fn filter_ip_time_series_generator_matches_all_when_no_ips() {
+    let tsg = RequestTimeSeriesGeneratorStream {
+        start: 0,
+        id: "p1".to_string(),
+        src_ip: None,
+        dst_ip: None,
+        sensor: Some("s1".to_string()),
+    };
+    assert!(tsg.filter_ip("1.1.1.1".parse().unwrap(), "2.2.2.2".parse().unwrap()));
+}
+
+#[test]
+fn filter_ip_time_series_generator_matches_src_only() {
+    let tsg = RequestTimeSeriesGeneratorStream {
+        start: 0,
+        id: "p1".to_string(),
+        src_ip: Some("1.1.1.1".parse().unwrap()),
+        dst_ip: None,
+        sensor: Some("s1".to_string()),
+    };
+    assert!(tsg.filter_ip("1.1.1.1".parse().unwrap(), "5.5.5.5".parse().unwrap()));
+    assert!(!tsg.filter_ip("9.9.9.9".parse().unwrap(), "5.5.5.5".parse().unwrap()));
+}
+
+#[test]
+fn filter_ip_time_series_generator_matches_dst_only() {
+    let tsg = RequestTimeSeriesGeneratorStream {
+        start: 0,
+        id: "p1".to_string(),
+        src_ip: None,
+        dst_ip: Some("2.2.2.2".parse().unwrap()),
+        sensor: Some("s1".to_string()),
+    };
+    assert!(tsg.filter_ip("9.9.9.9".parse().unwrap(), "2.2.2.2".parse().unwrap()));
+    assert!(!tsg.filter_ip("9.9.9.9".parse().unwrap(), "8.8.8.8".parse().unwrap()));
+}
+
+#[test]
+fn filter_ip_time_series_generator_matches_both() {
+    let tsg = RequestTimeSeriesGeneratorStream {
+        start: 0,
+        id: "p1".to_string(),
+        src_ip: Some("1.1.1.1".parse().unwrap()),
+        dst_ip: Some("2.2.2.2".parse().unwrap()),
+        sensor: Some("s1".to_string()),
+    };
+    assert!(tsg.filter_ip("1.1.1.1".parse().unwrap(), "2.2.2.2".parse().unwrap()));
+    assert!(!tsg.filter_ip("1.1.1.1".parse().unwrap(), "9.9.9.9".parse().unwrap()));
+    assert!(!tsg.filter_ip("9.9.9.9".parse().unwrap(), "2.2.2.2".parse().unwrap()));
 }


### PR DESCRIPTION
- The root certificate loader now validates empty inputs and returns an error if no valid certificates are added.
- Move settings initialization out of main to improve readability and reuse configuration loading logic.

Close #1400