### PR TITLE
Add root cert validation and ensure one cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Updated root certificate loading logic to validate empty inputs and ensure at
+  least one valid certificate is added.
+
 ### Fixed
 
 - Fixed sub-second timestamp corruption in pcap file generation. The `pcap`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "proc-macro2",
  "quinn",
  "quote",
+ "rcgen",
  "regex",
  "reqwest",
  "rocksdb",
@@ -2101,6 +2102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2469,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec0a99f2de91c3cddc84b37e7db80e4d96b743e05607f647eb236fc0455907f"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -4372,8 +4397,18 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ async-graphql-poem = "7"
 
 [dev-dependencies]
 mockito = "1"
+rcgen = "0.14"
 regex = "1"
 serial_test = "3"
 tempfile = "3"

--- a/src/comm.rs
+++ b/src/comm.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use quinn::Connection;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -43,7 +43,12 @@ pub(crate) fn to_private_key(pem: &[u8]) -> Result<PrivateKeyDer<'static>> {
 }
 
 pub(crate) fn to_root_cert(ca_certs_paths: &[String]) -> Result<rustls::RootCertStore> {
+    if ca_certs_paths.is_empty() {
+        bail!("no root certificate paths provided");
+    }
+
     let mut ca_certs_files = Vec::new();
+    let mut added_any = false;
 
     for ca_cert in ca_certs_paths {
         let file = fs::read(ca_cert)
@@ -60,7 +65,11 @@ pub(crate) fn to_root_cert(ca_certs_paths: &[String]) -> Result<rustls::RootCert
             root_cert
                 .add(cert.to_owned())
                 .context("failed to add root cert")?;
+            added_any = true;
         }
+    }
+    if !added_any {
+        bail!("no valid root certificates loaded");
     }
 
     Ok(root_cert)
@@ -90,4 +99,133 @@ pub(crate) fn new_peers_data(peers_list: Option<HashSet<PeerIdentity>>) -> (Peer
         Arc::new(RwLock::new(HashMap::<String, PeerInfo>::new())),
         Arc::new(RwLock::new(peers_list.unwrap_or_default())),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn generate_test_cert() -> rcgen::CertifiedKey<rcgen::KeyPair> {
+        rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap()
+    }
+
+    #[test]
+    fn test_to_cert_chain_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.cert.pem();
+        let chain = to_cert_chain(pem.as_bytes());
+        assert!(chain.is_ok());
+        let chain = chain.unwrap();
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn test_to_cert_chain_invalid() {
+        let pem = b"invalid pem";
+        let chain = to_cert_chain(pem);
+        assert!(chain.is_ok());
+        assert!(chain.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_to_private_key_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.signing_key.serialize_pem();
+        let key = to_private_key(pem.as_bytes());
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn test_to_private_key_invalid() {
+        let pem = b"invalid pem";
+        let key = to_private_key(pem);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn test_to_root_cert_valid() {
+        let cert = generate_test_cert();
+        let pem = cert.cert.pem();
+
+        let dir = tempdir().expect("failed to create temp dir");
+        let file_path = dir.path().join("ca.pem");
+        let mut file = fs::File::create(&file_path).expect("failed to create ca file");
+        file.write_all(pem.as_bytes())
+            .expect("failed to write ca file");
+
+        let paths = vec![file_path.to_str().unwrap().to_string()];
+        let root_cert = to_root_cert(&paths);
+        assert!(root_cert.is_ok());
+        assert!(!root_cert.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_to_root_cert_invalid_path() {
+        let paths = vec!["/non/existent/path".to_string()];
+        let root_cert = to_root_cert(&paths);
+        assert!(root_cert.is_err());
+    }
+
+    #[test]
+    fn test_to_root_cert_empty_path() {
+        let paths = Vec::new();
+        let result = to_root_cert(&paths);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "no root certificate paths provided"
+        );
+    }
+
+    #[test]
+    fn test_to_root_cert_invalid_content() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let file_path = dir.path().join("invalid.pem");
+        let mut file = fs::File::create(&file_path).expect("failed to create invalid file");
+        file.write_all(b"invalid content")
+            .expect("failed to write invalid file");
+
+        let paths = vec![file_path.to_str().unwrap().to_string()];
+        let root_cert = to_root_cert(&paths);
+        let result = root_cert;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_new_pcap_sensors() {
+        let sensors = new_pcap_sensors();
+        assert!(sensors.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_runtime_ingest_sensors() {
+        let sensors = new_runtime_ingest_sensors();
+        assert!(sensors.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_stream_direct_channels() {
+        let channels = new_stream_direct_channels();
+        assert!(channels.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_new_peers_data() {
+        let (peers, idents) = new_peers_data(None);
+        assert!(peers.read().await.is_empty());
+        assert!(idents.read().await.is_empty());
+
+        let mut set = HashSet::new();
+        set.insert(PeerIdentity {
+            addr: "127.0.0.1:0".parse().unwrap(),
+            hostname: "test".to_string(),
+        });
+        let (peers, idents) = new_peers_data(Some(set));
+        assert!(peers.read().await.is_empty());
+        assert!(!idents.read().await.is_empty());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -448,4 +448,15 @@ mod tests {
         let result = create_graphql_client(invalid_cert, invalid_key);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_create_graphql_client_with_valid_cert() {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("failed to generate self-signed certificate");
+        let cert_pem = cert.cert.pem();
+        let key_pem = cert.signing_key.serialize_pem();
+
+        let result = create_graphql_client(cert_pem.as_bytes(), key_pem.as_bytes());
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
- The root certificate loader now validates empty inputs and returns an error if no valid certificates are added.

Close #1416