### PR TITLE
Revert "Bump ctrlc from 3.5.1 to 3.5.2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,12 +630,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.2"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
- "nix 0.31.1",
+ "nix",
  "windows-sys 0.61.2",
 ]
 
@@ -1974,18 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,7 +2372,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "mime",
- "nix 0.30.1",
+ "nix",
  "parking_lot",
  "percent-encoding",
  "pin-project-lite",
@@ -2760,7 +2748,7 @@ dependencies = [
  "gethostname",
  "hostname",
  "ipnet",
- "nix 0.30.1",
+ "nix",
  "pnet",
  "regex",
  "serde",


### PR DESCRIPTION
This reverts commit 1122aaf97edb5c274197d2fad16cdd3fed781731.

Close: #1503 