### PR TITLE
Fix typo: opertation -> operation

### DIFF
--- a/src/graphql/sysmon.rs
+++ b/src/graphql/sysmon.rs
@@ -924,7 +924,7 @@ impl SysmonQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, ImageLoadedEvent>> {
-        let opertation = handle_image_load_events;
+        let operation = handle_image_load_events;
 
         paged_events_in_cluster!(
             ctx,
@@ -934,7 +934,7 @@ impl SysmonQuery {
             before,
             first,
             last,
-            opertation,
+            operation,
             ImageLoadEvents,
             image_load_events::Variables,
             image_load_events::ResponseData,


### PR DESCRIPTION
Fixes #1511

Simple typo fix in `src/graphql/sysmon.rs`:
- Line 927: `let opertation` → `let operation`
- Line 937: `opertation,` → `operation,`