### PR TITLE
Skip disk usage check in retain_periodically tests

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1009,7 +1009,7 @@ pub async fn retain_periodically(
                     - retention_duration;
                 let mut usage_flag = false;
 
-                if check_db_usage().await.0 {
+                if !cfg!(test) && check_db_usage().await.0 {
                     info!(
                         "Disk usage is over {USAGE_THRESHOLD}%. \
                         Retention period is temporarily reduced."
@@ -1093,7 +1093,7 @@ pub async fn retain_periodically(
                     } else {
                         warn!("Failed to delete file in range for operation log");
                     }
-                    if check_db_usage().await.1 && usage_flag {
+                    if !cfg!(test) && check_db_usage().await.1 && usage_flag {
                         retention_timestamp += ONE_DAY_TIMESTAMP_NANOS;
                         if retention_timestamp > now.timestamp_nanos_opt().unwrap_or(0) {
                             warn!("cannot delete data to usage under {USAGE_LOW}");


### PR DESCRIPTION
## Summary
- Guard both `check_db_usage()` calls in `retain_periodically` with `!cfg!(test)` so that tests are not affected by host disk state

## Problem
`retain_periodically` calls `check_db_usage()` to accelerate data cleanup when disk usage exceeds 95%. On machines with high disk usage, this causes `test_retain_periodically_deletes_expired_data` and `test_retain_periodically_keeps_within_retention_window` to fail because the accelerated retention window extends into the future and deletes all data — including records that should be retained.

## Test plan
- [x] All 4 `retain_periodically` tests pass
- [x] Full test suite passes (448 tests, 0 failures)
- [x] CI passes

Closes #1523