### PR TITLE
Migrate from deluxe to darling and bump syn to 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,12 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
 name = "arrow"
 version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +407,7 @@ dependencies = [
  "Inflector",
  "async-graphql-parser",
  "darling 0.23.0",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "strum 0.27.2",
@@ -798,7 +792,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -807,7 +801,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 3.0.3",
@@ -849,7 +843,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -887,7 +881,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow 1.0.4",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -1038,6 +1032,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,7 +1051,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -1060,8 +1064,21 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1084,6 +1101,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1121,47 +1149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror 2.0.19",
-]
-
-[[package]]
-name = "deluxe"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
-dependencies = [
- "deluxe-core",
- "deluxe-macros",
- "once_cell",
- "proc-macro2",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
-dependencies = [
- "arrayvec",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
-dependencies = [
- "deluxe-core",
- "heck 0.4.1",
- "if_chain",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1328,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1586,8 +1573,8 @@ dependencies = [
  "clap",
  "config",
  "ctrlc",
+ "darling 0.24.0",
  "data-encoding",
- "deluxe",
  "futures-util",
  "giganto-client",
  "graphql_client",
@@ -1615,13 +1602,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "toml",
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1691,7 +1678,7 @@ checksum = "aa0141e66c8d0302f8a586df12ad5d0cf87c0fa8c391f2f5b5dc296312dce569"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "serde",
@@ -1816,12 +1803,6 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2106,12 +2087,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -2767,7 +2742,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3121,7 +3096,7 @@ version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "056e2fea6de1cb240ffe23cfc4fc370b629f8be83b5f27e16b7acd5231a72de4"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3192,21 +3167,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3273,7 +3238,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3725,7 +3690,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3793,7 +3758,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4193,12 +4158,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4246,7 +4205,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4259,7 +4218,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4355,7 +4314,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4557,17 +4516,11 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -4580,26 +4533,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -4608,7 +4550,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5037,7 +4979,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5333,15 +5275,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bincode = "1"
 clap = { version = "4", features = ["derive"] }
 config = { version = "0.15", features = ["toml"], default-features = false }
 data-encoding = "2"
-deluxe = "0.5"
+darling = "0.24"
 futures-util = "0.3"
 giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "0.28.0" }
 graphql_client = "0.16"
@@ -50,7 +50,7 @@ rustls-pemfile = "2"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syn = "2"
+syn = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,12 @@
 
 use core::panic;
 
+use darling::{FromDeriveInput, FromField, FromMeta};
 use proc_macro::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{
-    Data, DataStruct, DeriveInput, Fields, GenericArgument, Ident, PathArguments, Type, parse_str,
-    parse2,
+    Data, DataStruct, DeriveInput, Expr, Fields, GenericArgument, Ident, PathArguments, Type,
+    parse_str, parse2,
 };
 
 extern crate proc_macro;
@@ -99,8 +100,8 @@ extern crate proc_macro;
 ///             orig_port: node.orig_port.map(|x| x as _),
 ///             proto: node.proto as _,
 ///             start_time: node.start_time as _,
-///             service: node.service as _,
-///             resp_pkts: node.resp_pkts as _,
+///             service: node.service,
+///             resp_pkts: node.resp_pkts,
 ///             ttl: node.ttl.into_iter().map(|x| x as _).collect(),
 ///             filenames: node.filenames,
 ///             ja3s: node.ja3_s,
@@ -171,116 +172,79 @@ pub fn derive_from_graphql_client_autogen(input: TokenStream) -> TokenStream {
     }
 }
 
-#[derive(deluxe::ExtractAttributes)]
-#[deluxe(attributes(graphql_client_type))]
+#[derive(FromDeriveInput)]
+#[darling(attributes(graphql_client_type))]
 struct FromGraphQlAutogenStructAttrs {
-    names: Vec<Type>,
+    names: GraphQlClientTypes,
 }
 
-#[derive(deluxe::ExtractAttributes, deluxe::ParseAttributes)]
-#[deluxe(attributes(graphql_client_type))]
+struct GraphQlClientTypes(Vec<Type>);
+
+impl FromMeta for GraphQlClientTypes {
+    fn from_expr(expr: &Expr) -> darling::Result<Self> {
+        match expr {
+            Expr::Array(array) => array
+                .elems
+                .iter()
+                .map(|expr| {
+                    parse2(expr.to_token_stream())
+                        .map_err(|err| darling::Error::from(err).with_span(expr))
+                })
+                .collect::<darling::Result<Vec<_>>>()
+                .map(Self),
+            Expr::Group(group) => Self::from_expr(&group.expr),
+            Expr::Paren(paren) => Self::from_expr(&paren.expr),
+            _ => Err(darling::Error::unexpected_expr_type(expr)),
+        }
+    }
+}
+
+#[derive(FromField)]
+#[darling(attributes(graphql_client_type))]
 struct GraphQlAutogenFieldAttrs {
-    #[deluxe(default = String::new())]
+    #[darling(default)]
     pub from_name: String,
-    #[deluxe(default = false)]
+    #[darling(default)]
     pub recursive_into: bool,
-    #[deluxe(default = false)]
+    #[darling(default)]
     pub skip: bool,
 }
 
 #[allow(clippy::too_many_lines)]
 fn derive_from_graphql_client_autogen_2(
     item: proc_macro2::TokenStream,
-) -> deluxe::Result<proc_macro2::TokenStream> {
-    let mut ast: DeriveInput = parse2(item)?;
+) -> darling::Result<proc_macro2::TokenStream> {
+    let ast: DeriveInput = parse2(item)?;
 
-    let FromGraphQlAutogenStructAttrs { names } = deluxe::extract_attributes(&mut ast)?;
+    let FromGraphQlAutogenStructAttrs {
+        names: GraphQlClientTypes(names),
+    } = FromGraphQlAutogenStructAttrs::from_derive_input(&ast)?;
 
     let struct_ident = &ast.ident;
 
-    if let Data::Struct(DataStruct { fields, .. }) = &ast.data {
-        let implementations = names.into_iter().map(|name| {
-            let field_conversions = match fields {
-                Fields::Named(named_fields) => named_fields.named.iter().map(|field| {
-                    let Ok(GraphQlAutogenFieldAttrs { from_name, recursive_into, skip }) = deluxe::parse_attributes(field) else {
-                        panic!(
-                            "inappropriate use of field attributes on {}. Allowed field attributes are `from_name: String`, `recursive_into: bool`, `skip: bool`. Found {:?}",
-                            field.to_token_stream(),
-                            field.attrs.iter().map(|attr| attr.into_token_stream().to_string()).collect::<Vec<_>>()
-                        );
-                    };
+    let Data::Struct(DataStruct { fields, .. }) = &ast.data else {
+        return Err(darling::Error::custom(
+            "`ConvertGraphQLEdgesNode` can only be derived for structs",
+        )
+        .with_span(struct_ident));
+    };
 
-                    if skip {
-                        return quote! {};
-                    }
+    let Fields::Named(named_fields) = fields else {
+        return Err(darling::Error::custom(
+            "Structs that derive `ConvertGraphQLEdgesNode` should only have named fields",
+        )
+        .with_span(struct_ident));
+    };
 
-                    let Some(to_field_name) = &field.ident.clone() else {
-                        panic!("inappropriate field {}. Please make sure the field is named", field.to_token_stream());
-                    };
-                    let from_field_name = resolve_from_field_name(&from_name, to_field_name);
-                    let field_type = &field.ty;
+    let field_conversions = named_fields
+        .named
+        .iter()
+        .map(graphql_field_conversion)
+        .collect::<darling::Result<Vec<_>>>()?;
 
-                    match segment_type_and_cast_style(field_type, recursive_into) {
-                        (_, CastStyle::None) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name,
-                            }
-                        },
-                        (SegmentType::Vec, CastStyle::As) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name.into_iter().map(|x| x as _).collect(),
-                            }
-                        },
-                        (SegmentType::Option, CastStyle::As) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name.map(|x| x as _),
-                            }
-                        },
-                        (SegmentType::Other, CastStyle::As) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name as _,
-                            }
-                        },
-                        (SegmentType::Vec, CastStyle::Into) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name.into_iter().map(|x| x.into()).collect(),
-                            }
-                        },
-                        (SegmentType::VecVec, CastStyle::As) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name
-                                    .into_iter()
-                                    .map(|inner| inner.into_iter().map(|x| x as _).collect())
-                                    .collect(),
-                            }
-                        },
-                        (SegmentType::VecVec, CastStyle::Into) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name
-                                    .into_iter()
-                                    .map(|inner| inner.into_iter().map(|x| x.into()).collect())
-                                    .collect(),
-                            }
-                        },
-                        (SegmentType::Option, CastStyle::Into) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name.map(|x| x.into()),
-                            }
-                        },
-                        (SegmentType::Other,CastStyle::Into) => {
-                            quote! {
-                                #to_field_name: node.#from_field_name.into(),
-                            }
-                        },
-                    }
-                }),
-                _ => {
-                    panic!(
-                        "Structs that derive `ConvertGraphQLEdgesNode` should only have named fields"
-                    );
-                }
-            };
-
+    let implementations = names
+        .into_iter()
+        .map(|name| {
             quote! {
                 impl From<#name> for #struct_ident {
                     fn from(node: #name) -> Self {
@@ -290,41 +254,105 @@ fn derive_from_graphql_client_autogen_2(
                     }
                 }
             }
-        }).collect::<Vec<_>>();
-
-        Ok(quote! {
-            #(#implementations)*
         })
-    } else {
-        let implementations = names
-            .iter()
-            .map(|name| {
-                quote! {
-                    impl From<#name> for #struct_ident {
-                        fn from(node: #name) -> Self {
-                            Self {}
-                        }
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
+        .collect::<Vec<_>>();
 
-        Ok(quote! {
-            #(#implementations)*
-        })
-    }
+    Ok(quote! {
+        #(#implementations)*
+    })
 }
 
-fn resolve_from_field_name(from_name: &str, field_name: &Ident) -> Ident {
+fn graphql_field_conversion(field: &syn::Field) -> darling::Result<proc_macro2::TokenStream> {
+    let GraphQlAutogenFieldAttrs {
+        from_name,
+        recursive_into,
+        skip,
+    } = GraphQlAutogenFieldAttrs::from_field(field)?;
+
+    if skip {
+        return Ok(quote! {});
+    }
+
+    let Some(to_field_name) = &field.ident else {
+        return Err(darling::Error::custom(
+            "Fields converted by `ConvertGraphQLEdgesNode` should be named",
+        )
+        .with_span(field));
+    };
+    let from_field_name = resolve_from_field_name(&from_name, to_field_name, field)?;
+    let field_type = &field.ty;
+
+    let (segment_type, cast_style) = segment_type_and_cast_style(field_type, recursive_into)
+        .map_err(|err| err.with_span(field))?;
+
+    Ok(match (segment_type, cast_style) {
+        (_, CastStyle::None) => {
+            quote! {
+                #to_field_name: node.#from_field_name,
+            }
+        }
+        (SegmentType::Vec, CastStyle::As) => {
+            quote! {
+                #to_field_name: node.#from_field_name.into_iter().map(|x| x as _).collect(),
+            }
+        }
+        (SegmentType::Option, CastStyle::As) => {
+            quote! {
+                #to_field_name: node.#from_field_name.map(|x| x as _),
+            }
+        }
+        (SegmentType::Other, CastStyle::As) => {
+            quote! {
+                #to_field_name: node.#from_field_name as _,
+            }
+        }
+        (SegmentType::Vec, CastStyle::Into) => {
+            quote! {
+                #to_field_name: node.#from_field_name.into_iter().map(|x| x.into()).collect(),
+            }
+        }
+        (SegmentType::VecVec, CastStyle::As) => {
+            quote! {
+                #to_field_name: node.#from_field_name
+                    .into_iter()
+                    .map(|inner| inner.into_iter().map(|x| x as _).collect())
+                    .collect(),
+            }
+        }
+        (SegmentType::VecVec, CastStyle::Into) => {
+            quote! {
+                #to_field_name: node.#from_field_name
+                    .into_iter()
+                    .map(|inner| inner.into_iter().map(|x| x.into()).collect())
+                    .collect(),
+            }
+        }
+        (SegmentType::Option, CastStyle::Into) => {
+            quote! {
+                #to_field_name: node.#from_field_name.map(|x| x.into()),
+            }
+        }
+        (SegmentType::Other, CastStyle::Into) => {
+            quote! {
+                #to_field_name: node.#from_field_name.into(),
+            }
+        }
+    })
+}
+
+fn resolve_from_field_name(
+    from_name: &str,
+    field_name: &Ident,
+    field: &syn::Field,
+) -> darling::Result<Ident> {
     if from_name.is_empty() {
-        field_name.clone()
+        Ok(field_name.clone())
     } else {
-        let Ok(parsed_ident) = parse_str::<Ident>(from_name) else {
-            panic!(
-                r#"inappropriate use of `from_name`. Please check if the value of `from_name = "{from_name}"` exists in the specified source structs in `names` attribute"#
-            );
-        };
-        parsed_ident
+        parse_str::<Ident>(from_name).map_err(|err| {
+            darling::Error::from(err)
+                .with_span(field)
+                .at(format!(r#"from_name = "{from_name}""#))
+        })
     }
 }
 
@@ -343,7 +371,10 @@ enum CastStyle {
     Into,
 }
 
-fn segment_type_and_cast_style(ty: &Type, recursive_into: bool) -> (SegmentType, CastStyle) {
+fn segment_type_and_cast_style(
+    ty: &Type,
+    recursive_into: bool,
+) -> darling::Result<(SegmentType, CastStyle)> {
     if let Type::Path(type_path) = ty
         && let Some(segment) = type_path.path.segments.last()
     {
@@ -352,9 +383,12 @@ fn segment_type_and_cast_style(ty: &Type, recursive_into: bool) -> (SegmentType,
                 for arg in &vec_element_type_arg.args {
                     if let GenericArgument::Type(el_type) = arg {
                         if let Some(inner_type) = vec_vec_inner_type(el_type) {
-                            return (SegmentType::VecVec, cast_style(inner_type, recursive_into));
+                            return Ok((
+                                SegmentType::VecVec,
+                                cast_style(inner_type, recursive_into)?,
+                            ));
                         }
-                        return (SegmentType::Vec, cast_style(el_type, recursive_into));
+                        return Ok((SegmentType::Vec, cast_style(el_type, recursive_into)?));
                     }
                 }
             }
@@ -362,29 +396,30 @@ fn segment_type_and_cast_style(ty: &Type, recursive_into: bool) -> (SegmentType,
             if let PathArguments::AngleBracketed(option_element_type_arg) = &segment.arguments {
                 for arg in &option_element_type_arg.args {
                     if let GenericArgument::Type(el_type) = arg {
-                        return (SegmentType::Option, cast_style(el_type, recursive_into));
+                        return Ok((SegmentType::Option, cast_style(el_type, recursive_into)?));
                     }
                 }
             }
         } else {
-            return (SegmentType::Other, cast_style(ty, recursive_into));
+            return Ok((SegmentType::Other, cast_style(ty, recursive_into)?));
         }
     }
-    (SegmentType::Other, cast_style(ty, recursive_into))
+    Ok((SegmentType::Other, cast_style(ty, recursive_into)?))
 }
 
-fn cast_style(field_type: &Type, recursive_into: bool) -> CastStyle {
+fn cast_style(field_type: &Type, recursive_into: bool) -> darling::Result<CastStyle> {
     if is_target_of_safe_to_i64_cast(field_type) {
-        assert!(
-            !recursive_into,
-            "inappropriate use of `recursive_into`. Please remove `recursive_into` attribute on a field with `{}`",
-            field_type.to_token_stream()
-        );
-        CastStyle::As
+        if recursive_into {
+            return Err(darling::Error::custom(format!(
+                "inappropriate use of `recursive_into`. Please remove `recursive_into` attribute on a field with `{}`",
+                field_type.to_token_stream()
+            )));
+        }
+        Ok(CastStyle::As)
     } else if recursive_into {
-        CastStyle::Into
+        Ok(CastStyle::Into)
     } else {
-        CastStyle::None
+        Ok(CastStyle::None)
     }
 }
 
@@ -412,4 +447,290 @@ fn extract_vec_inner_type(ty: &Type) -> Option<&Type> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graphql_client_types_parse_array_syntax() {
+        let expr: Expr = syn::parse_quote!([foo::Bar, baz::Qux]);
+
+        let types = GraphQlClientTypes::from_expr(&expr).expect("array syntax should parse");
+
+        assert_eq!(types.0.len(), 2);
+        assert_eq!(types.0[0].to_token_stream().to_string(), "foo :: Bar");
+        assert_eq!(types.0[1].to_token_stream().to_string(), "baz :: Qux");
+    }
+
+    #[test]
+    fn graphql_client_types_parse_parenthesized_array_syntax() {
+        let expr: Expr = syn::parse_quote!(([foo::Bar]));
+
+        let types =
+            GraphQlClientTypes::from_expr(&expr).expect("parenthesized array syntax should parse");
+
+        assert_eq!(types.0.len(), 1);
+        assert_eq!(types.0[0].to_token_stream().to_string(), "foo :: Bar");
+    }
+
+    #[test]
+    fn graphql_client_types_reject_non_array_syntax() {
+        let expr: Expr = syn::parse_quote!(foo::Bar);
+
+        assert!(GraphQlClientTypes::from_expr(&expr).is_err());
+    }
+
+    #[test]
+    fn field_attrs_default_to_disabled_flags() {
+        let field: syn::Field = syn::parse_quote!(value: String);
+
+        let attrs = GraphQlAutogenFieldAttrs::from_field(&field).expect("field should parse");
+
+        assert!(attrs.from_name.is_empty());
+        assert!(!attrs.recursive_into);
+        assert!(!attrs.skip);
+    }
+
+    #[test]
+    fn field_attrs_parse_existing_syntax() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(from_name = "source", recursive_into = true, skip = true)]
+            value: String
+        );
+
+        let attrs = GraphQlAutogenFieldAttrs::from_field(&field).expect("field should parse");
+
+        assert_eq!(attrs.from_name, "source");
+        assert!(attrs.recursive_into);
+        assert!(attrs.skip);
+    }
+
+    #[test]
+    fn field_conversion_uses_from_name() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(from_name = "source")]
+            value: String
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert_eq!(conversion.to_string(), "value : node . source ,");
+    }
+
+    #[test]
+    fn field_conversion_skips_fields() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(skip = true)]
+            value: String
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert!(conversion.is_empty());
+    }
+
+    #[test]
+    fn recursive_into_uses_into_for_plain_fields() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(recursive_into = true)]
+            detail: Detail
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert_eq!(conversion.to_string(), "detail : node . detail . into () ,");
+    }
+
+    #[test]
+    fn recursive_into_uses_into_for_option_fields() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(recursive_into = true)]
+            detail: Option<Detail>
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert_eq!(
+            conversion.to_string(),
+            "detail : node . detail . map (| x | x . into ()) ,"
+        );
+    }
+
+    #[test]
+    fn recursive_into_uses_into_for_vec_fields() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(recursive_into = true)]
+            details: Vec<Detail>
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert_eq!(
+            conversion.to_string(),
+            "details : node . details . into_iter () . map (| x | x . into ()) . collect () ,"
+        );
+    }
+
+    #[test]
+    fn recursive_into_uses_into_for_nested_vec_fields() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(recursive_into = true)]
+            details: Vec<Vec<Detail>>
+        );
+
+        let conversion = graphql_field_conversion(&field).expect("field should convert");
+
+        assert_eq!(
+            conversion.to_string(),
+            "details : node . details . into_iter () . map (| inner | inner . into_iter () . map (| x | x . into ()) . collect ()) . collect () ,"
+        );
+    }
+
+    #[test]
+    fn safe_integer_fields_use_as_casts() {
+        let u8_field: syn::Field = syn::parse_quote!(value: u8);
+        let u16_field: syn::Field = syn::parse_quote!(value: u16);
+        let i8_field: syn::Field = syn::parse_quote!(value: i8);
+        let i16_field: syn::Field = syn::parse_quote!(value: i16);
+        let i32_field: syn::Field = syn::parse_quote!(value: i32);
+
+        assert_eq!(
+            graphql_field_conversion(&u8_field)
+                .expect("u8 field should convert")
+                .to_string(),
+            "value : node . value as _ ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&u16_field)
+                .expect("u16 field should convert")
+                .to_string(),
+            "value : node . value as _ ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&i8_field)
+                .expect("i8 field should convert")
+                .to_string(),
+            "value : node . value as _ ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&i16_field)
+                .expect("i16 field should convert")
+                .to_string(),
+            "value : node . value as _ ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&i32_field)
+                .expect("i32 field should convert")
+                .to_string(),
+            "value : node . value as _ ,"
+        );
+    }
+
+    #[test]
+    fn safe_integer_container_fields_use_as_casts() {
+        let vec_field: syn::Field = syn::parse_quote!(value: Vec<u8>);
+        let nested_vec_field: syn::Field = syn::parse_quote!(value: Vec<Vec<u16>>);
+        let option_field: syn::Field = syn::parse_quote!(value: Option<i32>);
+
+        assert_eq!(
+            graphql_field_conversion(&vec_field)
+                .expect("Vec integer field should convert")
+                .to_string(),
+            "value : node . value . into_iter () . map (| x | x as _) . collect () ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&nested_vec_field)
+                .expect("nested Vec integer field should convert")
+                .to_string(),
+            "value : node . value . into_iter () . map (| inner | inner . into_iter () . map (| x | x as _) . collect ()) . collect () ,"
+        );
+        assert_eq!(
+            graphql_field_conversion(&option_field)
+                .expect("Option integer field should convert")
+                .to_string(),
+            "value : node . value . map (| x | x as _) ,"
+        );
+    }
+
+    #[test]
+    fn from_name_rejects_invalid_ident() {
+        let field: syn::Field = syn::parse_quote!(
+            #[graphql_client_type(from_name = "not-valid")]
+            value: String
+        );
+
+        let err = graphql_field_conversion(&field).expect_err("invalid from_name should fail");
+
+        assert!(err.to_string().contains("from_name"));
+    }
+
+    #[test]
+    fn derive_generates_from_impl_for_named_struct() {
+        let item = quote! {
+            #[graphql_client_type(names = [source::Node])]
+            struct Target {
+                value: String,
+            }
+        };
+
+        let generated = derive_from_graphql_client_autogen_2(item)
+            .expect("named struct should generate conversion");
+        let generated = generated.to_string();
+
+        assert!(generated.contains("impl From < source :: Node > for Target"));
+        assert!(generated.contains("value : node . value"));
+    }
+
+    #[test]
+    fn derive_generates_from_impl_for_each_client_type() {
+        let item = quote! {
+            #[graphql_client_type(names = [source::Node, other::Node])]
+            struct Target {
+                value: String,
+            }
+        };
+
+        let generated = derive_from_graphql_client_autogen_2(item)
+            .expect("named struct should generate conversions");
+        let generated = generated.to_string();
+
+        assert_eq!(generated.matches("impl From <").count(), 2);
+        assert!(generated.contains("impl From < source :: Node > for Target"));
+        assert!(generated.contains("impl From < other :: Node > for Target"));
+    }
+
+    #[test]
+    fn derive_rejects_tuple_structs() {
+        let item = quote! {
+            #[graphql_client_type(names = [source::Node])]
+            struct Target(String);
+        };
+
+        let err = derive_from_graphql_client_autogen_2(item).expect_err("tuple struct should fail");
+
+        assert!(err.to_string().contains("named fields"));
+    }
+
+    #[test]
+    fn derive_rejects_enums() {
+        let item = quote! {
+            #[graphql_client_type(names = [source::Node])]
+            enum Target {
+                Value,
+            }
+        };
+
+        let err = derive_from_graphql_client_autogen_2(item).expect_err("enum should fail");
+
+        assert!(err.to_string().contains("only be derived for structs"));
+    }
+
+    #[test]
+    fn recursive_into_is_rejected_for_casted_integer_types() {
+        let ty: Type = syn::parse_quote!(u8);
+
+        assert!(segment_type_and_cast_style(&ty, true).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1731.
Supersedes #1718.

This migrates the `ConvertGraphQLEdgesNode` proc-macro attribute parsing from `deluxe` to `darling` so that `giganto` can move its direct `syn` dependency to 3.

Changes:
- Replace `deluxe = "0.5"` with `darling = "0.24"`.
- Bump the direct `syn` dependency from 2 to 3.
- Preserve the existing `#[graphql_client_type(...)]` syntax, including `names = [module::Type, ...]`.
- Add focused unit coverage for the new attribute parsing paths.
- Remove `deluxe` from the dependency graph.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --no-default-features --features cluster -- -D warnings`
- `cargo clippy --features bootroot --tests -- -D warnings`
- `cargo check --locked --no-default-features --features cluster`
- `cargo check --locked --all-features`
- `cargo test -q`
- `cargo test -q schema_should_be_up_to_date -- --ignored`
- Started the binary with `cluster` enabled using test certificates and confirmed the GraphQL endpoint responds.
