### PR TITLE
Lint the Markdown under docs/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
         run: git diff-index --quiet HEAD --
       - name: markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          # Recursive, deliberately. The action's default glob is
+          # `*.{md,markdown}` — repository root only — and `.markdownlint.yaml`
+          # supplies no `globs` of its own, so 13 of the 15 tracked documents,
+          # every one of them under `docs/`, went unlinted.
+          globs: "**/*.md"
       - name: Fetch docs theme
         run: scripts/fetch-theme.sh
         env:


### PR DESCRIPTION
Closes #1735.

## What was wrong

`markdownlint-cli2-action@v23` ran with no `globs` input. The action's default is `*.{md,markdown}` — repository root only — and this repository's markdownlint config supplies no `globs` key of its own to override it. The most recent run on `main` says so plainly:

```
Finding: *.{md,markdown}
Linting: 2 file(s)
```

2 of 15 tracked documents. Everything under `docs/`, RFCs included, was skipped.

## Why now

While a documentation change also ran clippy and the tests, this was a latent gap. It is not latent any more: a docs-only change skips every gated job by design, so the Markdown lint is the only check such a change gets — and it was not looking where the change was.

## The change

One `with: globs: "**/*.md"` on the existing step. Same action, same pinned major version, same config file. A coverage fix, not an upgrade.

## Verification

- **Does not turn the build red**: `markdownlint-cli2@0.22.1` — the version `@v23` pins — run recursively against `main` locally reports **0 errors** across all 15 files.
- **The job's own log** on this pull request should now read `Finding: **/*.md` and `Linting: 15 file(s)`, up from 2.
- `actionlint` (with shellcheck) is clean.

## Relationship to the other open pull request

There is a separate pull request in this repository scoping the CI triggers so a pull request stops running twice. The two touch different parts of `ci.yml` and were tested to merge cleanly in either order (`git merge-tree`, no conflict).

## Out of scope

- Upgrading the action or markdownlint itself.
- Editing any Markdown content.
