### PR TITLE
Track the current markdownlint and Biome releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: biomejs/setup-biome@v2
         with:
-          version: 2.3.5
+          version: latest
       - uses: ./.github/cache-cargo
       - name: Check formatting
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
@@ -52,7 +52,7 @@ jobs:
       - name: Detect Cargo.lock changes
         run: git diff-index --quiet HEAD --
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           # Recursive, deliberately. The action's default glob is
           # `*.{md,markdown}` — repository root only — and `.markdownlint.yaml`

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -8,7 +8,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "files": {


### PR DESCRIPTION
Closes #1738

Brings both linters onto the versions the rest of the organisation uses: `markdownlint-cli2-action` `@v23` → `@v24` (markdownlint 0.41.1), and the Biome pin `2.3.5` → `latest` (2.5.7 today). `biome.json` is migrated to match — the declared schema had drifted and `linter.rules.recommended` is deprecated in favour of `preset`.

**Verification**
- markdownlint-cli2 0.23.2 with this repository's config and CI globs: 15 files, `0 issues`, exit 0.
- `biome ci` at 2.5.7 before migration: exit 0 with two deprecation notices; after `biome migrate --write`: exit 0, no notices.